### PR TITLE
Added optional use of readline library for shell_tui

### DIFF
--- a/shell_tui/CMakeLists.txt
+++ b/shell_tui/CMakeLists.txt
@@ -15,8 +15,12 @@
 # specific language governing permissions and limitations
 # under the License.
 celix_subproject(SHELL_TUI "Option to enable building the Shell Textual User Interface bundles" ON DEPS LAUNCHER SHELL)
+option(BUILD_USE_READLINE "Enables readline functionality(i.e. history scroll back) for shell_tui" FALSE)
 if (SHELL_TUI)
-
+    if(BUILD_USE_READLINE)
+      set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -DUSE_READLINE")
+    endif(BUILD_USE_READLINE)
+    
     add_bundle(shell_tui
     	SYMBOLIC_NAME "apache_celix_shell_tui"
     	VERSION "1.1.0"
@@ -32,4 +36,7 @@ if (SHELL_TUI)
     include_directories("${PROJECT_SOURCE_DIR}/utils/public/include")
     include_directories("${PROJECT_SOURCE_DIR}/shell/public/include")
     target_link_libraries(shell_tui celix_framework)
+    if(BUILD_USE_READLINE)
+      target_link_libraries(shell_tui readline)
+    endif(BUILD_USE_READLINE)  
 endif (SHELL_TUI)

--- a/shell_tui/private/src/shell_tui.c
+++ b/shell_tui/private/src/shell_tui.c
@@ -43,7 +43,9 @@
 
 #define PROMPT "-> "
 
-shell_tui_activator_pt act = NULL;
+#ifdef USE_READLINE
+static shell_tui_activator_pt act = NULL;
+#endif
 
 #ifdef USE_READLINE
 void rl_callback_handler(char *dline) {
@@ -63,12 +65,12 @@ void rl_callback_handler(char *dline) {
 }
 
 char ** tab_completion(const char *text, int start, int end) {
-    array_list_pt list;
+    array_list_pt list ;
     act->shell->getCommands(act->shell->shell, &list);
     char **a;
     int size = arrayList_size(list);
     a = calloc(sizeof(char*),  size + 2); // 1 extra for string to be used and one for terminating NULL
-    a[0] = "";
+    a[0] = strdup("");
     unsigned int j = 1;
     for(unsigned int i = 0; i < size; i++) {
         if(text && strlen(text) > 0) {
@@ -81,6 +83,7 @@ char ** tab_completion(const char *text, int start, int end) {
     }
     // In case of one option, use that option
     if(j == 2) {
+        free(a[0]);
         a[0] = a[1];
         a[1] = 0;
     }

--- a/shell_tui/private/src/shell_tui.c
+++ b/shell_tui/private/src/shell_tui.c
@@ -36,32 +36,99 @@
 #include "utils.h"
 #include <signal.h>
 #include <unistd.h>
+#ifdef USE_READLINE
+#include <readline/readline.h>
+#include <readline/history.h>
+#endif
 
+#define PROMPT "-> "
+
+shell_tui_activator_pt act = NULL;
+
+#ifdef USE_READLINE
+void rl_callback_handler(char *dline) {
+    char *line;
+    line = utils_stringTrim(dline);
+    if (dline == NULL || *dline == 0 || act == NULL || line == NULL || (strlen(line) == 0) || (act->shell == NULL)) {
+        return;
+    }
+    add_history(dline);
+    celixThreadMutex_lock(&act->mutex);
+    if (act->shell != NULL) {
+        act->shell->executeCommand(act->shell->shell, line, stdout, stderr);
+    } else {
+        fprintf(stderr, "Shell service not available\n");
+    }
+    celixThreadMutex_unlock(&act->mutex);
+}
+
+char ** tab_completion(const char *text, int start, int end) {
+    array_list_pt list;
+    act->shell->getCommands(act->shell->shell, &list);
+    char **a;
+    int size = arrayList_size(list);
+    a = calloc(sizeof(char*),  size + 2); // 1 extra for string to be used and one for terminating NULL
+    a[0] = "";
+    unsigned int j = 1;
+    for(unsigned int i = 0; i < size; i++) {
+        if(text && strlen(text) > 0) {
+            if(strncmp(arrayList_get(list, i), text, strlen(text)) == 0) {
+                a[j++] = strdup(arrayList_get(list, i));
+             }
+        } else {
+            a[j++] = strdup(arrayList_get(list, i));
+        }
+    }
+    // In case of one option, use that option
+    if(j == 2) {
+        a[0] = a[1];
+        a[1] = 0;
+    }
+    arrayList_destroy(list);
+    return a;
+}
+
+#endif
 
 static void* shellTui_runnable(void *data) {
+#ifndef USE_READLINE
     shell_tui_activator_pt act = (shell_tui_activator_pt) data;
+#else
+    act = (shell_tui_activator_pt) data;
+#endif
 
+#ifndef USE_READLINE
     char in[256];
     char dline[256];
     bool needPrompt = true;
+#endif
 
     fd_set rfds;
     struct timeval tv;
-
+#ifdef USE_READLINE
+    rl_callback_handler_install(PROMPT, rl_callback_handler);
+    rl_attempted_completion_function = tab_completion;
+#endif
     while (act->running) {
+#ifndef USE_READLINE        
         char * line = NULL;
         if (needPrompt) {
-            printf("-> ");
+            printf(PROMPT);
             fflush(stdout);
             needPrompt = false;
         }
+#endif
+   
         FD_ZERO(&rfds);
         FD_SET(STDIN_FILENO, &rfds);
 
         tv.tv_sec = 1;
         tv.tv_usec = 0;
-
+        
         if (select(1, &rfds, NULL, NULL, &tv) > 0) {
+#ifdef USE_READLINE
+            rl_callback_read_char();
+#else
             fgets(in, sizeof(in)-1, stdin);
             needPrompt = true;
             memset(dline, 0, 256);
@@ -79,9 +146,12 @@ static void* shellTui_runnable(void *data) {
                 fprintf(stderr, "Shell service not available\n");
             }
             celixThreadMutex_unlock(&act->mutex);
+#endif
         }
     }
-
+#ifdef USE_READLINE
+    rl_callback_handler_remove();
+#endif
     return NULL;
 }
 


### PR DESCRIPTION
I have added optional usage of the readline library in shell tui. With this addition there can be scrolled though previous entered commands with the up/down arrow keys and tab completion on commands is added.

Note that  this  the GNU readline library has a GPL license and  therefore the usage is optional.  

Regards,
Erjan Altena