### PR TITLE
Fix for memory leak in framework

### DIFF
--- a/framework/private/src/framework.c
+++ b/framework/private/src/framework.c
@@ -2392,7 +2392,7 @@ static void *fw_eventDispatcher(void *fw) {
                     event->errorCode = request->errorCode;
 
                     fw_invokeFrameworkListener(framework, listener->listener, event, listener->bundle);
-
+                    free(event->bundleSymbolicName);
                     free(event);
                 }
             }


### PR DESCRIPTION
Fix for a not freed strdup
