### PR TITLE
Dependency manager

### DIFF
--- a/dependency_manager/CMakeLists.txt
+++ b/dependency_manager/CMakeLists.txt
@@ -16,7 +16,10 @@
 # under the License.
 
 celix_subproject(DEPENDENCY_MANAGER "Option to build the dependency manager static library" ON DEPS framework)
-if (DEPENDENCY_MANAGER) 
+if (DEPENDENCY_MANAGER)
+    SET(BUNDLE_SYMBOLICNAME "apache_celix_dm_shell")
+    SET(BUNDLE_VERSION "0.0.1")
+    SET(BUNDLE_NAME "Apache Celix DM Shell commands")
     # Add -fPIC for x86_64 Unix platforms; this lib will be linked to a shared lib
     if(UNIX AND NOT WIN32)
       find_program(CMAKE_UNAME uname /bin /usr/bin /usr/local/bin )
@@ -34,15 +37,22 @@ if (DEPENDENCY_MANAGER)
         DESCRIPTION "The Apache Celix dependency manager (static) library"
         GROUP all
     )
-    
+    bundle(dm_shell SOURCES
+            private/src/dm_shell_activator
+            private/src/dm_shell_list_command
+    )
     add_library(dependency_manager STATIC 
     	private/src/dm_activator_base 
     	private/src/dm_component_impl 
     	private/src/dm_service_dependency
     	private/src/dm_event
-    	private/src/dm_dependency_manager_impl)
+    	private/src/dm_dependency_manager_impl
+        private/src/dm_server
+    )
+
    	include_directories("public/include")
    	include_directories("private/include")
+    include_directories("../shell/public/include")
     include_directories("${PROJECT_SOURCE_DIR}/utils/public/include")
     target_link_libraries(dependency_manager celix_framework)
     
@@ -52,10 +62,12 @@ if (DEPENDENCY_MANAGER)
             public/include/dm_component.h
             public/include/dm_dependency_manager.h
             public/include/dm_service_dependency.h
+            public/include/dm_server.h
 		DESTINATION 
 			include/celix/dependency_manager
 		COMPONENT 
 			dependency_manager
 	)
+    install_bundle(dm_shell)
     install(TARGETS dependency_manager DESTINATION lib COMPONENT dependency_manager)
 endif (DEPENDENCY_MANAGER)

