### PR TITLE
CELIX-371: properties_loadWithStream does not use fixed-sized buffers…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,7 @@ add_subdirectory(device_access)
 add_subdirectory(deployment_admin)
 add_subdirectory(remote_services)
 add_subdirectory(remote_shell)
-#add_subdirectory(shell_bonjour) shell_bonjour is still based on APR and old shell command service
+add_subdirectory(shell_bonjour)
 add_subdirectory(shell_tui)
 add_subdirectory(shell)
 add_subdirectory(log_writer)

--- a/shell_bonjour/CMakeLists.txt
+++ b/shell_bonjour/CMakeLists.txt
@@ -17,9 +17,6 @@
 
 celix_subproject(SHELL_BONJOUR "Option to enable building the Bonjour Shell (shell access by chat clients)" OFF DEPS LAUNCHER shell)
 if (SHELL_BONJOUR)
-	if(NOT ${WITH_APR})
-		message(FATAL_ERROR "SHELL_BONJOUR requires APR, enable WITH_APR option.")
-	endif()
 	find_package(LibXml2 REQUIRED)
 	
 	#TODO create/add FindDNS_SD.cmake and use it (with required)
@@ -35,6 +32,7 @@ if (SHELL_BONJOUR)
 	include_directories("private/include")
 	
 	add_bundle(bonjour_shell
+                VERSION "1.0.0"
 		SOURCES
 		 	private/src/activator.c
 		 	private/src/bonjour_shell.c
@@ -42,7 +40,7 @@ if (SHELL_BONJOUR)
 	
 	target_link_libraries(bonjour_shell celix_framework celix_utils ${LIBXML2_LIBRARIES} ${DNS_SD_LIB})
 
-	add_deploy("bonjour_shell" BUNDLES 
+	add_deploy("bonjour_shell_deploy" BUNDLES 
 		shell
 		bonjour_shell
 		PROPERTIES "bonjour.shell.id=Apache Celix"

--- a/shell_bonjour/private/include/bonjour_shell.h
+++ b/shell_bonjour/private/include/bonjour_shell.h
@@ -27,15 +27,13 @@
 #ifndef BONJOUR_SHELL_H_
 #define BONJOUR_SHELL_H_
 
-#include <apr_pools.h>
-
 #include <service_reference.h>
 
 #include "celix_errno.h"
 
 typedef struct bonjour_shell *bonjour_shell_pt;
 
-celix_status_t bonjourShell_create(apr_pool_t *pool, char *id, bonjour_shell_pt *shell);
+celix_status_t bonjourShell_create(char *id, bonjour_shell_pt *shell);
 celix_status_t bonjourShell_destroy(bonjour_shell_pt shell);
 
 celix_status_t bonjourShell_addShellService(void * handle, service_reference_pt reference, void * service);


### PR DESCRIPTION
Fix for CELIX_371. The properties_loadWithStream function does not rely on fixed buffer sizes any more. Checked with valgrind that there are no memory leaks.

Also put part of the properties_loadWithStream in a separate fucntion since it was quite big.

Regards,
Erjan Altena