### PR TITLE
CELIX-379: Added LAUNCHER option to add_deploy command

### DIFF
--- a/cmake/cmake_celix/Packaging.cmake
+++ b/cmake/cmake_celix/Packaging.cmake
@@ -456,7 +456,7 @@ function(add_deploy)
     list(REMOVE_AT ARGN 0)
 
     set(OPTIONS COPY)
-    set(ONE_VAL_ARGS GROUP NAME)
+    set(ONE_VAL_ARGS GROUP NAME LAUNCHER)
     set(MULTI_VAL_ARGS BUNDLES PROPERTIES)
     cmake_parse_arguments(DEPLOY "${OPTIONS}" "${ONE_VAL_ARGS}" "${MULTI_VAL_ARGS}" ${ARGN})
 
@@ -556,7 +556,15 @@ $<JOIN:$<TARGET_PROPERTY:${DEPLOY_TARGET},DEPLOY_PROPERTIES>,
         OUTPUT ${DEPLOY_RELEASE_SH}
         CONTENT ${RELEASE_CONTENT}
     )
-    set(RUN_CONTENT "${RELEASE_CONTENT}\ncelix \$@")
+    if(DEPLOY_LAUNCHER)
+        if(TARGET ${DEPLOY_LAUNCHER})
+            set(RUN_CONTENT "${RELEASE_CONTENT}\n$<TARGET_FILE:${DEPLOY_LAUNCHER}> \$@\n")
+        else() 
+            set(RUN_CONTENT "${RELEASE_CONTENT}\n${DEPLOY_LAUNCHER} \$@\n")
+        endif()
+    else()
+        set(RUN_CONTENT "${RELEASE_CONTENT}\ncelix \$@\n")
+    endif()
     file(GENERATE
         OUTPUT ${DEPLOY_RUN_SH}
         CONTENT ${RUN_CONTENT}

--- a/framework/public/include/properties.h
+++ b/framework/public/include/properties.h
@@ -47,10 +47,8 @@ FRAMEWORK_EXPORT void properties_set(properties_pt properties, const char* key, 
 
 FRAMEWORK_EXPORT celix_status_t properties_copy(properties_pt properties, properties_pt *copy);
 
-
 #define PROPERTIES_FOR_EACH(props, key) \
-	for(hash_map_iterator_t iter = hashMapIterator_construct((props)); \
-		hashMapIterator_hasNext(&iter); \
-		(key) = (const char*)hashMapIterator_nextKey(&iter))
+	for(hash_map_iterator_t iter = hashMapIterator_construct(props); \
+		hashMapIterator_hasNext(&iter), (key) = (const char*)hashMapIterator_nextKey(&iter);) 
 
 #endif /* PROPERTIES_H_ */


### PR DESCRIPTION
Added LAUNCHER option to the add_deploy command to be able to use an own implementation of the launcher. if the launcher is a target, the full path to this target will be used. 
If it is not a target the launcher name will be used as an external command.
If it is not defined, the default "celix" will be used.