--- a/dependency_manager/private/include/dm_component_impl.h
+++ b/dependency_manager/private/include/dm_component_impl.h
@@ -60,7 +60,7 @@ struct dm_component {
     init_fpt callbackInit;
     start_fpt callbackStart;
     stop_fpt callbackStop;
-    destroy_fpt callbackDestroy;
+    deinit_fpt callbackDeinit;
 
     array_list_pt dependencies;
     pthread_mutex_t mutex;

--- a/dependency_manager/private/include/dm_dependency_manager_impl.h
+++ b/dependency_manager/private/include/dm_dependency_manager_impl.h
@@ -1,3 +1,28 @@
+/**
+ *Licensed to the Apache Software Foundation (ASF) under one
+ *or more contributor license agreements.  See the NOTICE file
+ *distributed with this work for additional information
+ *regarding copyright ownership.  The ASF licenses this file
+ *to you under the Apache License, Version 2.0 (the
+ *"License"); you may not use this file except in compliance
+ *with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *Unless required by applicable law or agreed to in writing,
+ *software distributed under the License is distributed on an
+ *"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ *specific language governing permissions and limitations
+ *under the License.
+ */
+/*
+ * dm_dependency_manager_impl.h
+ *
+ *  \date       15 Oct 2015
+ *  \author     <a href="mailto:dev@celix.apache.org">Apache Celix Project Team</a>
+ *  \copyright  Apache License, Version 2.0
+ */
 
 #ifndef CELIX_DM_DEPENDENCY_MANAGER_IMPL_H
 #define CELIX_DM_DEPENDENCY_MANAGER_IMPL_H

--- a/dependency_manager/private/include/dm_dependency_manager_impl.h
+++ b/dependency_manager/private/include/dm_dependency_manager_impl.h
@@ -1,0 +1,11 @@
+
+#ifndef CELIX_DM_DEPENDENCY_MANAGER_IMPL_H
+#define CELIX_DM_DEPENDENCY_MANAGER_IMPL_H
+
+struct dm_dependency_manager {
+    array_list_pt components;
+
+    pthread_mutex_t mutex;
+};
+
+#endif //CELIX_DM_DEPENDENCY_MANAGER_IMPL_H

--- a/dependency_manager/private/include/dm_server_impl.h
+++ b/dependency_manager/private/include/dm_server_impl.h
@@ -1,3 +1,29 @@
+/**
+ *Licensed to the Apache Software Foundation (ASF) under one
+ *or more contributor license agreements.  See the NOTICE file
+ *distributed with this work for additional information
+ *regarding copyright ownership.  The ASF licenses this file
+ *to you under the Apache License, Version 2.0 (the
+ *"License"); you may not use this file except in compliance
+ *with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *Unless required by applicable law or agreed to in writing,
+ *software distributed under the License is distributed on an
+ *"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ *specific language governing permissions and limitations
+ *under the License.
+ */
+/*
+ * dm_server_impl.h
+ *
+ *  \date       16 Oct 2015
+ *  \author     <a href="mailto:dev@celix.apache.org">Apache Celix Project Team</a>
+ *  \copyright  Apache License, Version 2.0
+ */
+
 #include "dm_server.h"
 #include "dm_component.h"
 #include "dm_component_impl.h"

--- a/dependency_manager/private/include/dm_server_impl.h
+++ b/dependency_manager/private/include/dm_server_impl.h
@@ -1,0 +1,10 @@
+#include "dm_server.h"
+#include "dm_component.h"
+#include "dm_component_impl.h"
+#include "dm_dependency_manager_impl.h"
+
+celix_status_t dmServiceCreate(dm_server_pt * dmServ, bundle_context_pt context, struct dm_dependency_manager *manager);
+celix_status_t dmServiceAddComponent(dm_server_pt dmServ, dm_component_pt component);
+celix_status_t dmServiceDestroy(dm_server_pt dmServ);
+celix_status_t dmService_getInfo(dm_server_pt dmServ, dm_info_pt info);
+

--- a/dependency_manager/private/include/dm_service_dependency_impl.h
+++ b/dependency_manager/private/include/dm_service_dependency_impl.h
@@ -41,11 +41,13 @@ struct dm_service_dependency {
 	bool instanceBound;
 	bool required;
 
+	service_set_fpt set;
 	service_add_fpt add;
 	service_change_fpt change;
 	service_remove_fpt remove;
 	service_swap_fpt swap;
 
+	service_set_with_ref_fpt set_with_ref;
 	service_add_with_ref_fpt add_with_ref;
 	service_change_with_ref_fpt change_with_ref;
 	service_remove_with_ref_fpt remove_with_ref;
@@ -73,6 +75,7 @@ celix_status_t serviceDependency_setAvailable(dm_service_dependency_pt dependenc
 celix_status_t serviceDependency_setComponent(dm_service_dependency_pt dependency, dm_component_pt component);
 //celix_status_t serviceDependency_removeComponent(dm_service_dependency_pt dependency, dm_component_pt component);
 
+celix_status_t serviceDependency_invokeSet(dm_service_dependency_pt dependency, dm_event_pt event);
 celix_status_t serviceDependency_invokeAdd(dm_service_dependency_pt dependency, dm_event_pt event);
 celix_status_t serviceDependency_invokeChange(dm_service_dependency_pt dependency, dm_event_pt event);
 celix_status_t serviceDependency_invokeRemove(dm_service_dependency_pt dependency, dm_event_pt event);

--- a/dependency_manager/private/include/dm_service_dependency_impl.h
+++ b/dependency_manager/private/include/dm_service_dependency_impl.h
@@ -19,7 +19,7 @@
 /*
  * dm_service_dependency_impl.h
  *
- *  \date       8 Oct 2014
+ *  \date       16 Oct 2015
  *  \author     <a href="mailto:dev@celix.apache.org">Apache Celix Project Team</a>
  *  \copyright  Apache License, Version 2.0
  */

--- a/dependency_manager/private/include/dm_shell_list_command.h
+++ b/dependency_manager/private/include/dm_shell_list_command.h
@@ -17,9 +17,9 @@
  *under the License.
  */
 /*
- * help_command.c
+ * dm_shell_list_command.h
  *
- *  \date       Aug 20, 2010
+ *  \date       Oct 16, 2015
  *  \author    	<a href="mailto:dev@celix.apache.org">Apache Celix Project Team</a>
  *  \copyright	Apache License, Version 2.0
  */

--- a/dependency_manager/private/include/dm_shell_list_command.h
+++ b/dependency_manager/private/include/dm_shell_list_command.h
@@ -1,0 +1,34 @@
+/**
+ *Licensed to the Apache Software Foundation (ASF) under one
+ *or more contributor license agreements.  See the NOTICE file
+ *distributed with this work for additional information
+ *regarding copyright ownership.  The ASF licenses this file
+ *to you under the Apache License, Version 2.0 (the
+ *"License"); you may not use this file except in compliance
+ *with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *Unless required by applicable law or agreed to in writing,
+ *software distributed under the License is distributed on an
+ *"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ *specific language governing permissions and limitations
+ *under the License.
+ */
+/*
+ * help_command.c
+ *
+ *  \date       Aug 20, 2010
+ *  \author    	<a href="mailto:dev@celix.apache.org">Apache Celix Project Team</a>
+ *  \copyright	Apache License, Version 2.0
+ */
+#include <stdlib.h>
+#include <string.h>
+
+#include "command_impl.h"
+
+char * dmListCommand_getName(command_pt command);
+char * dmListCommand_getUsage(command_pt command);
+char * dmListCommand_getShortDescription(command_pt command);
+void dmListCommand_execute(command_pt command, char * line, void (*out)(char *), void (*err)(char *));

--- a/dependency_manager/private/src/dm_component_impl.c
+++ b/dependency_manager/private/src/dm_component_impl.c
@@ -120,7 +120,7 @@ celix_status_t component_create(bundle_context_pt context, dm_dependency_manager
 
         (*component)->state = DM_CMP_STATE_INACTIVE;
         (*component)->isStarted = false;
-        (*component)->active = false;
+        (*component)->active = a;
 
         (*component)->dependencyEvents = hashMap_create(NULL, NULL, NULL, NULL);
 

--- a/dependency_manager/private/src/dm_component_impl.c
+++ b/dependency_manager/private/src/dm_component_impl.c
@@ -120,7 +120,7 @@ celix_status_t component_create(bundle_context_pt context, dm_dependency_manager
 
         (*component)->state = DM_CMP_STATE_INACTIVE;
         (*component)->isStarted = false;
-        (*component)->active = a;
+        (*component)->active = false;
 
         (*component)->dependencyEvents = hashMap_create(NULL, NULL, NULL, NULL);
 

--- a/dependency_manager/private/src/dm_dependency_manager_impl.c
+++ b/dependency_manager/private/src/dm_dependency_manager_impl.c
@@ -31,12 +31,8 @@
 
 #include "bundle_context.h"
 #include "dm_component_impl.h"
+#include "dm_dependency_manager_impl.h"
 
-struct dm_dependency_manager {
-	array_list_pt components;
-
-	pthread_mutex_t mutex;
-};
 
 celix_status_t dependencyManager_create(bundle_context_pt context __attribute__((unused)), dm_dependency_manager_pt *manager) {
 	celix_status_t status = CELIX_ENOMEM;

--- a/dependency_manager/private/src/dm_server.c
+++ b/dependency_manager/private/src/dm_server.c
@@ -1,3 +1,29 @@
+/**
+ *Licensed to the Apache Software Foundation (ASF) under one
+ *or more contributor license agreements.  See the NOTICE file
+ *distributed with this work for additional information
+ *regarding copyright ownership.  The ASF licenses this file
+ *to you under the Apache License, Version 2.0 (the
+ *"License"); you may not use this file except in compliance
+ *with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *Unless required by applicable law or agreed to in writing,
+ *software distributed under the License is distributed on an
+ *"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ *specific language governing permissions and limitations
+ *under the License.
+ */
+/*
+ * dm_component_impl.c
+ *
+ *  \date       9 Oct 2014
+ *  \author     <a href="mailto:dev@celix.apache.org">Apache Celix Project Team</a>
+ *  \copyright  Apache License, Version 2.0
+ */
+
 #include <stdlib.h>
 
 #include "array_list.h"

--- a/dependency_manager/private/src/dm_server.c
+++ b/dependency_manager/private/src/dm_server.c
@@ -1,0 +1,71 @@
+#include <stdlib.h>
+
+#include "array_list.h"
+
+#include "dm_server.h"
+#include "dm_component.h"
+#include "dm_component_impl.h"
+#include "dm_dependency_manager_impl.h"
+
+struct dm_server {
+    struct dm_dependency_manager *manager;
+};
+
+celix_status_t dmServiceCreate(dm_server_pt * dmServ, bundle_context_pt context, struct dm_dependency_manager *manager) {
+    *dmServ = calloc(sizeof(struct dm_server), 1);
+    (*dmServ)->manager = manager;
+    return CELIX_SUCCESS;
+}
+
+celix_status_t dmServiceDestroy(dm_server_pt dmServ) {
+    free(dmServ);
+    return CELIX_SUCCESS;
+}
+
+celix_status_t dmService_getInfo(dm_server_pt dmServ, dm_info_pt info) {
+    int compCnt;
+    arrayList_create(&(info->components));
+    array_list_pt  compList = dmServ->manager->components;
+
+    for (compCnt = 0; compCnt < arrayList_size(compList); compCnt++) {
+        int i;
+        struct dm_component *component = arrayList_get(compList, compCnt);
+
+        // Create a component info
+        dm_component_info_pt compInfo = calloc(sizeof(*compInfo),1);
+        arrayList_create(&(compInfo->interface_list));
+        arrayList_create(&(compInfo->dependency_list));
+
+        //Fill in the fields of the component
+        char *outstr;
+        asprintf(&outstr, "%p",component->implementation);
+        compInfo->id = outstr;
+        compInfo->active = component->active;
+
+        array_list_pt interfaces = component->dm_interface;
+        array_list_pt dependencies = component->dependencies;
+
+        for(i = 0; i < arrayList_size(interfaces); i++) {
+            dm_interface * interface = arrayList_get(interfaces, i);
+            arrayList_add(compInfo->interface_list, strdup(interface->serviceName));
+        }
+
+        for(i = 0; i < arrayList_size(dependencies); i++) {
+            dm_service_dependency_pt  dependency = arrayList_get(dependencies, i);
+
+            dependency_info_pt depInfo = calloc(sizeof(*depInfo), 1);
+            depInfo->available = dependency->available;
+            depInfo->required = dependency->required;
+            if(dependency->tracked_filter) {
+                depInfo->interface  = strdup(dependency->tracked_filter);
+            } else {
+                depInfo->interface = strdup(dependency->tracked_service_name);
+            }
+            arrayList_add(compInfo->dependency_list, depInfo);
+        }
+
+        arrayList_add(info->components, compInfo);
+    }
+
+    return CELIX_SUCCESS;
+}

--- a/dependency_manager/private/src/dm_shell_activator.c
+++ b/dependency_manager/private/src/dm_shell_activator.c
@@ -1,3 +1,29 @@
+/**
+ *Licensed to the Apache Software Foundation (ASF) under one
+ *or more contributor license agreements.  See the NOTICE file
+ *distributed with this work for additional information
+ *regarding copyright ownership.  The ASF licenses this file
+ *to you under the Apache License, Version 2.0 (the
+ *"License"); you may not use this file except in compliance
+ *with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *Unless required by applicable law or agreed to in writing,
+ *software distributed under the License is distributed on an
+ *"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ *specific language governing permissions and limitations
+ *under the License.
+ */
+/*
+ * dm_shell_activator.c
+ *
+ *  \date       16 Oct 2015
+ *  \author     <a href="mailto:dev@celix.apache.org">Apache Celix Project Team</a>
+ *  \copyright  Apache License, Version 2.0
+ */
+
 #include "bundle_context.h"
 #include "service_registration.h"
 #include "command.h"

--- a/dependency_manager/private/src/dm_shell_activator.c
+++ b/dependency_manager/private/src/dm_shell_activator.c
@@ -1,0 +1,72 @@
+#include "bundle_context.h"
+#include "service_registration.h"
+#include "command.h"
+
+#include "dm_shell_list_command.h"
+
+struct bundle_instance {
+    service_registration_pt reg;
+    command_pt dmListCmd;
+};
+
+typedef struct bundle_instance * bundle_instance_pt;
+
+celix_status_t bundleActivator_create(bundle_context_pt context, void **userData) {
+
+    struct bundle_instance *bi = calloc(sizeof (struct bundle_instance), 1);
+    celix_status_t status = CELIX_SUCCESS;
+
+    if (!bi) {
+        status = CELIX_ENOMEM;
+    }
+    else if (userData == NULL) {
+        status = CELIX_ILLEGAL_ARGUMENT;
+        free(bi);
+    }
+    else {
+        if (status != CELIX_SUCCESS) {
+            printf("DM:LIST Create failed\n");
+            free(bi);
+        }
+
+        (*userData) = bi;
+    }
+
+    return status;
+}
+
+celix_status_t bundleActivator_start(void * userData, bundle_context_pt context) {
+    celix_status_t status = CELIX_SUCCESS;
+    bundle_instance_pt bi = (bundle_instance_pt) userData;
+    command_service_pt commandService = calloc(1, sizeof(*commandService));
+
+    command_pt command = calloc(sizeof(*command),1);
+    command->executeCommand = dmListCommand_execute;
+    command->bundleContext = context;
+    command->handle = NULL;
+    command->name ="dm:list";
+    command->shortDescription ="not_used";
+    command->usage="not_used";
+
+    commandService->getName             = dmListCommand_getName;
+    commandService->command             = command;
+    commandService->executeCommand      = dmListCommand_execute;
+    commandService->getShortDescription = dmListCommand_getShortDescription;
+    commandService->getUsage            = dmListCommand_getUsage;
+
+    bundleContext_registerService(context, (char *) OSGI_SHELL_COMMAND_SERVICE_NAME, commandService, NULL, &bi->reg);
+
+    return status;
+}
+
+celix_status_t bundleActivator_stop(void * userData, bundle_context_pt context) {
+    bundle_instance_pt bi = (bundle_instance_pt) userData;
+    serviceRegistration_unregister(bi->reg);
+    return CELIX_SUCCESS;
+}
+
+celix_status_t bundleActivator_destroy(void * userData, bundle_context_pt context) {
+    free(userData);
+    return CELIX_SUCCESS;
+}
+

--- a/dependency_manager/private/src/dm_shell_list_command.c
+++ b/dependency_manager/private/src/dm_shell_list_command.c
@@ -17,9 +17,9 @@
  *under the License.
  */
 /*
- * help_command.c
+ * dm_shell_list_command.c
  *
- *  \date       Aug 20, 2010
+ *  \date       Oct 16, 2015
  *  \author    	<a href="mailto:dev@celix.apache.org">Apache Celix Project Team</a>
  *  \copyright	Apache License, Version 2.0
  */

--- a/dependency_manager/private/src/dm_shell_list_command.c
+++ b/dependency_manager/private/src/dm_shell_list_command.c
@@ -1,0 +1,101 @@
+/**
+ *Licensed to the Apache Software Foundation (ASF) under one
+ *or more contributor license agreements.  See the NOTICE file
+ *distributed with this work for additional information
+ *regarding copyright ownership.  The ASF licenses this file
+ *to you under the Apache License, Version 2.0 (the
+ *"License"); you may not use this file except in compliance
+ *with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *Unless required by applicable law or agreed to in writing,
+ *software distributed under the License is distributed on an
+ *"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ *specific language governing permissions and limitations
+ *under the License.
+ */
+/*
+ * help_command.c
+ *
+ *  \date       Aug 20, 2010
+ *  \author    	<a href="mailto:dev@celix.apache.org">Apache Celix Project Team</a>
+ *  \copyright	Apache License, Version 2.0
+ */
+#include <stdlib.h>
+#include <string.h>
+#include "dm_server.h"
+#include "service_reference.h"
+#include "command_impl.h"
+#include "array_list.h"
+#include "bundle_context.h"
+#include "bundle.h"
+#include "shell.h"
+
+
+void dmListCommand_execute(command_pt command, char * line, void (*out)(char *), void (*err)(char *));
+
+
+char * dmListCommand_getName(command_pt command) {
+    return "dm:list";
+}
+
+char * dmListCommand_getUsage(command_pt command) {
+    return "dm:list";
+}
+
+char * dmListCommand_getShortDescription(command_pt command) {
+    return "Get an overview of the dependency-managed components with their dependencies.";
+}
+
+void dmListCommand_execute(command_pt command, char * line, void (*out)(char *), void (*err)(char *)) {
+    char outString[256];
+    array_list_pt servRefs = NULL;
+    int i;
+    bundleContext_getServiceReferences(command->bundleContext, DM_SERVICE_NAME ,NULL, &servRefs);
+
+    for(i = 0; i < arrayList_size(servRefs); i++) {
+        struct dm_info info;
+        dm_service_pt dmService = NULL;
+        service_reference_pt servRef = NULL;
+        servRef = arrayList_get(servRefs, i);
+        bundleContext_getService(command->bundleContext,  servRef, (void**)&dmService);
+        dmService->getInfo(dmService->server, &info);
+
+        int cmpCnt;
+        for (cmpCnt = 0; cmpCnt < arrayList_size(info.components); cmpCnt++) {
+            dm_component_info_pt compInfo = arrayList_get(info.components, cmpCnt);
+            sprintf(outString, "Component: ID=%s, Active=%s\n", compInfo->id, compInfo->active ? "true" : "false");
+            out(outString);
+
+            int interfCnt;
+            sprintf(outString, "    Interfaces (%d):\n", arrayList_size(compInfo->interface_list));
+            out(outString);
+            for(interfCnt = 0 ;interfCnt < arrayList_size(compInfo->interface_list); interfCnt++) {
+                char * interface;
+                interface = arrayList_get(compInfo->interface_list, interfCnt);
+                sprintf(outString, "        Interface: %s\n", interface);
+                out(outString);
+                free(interface);
+            }
+            arrayList_destroy(compInfo->interface_list);
+
+            int depCnt;
+            sprintf(outString, "    Dependencies (%d):\n", arrayList_size(compInfo->dependency_list));
+            out(outString);
+            for(depCnt = 0 ;depCnt < arrayList_size(compInfo->dependency_list); depCnt++) {
+                dependency_info_pt dependency;
+                dependency = arrayList_get(compInfo->dependency_list, depCnt);
+                sprintf(outString, "         Dependency: Available = %s, Required = %s, Filter = %s\n",
+                        dependency->available? "true" : "false" ,
+                        dependency->required ? "true" : "false",
+                        dependency->interface);
+                out(outString);
+                free(dependency->interface);
+                free(dependency);
+            }
+            arrayList_destroy(compInfo->dependency_list);
+        }
+    }
+}

--- a/dependency_manager/public/include/dm_component.h
+++ b/dependency_manager/public/include/dm_component.h
@@ -38,7 +38,7 @@ typedef struct dm_component *dm_component_pt;
 typedef celix_status_t (*init_fpt)(void *userData);
 typedef celix_status_t (*start_fpt)(void *userData);
 typedef celix_status_t (*stop_fpt)(void *userData);
-typedef celix_status_t (*destroy_fpt)(void *userData);
+typedef celix_status_t (*deinit_fpt)(void *userData);
 
 celix_status_t component_create(bundle_context_pt context, dm_dependency_manager_pt manager, dm_component_pt *component);
 celix_status_t component_destroy(dm_component_pt *component);
@@ -49,6 +49,6 @@ celix_status_t component_setImplementation(dm_component_pt component, void *impl
 celix_status_t component_addServiceDependency(dm_component_pt component, ...);
 celix_status_t component_removeServiceDependency(dm_component_pt component, dm_service_dependency_pt dependency);
 
-celix_status_t component_setCallbacks(dm_component_pt component, init_fpt init, start_fpt start, stop_fpt, destroy_fpt);
+celix_status_t component_setCallbacks(dm_component_pt component, init_fpt init, start_fpt start, stop_fpt stop, deinit_fpt deinit);
 
 #endif /* COMPONENT_H_ */

--- a/dependency_manager/public/include/dm_server.h
+++ b/dependency_manager/public/include/dm_server.h
@@ -1,4 +1,28 @@
-
+/**
+ *Licensed to the Apache Software Foundation (ASF) under one
+ *or more contributor license agreements.  See the NOTICE file
+ *distributed with this work for additional information
+ *regarding copyright ownership.  The ASF licenses this file
+ *to you under the Apache License, Version 2.0 (the
+ *"License"); you may not use this file except in compliance
+ *with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *Unless required by applicable law or agreed to in writing,
+ *software distributed under the License is distributed on an
+ *"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ *specific language governing permissions and limitations
+ *under the License.
+ */
+/*
+ * dm_server.h
+ *
+ *  \date       15 Oct 2015
+ *  \author     <a href="mailto:dev@celix.apache.org">Apache Celix Project Team</a>
+ *  \copyright  Apache License, Version 2.0
+ */
 #ifndef CELIX_DM_SERVICE_H
 #define CELIX_DM_SERVICE_H
 

--- a/dependency_manager/public/include/dm_server.h
+++ b/dependency_manager/public/include/dm_server.h
@@ -1,0 +1,36 @@
+
+#ifndef CELIX_DM_SERVICE_H
+#define CELIX_DM_SERVICE_H
+
+#include "bundle_context.h"
+
+#define DM_SERVICE_NAME "dm_server"
+
+typedef struct dm_server * dm_server_pt;
+
+typedef struct dependency_info {
+    char *interface;
+    bool available;
+    bool required;
+} * dependency_info_pt;
+
+typedef struct dm_component_info {
+    char *id;
+    bool active;
+    array_list_pt interface_list;       // type char*
+    array_list_pt dependency_list;  // type interface_info_pt
+} * dm_component_info_pt;
+
+typedef struct dm_info {
+    array_list_pt  components;      // type dm_component_info
+} * dm_info_pt;
+
+struct dm_service {
+    dm_server_pt server;
+    celix_status_t (*getInfo)(dm_server_pt server, dm_info_pt info);
+};
+
+typedef struct dm_service * dm_service_pt;
+
+
+#endif //CELIX_DM_SERVICE_H

--- a/dependency_manager/public/include/dm_service_dependency.h
+++ b/dependency_manager/public/include/dm_service_dependency.h
@@ -33,11 +33,13 @@ typedef struct dm_service_dependency *dm_service_dependency_pt;
 
 #include "dm_component.h"
 
+typedef celix_status_t (*service_set_fpt)(void *handle, void *service);
 typedef celix_status_t (*service_add_fpt)(void *handle, void *service);
 typedef celix_status_t (*service_change_fpt)(void *handle, void *service);
 typedef celix_status_t (*service_remove_fpt)(void *handle, void *service);
 typedef celix_status_t (*service_swap_fpt)(void *handle, void *oldService, void *newService);
 
+typedef celix_status_t (*service_set_with_ref_fpt)(void *handle, service_reference_pt reference, void *service);
 typedef celix_status_t (*service_add_with_ref_fpt)(void *handle, service_reference_pt reference, void *service);
 typedef celix_status_t (*service_change_with_ref_fpt)(void *handle, service_reference_pt reference, void *service);
 typedef celix_status_t (*service_remove_with_ref_fpt)(void *handle, service_reference_pt reference, void *service);
@@ -48,8 +50,8 @@ celix_status_t serviceDependency_destroy(dm_service_dependency_pt *dependency_pt
 
 celix_status_t serviceDependency_setRequired(dm_service_dependency_pt dependency, bool required);
 celix_status_t serviceDependency_setService(dm_service_dependency_pt dependency, char *serviceName, char *filter);
-celix_status_t serviceDependency_setCallbacks(dm_service_dependency_pt dependency, service_add_fpt add, service_change_fpt change, service_remove_fpt remove, service_swap_fpt swap);
-celix_status_t serviceDependency_setCallbacksWithServiceReference(dm_service_dependency_pt dependency, service_add_with_ref_fpt add, service_change_with_ref_fpt change, service_remove_with_ref_fpt remove, service_swap_with_ref_fpt swap);
+celix_status_t serviceDependency_setCallbacks(dm_service_dependency_pt dependency, service_set_fpt set, service_add_fpt add, service_change_fpt change, service_remove_fpt remove, service_swap_fpt swap);
+celix_status_t serviceDependency_setCallbacksWithServiceReference(dm_service_dependency_pt dependency, service_set_with_ref_fpt set, service_add_with_ref_fpt add, service_change_with_ref_fpt change, service_remove_with_ref_fpt remove, service_swap_with_ref_fpt swap);
 celix_status_t serviceDependency_setAutoConfigure(dm_service_dependency_pt dependency, celix_thread_mutex_t *service_lock, void **field);
 
 #endif /* DM_SERVICE_DEPENDENCY_H_ */

--- a/examples/deploy.cmake
+++ b/examples/deploy.cmake
@@ -22,7 +22,7 @@ if (EXAMPLES)
 	
 	deploy("hello_world" BUNDLES shell shell_tui apache_celix_examples_hello_world hello_world_test log_service log_writer)
 	deploy("wb" BUNDLES tracker publisherA publisherB shell shell_tui log_service log_writer)
-	deploy("wb_dp" BUNDLES tracker_depman publisherA publisherB shell shell_tui log_service log_writer)
+	deploy("wb_dp" BUNDLES tracker_depman publisherA publisherB shell shell_tui log_service log_writer dm_shell)
 	deploy("echo" BUNDLES echo_server echo_client shell shell_tui)
 	deploy("producer_consumer" BUNDLES producer consumer database shell shell_tui)
 	if (NOT ANDROID)

--- a/examples/whiteboard/publisherA/private/src/activator.c
+++ b/examples/whiteboard/publisherA/private/src/activator.c
@@ -24,6 +24,7 @@
  *  \copyright	Apache License, Version 2.0
  */
 #include <stdlib.h>
+#include <constants.h>
 
 #include "bundle_activator.h"
 #include "publisher_private.h"
@@ -53,6 +54,7 @@ celix_status_t bundleActivator_start(void * userData, bundle_context_pt context)
 
 	props = properties_create();
 	properties_set(props, "id", "A");
+	properties_set(props,(char*)OSGI_FRAMEWORK_SERVICE_RANKING , "10");
 
 	status = bundleContext_registerService(context, PUBLISHER_NAME, data->ps, props, &data->reg);
 	if (status != CELIX_SUCCESS) {

--- a/examples/whiteboard/publisherB/private/src/activator.c
+++ b/examples/whiteboard/publisherB/private/src/activator.c
@@ -24,6 +24,7 @@
  *  \copyright	Apache License, Version 2.0
  */
 #include <stdlib.h>
+#include <constants.h>
 
 #include "bundle_activator.h"
 #include "publisher_private.h"
@@ -52,6 +53,7 @@ celix_status_t bundleActivator_start(void * userData, bundle_context_pt context)
 	data->reg = NULL;
 
 	properties_set(props, "id", "B");
+	properties_set(props,(char*)OSGI_FRAMEWORK_SERVICE_RANKING , "20");
 
 	bundleContext_registerService(context, PUBLISHER_NAME, data->ps, props, &data->reg);
     return status;

--- a/examples/whiteboard/tracker_depman/private/include/tracker.h
+++ b/examples/whiteboard/tracker_depman/private/include/tracker.h
@@ -44,10 +44,12 @@ struct data {
 	celix_thread_mutex_t publisher_lock;
 };
 
+celix_status_t tracker_setServ(void * handle, service_reference_pt ref, void * service);
 celix_status_t tracker_addedServ(void * handle, service_reference_pt ref, void * service);
 celix_status_t tracker_modifiedServ(void * handle, service_reference_pt ref, void * service);
 celix_status_t tracker_removedServ(void * handle, service_reference_pt ref, void * service);
 
+celix_status_t tracker_setLog(void * handle, service_reference_pt ref, void * service);
 celix_status_t tracker_addLog(void * handle, service_reference_pt ref, void * service);
 celix_status_t tracker_modifiedLog(void * handle, service_reference_pt ref, void * service);
 celix_status_t tracker_removeLog(void * handle, service_reference_pt ref, void * service);
@@ -55,7 +57,7 @@ celix_status_t tracker_removeLog(void * handle, service_reference_pt ref, void *
 celix_status_t service_init(void * userData);
 celix_status_t service_start(void * userData);
 celix_status_t service_stop(void * userData);
-celix_status_t service_destroy(void * userData);
+celix_status_t service_deinit(void * userData);
 
 
 #endif /* TRACKER_H_ */

--- a/examples/whiteboard/tracker_depman/private/src/dependency_activator.c
+++ b/examples/whiteboard/tracker_depman/private/src/dependency_activator.c
@@ -49,30 +49,30 @@ celix_status_t dm_init(void * userData, bundle_context_pt context, dm_dependency
 	printf("Init\n");
 	struct data * data = (struct data *) userData;
 	dm_component_pt service = NULL;
-	dm_service_dependency_pt dep = NULL;
+	dm_service_dependency_pt dep1 = NULL;
 	dm_service_dependency_pt dep2 = NULL;
 
 	data->context = context;
 
 	component_create(context, manager, &service);
 	component_setImplementation(service, data);
-	component_setCallbacks(service, service_init, service_start, service_stop, service_destroy);
+	component_setCallbacks(service, service_init, service_start, service_stop, service_deinit);
 
-	serviceDependency_create(&dep);
-	serviceDependency_setRequired(dep, false);
-	serviceDependency_setService(dep, PUBLISHER_NAME, "(|(id=A)(id=B))");
-	serviceDependency_setCallbacksWithServiceReference(dep, tracker_addedServ, tracker_modifiedServ, tracker_removedServ, NULL);
-	component_addServiceDependency(service, dep, NULL);
+	serviceDependency_create(&dep1);
+	serviceDependency_setRequired(dep1, true);
+	serviceDependency_setService(dep1, PUBLISHER_NAME, "(|(id=A)(id=B))");
+	serviceDependency_setCallbacksWithServiceReference(dep1, NULL /*tracker_setServ*/, tracker_addedServ, tracker_modifiedServ, tracker_removedServ, NULL);
+	component_addServiceDependency(service, dep1, NULL);
 
 	serviceDependency_create(&dep2);
     serviceDependency_setRequired(dep2, false);
     serviceDependency_setService(dep2, (char *) OSGI_LOGSERVICE_NAME, NULL);
-    serviceDependency_setCallbacksWithServiceReference(dep2, tracker_addLog, tracker_modifiedLog, tracker_removeLog, NULL);
+    serviceDependency_setCallbacksWithServiceReference(dep2, NULL  /*tracker_setLog*/, tracker_addLog, tracker_modifiedLog, tracker_removeLog, NULL);
 	serviceDependency_setAutoConfigure(dep2, &data->logger_lock, (void **) &data->logger);
     component_addServiceDependency(service, dep2, NULL);
 
 	data->service = service;
-	data->dep = dep;
+	data->dep = dep1;
 	data->dep2 = dep2;
 
 	dependencyManager_add(manager, service);

--- a/examples/whiteboard/tracker_depman/private/src/tracker.c
+++ b/examples/whiteboard/tracker_depman/private/src/tracker.c
@@ -56,12 +56,13 @@ static void *dp_send(void *handle) {
 }
 
 celix_status_t service_init(void * userData) {
+	fprintf(stderr, "Service init");
 	return CELIX_SUCCESS;
 }
 
 celix_status_t service_start(void * userData) {
 	struct data * data = (struct data *) userData;
-
+	fprintf(stderr, "Service started");
 	data->running = true;
 	pthread_create(&data->sender, NULL, dp_send, data);
 	return CELIX_SUCCESS;
@@ -69,14 +70,22 @@ celix_status_t service_start(void * userData) {
 
 celix_status_t service_stop(void * userData) {
 	struct data * data = (struct data *) userData;
+	fprintf(stderr, "Service stopped");
 	data->running = false;
 	pthread_join(data->sender, NULL);
 	return CELIX_SUCCESS;
 }
 
-celix_status_t service_destroy(void * userData) {
+celix_status_t service_deinit(void * userData) {
+	fprintf(stderr, "Service deinit");
 	return CELIX_SUCCESS;
 }
+
+celix_status_t tracker_setServ(void * handle, service_reference_pt ref, void * service) {
+	printf("Service Set %p\n", service);
+	return CELIX_SUCCESS;
+}
+
 
 celix_status_t tracker_addedServ(void * handle, service_reference_pt ref, void * service) {
 	struct data * data = (struct data *) handle;
@@ -97,9 +106,21 @@ celix_status_t tracker_removedServ(void * handle, service_reference_pt ref, void
 	return CELIX_SUCCESS;
 }
 
+celix_status_t tracker_setLog(void *handle, service_reference_pt ref, void *service) {
+	struct data * data = (struct data *) handle;
+
+	printf("SET log %p\n", service);
+	if(service) {
+		data->logger = service;
+		((log_service_pt) service)->log(((log_service_pt) service)->logger, OSGI_LOGSERVICE_DEBUG, "SET log");
+	}
+	fprintf(stderr, "SET end %p\n", service);
+	return CELIX_SUCCESS;
+}
+
 celix_status_t tracker_addLog(void *handle, service_reference_pt ref, void *service) {
     struct data * data = (struct data *) handle;
-    printf("Add log\n");
+    printf("Add log %p\n", service);
     data->logger = service;
     ((log_service_pt) service)->log(((log_service_pt) service)->logger, OSGI_LOGSERVICE_DEBUG, "test");
     return CELIX_SUCCESS;


### PR DESCRIPTION
Added set function to the serviceDependency_setCallbacks function to
be able to set a pointer to a service, dependent on its ranking. (if a higher ranking service disappears, the set fucntion will be called with a lower-ranked service)

Added a shell command to get an overview of the current available Dependency-Managed
components with their provided services and dependencies

Branch is: feature/CELIX-269_depman