### PR TITLE
Adding extern "C"  to headers in case __cplusplus is defined

### DIFF
--- a/dependency_manager/public/include/dm_activator.h
+++ b/dependency_manager/public/include/dm_activator.h
@@ -29,13 +29,14 @@
 #ifndef DM_ACTIVATOR_BASE_H_
 #define DM_ACTIVATOR_BASE_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 #include "bundle_context.h"
 #include "celix_errno.h"
 #include "dm_dependency_manager.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * Should be implemented by a bundle specific DM activator.

--- a/dependency_manager/public/include/dm_component.h
+++ b/dependency_manager/public/include/dm_component.h
@@ -27,14 +27,15 @@
 #ifndef COMPONENT_H_
 #define COMPONENT_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 #include <bundle_context.h>
 #include <celix_errno.h>
 
 #include "dm_service_dependency.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 typedef struct dm_component_struct *dm_component_pt;
 

--- a/dependency_manager/public/include/dm_dependency_manager.h
+++ b/dependency_manager/public/include/dm_dependency_manager.h
@@ -27,15 +27,16 @@
 #ifndef DM_DEPENDENCY_MANAGER_H_
 #define DM_DEPENDENCY_MANAGER_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 #include "bundle_context.h"
 #include "celix_errno.h"
 #include "array_list.h"
 #include "dm_info.h"
 #include "dm_component.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 typedef struct dm_dependency_manager *dm_dependency_manager_pt;
 

--- a/dependency_manager/public/include/dm_info.h
+++ b/dependency_manager/public/include/dm_info.h
@@ -26,13 +26,14 @@
 #ifndef CELIX_DM_INFO_SERVICE_H
 #define CELIX_DM_INFO_SERVICE_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 
 #include <stdbool.h>
 #include "array_list.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #define DM_INFO_SERVICE_NAME "dm_info"
 

--- a/dependency_manager/public/include/dm_service_dependency.h
+++ b/dependency_manager/public/include/dm_service_dependency.h
@@ -27,13 +27,13 @@
 #ifndef DM_SERVICE_DEPENDENCY_H_
 #define DM_SERVICE_DEPENDENCY_H_
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 #include "service_reference.h"
 #include "celix_errno.h"
 #include "dm_info.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 
 typedef struct dm_service_dependency *dm_service_dependency_pt;

--- a/dependency_manager_cxx/include/celix/dm/DependencyManager.h
+++ b/dependency_manager_cxx/include/celix/dm/DependencyManager.h
@@ -25,10 +25,8 @@
 #include "celix/dm/Component.h"
 #include "celix/dm/ServiceDependency.h"
 
-extern "C" {
 #include "bundle_context.h"
 #include "dm_dependency_manager.h"
-}
 
 #include <list>
 

--- a/framework/public/include/archive.h
+++ b/framework/public/include/archive.h
@@ -31,6 +31,10 @@
 
 #include "celix_errno.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * Extracts the bundle pointed to by bundleName to the given root.
  *
@@ -41,7 +45,11 @@
  * 		- CELIX_SUCCESS when no errors are encountered.
  * 		- CELIX_FILE_IO_EXCEPTION If the zip file cannot be extracted.
  */
-celix_status_t extractBundle(const char* bundleName, const char* revisionRoot);
+celix_status_t extractBundle(const char *bundleName, const char *revisionRoot);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* ARCHIVE_H_ */
 

--- a/framework/public/include/bundle.h
+++ b/framework/public/include/bundle.h
@@ -40,37 +40,63 @@ typedef struct bundle * bundle_pt;
 #include "celix_log.h"
 #include "celix_threads.h"
 
-FRAMEWORK_EXPORT celix_status_t bundle_create(bundle_pt * bundle);
-FRAMEWORK_EXPORT celix_status_t bundle_createFromArchive(bundle_pt * bundle, framework_pt framework, bundle_archive_pt archive);
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+FRAMEWORK_EXPORT celix_status_t bundle_create(bundle_pt *bundle);
+
+FRAMEWORK_EXPORT celix_status_t
+bundle_createFromArchive(bundle_pt *bundle, framework_pt framework, bundle_archive_pt archive);
+
 FRAMEWORK_EXPORT celix_status_t bundle_destroy(bundle_pt bundle);
 
 FRAMEWORK_EXPORT celix_status_t bundle_isSystemBundle(bundle_pt bundle, bool *systemBundle);
+
 FRAMEWORK_EXPORT celix_status_t bundle_getArchive(bundle_pt bundle, bundle_archive_pt *archive);
+
 FRAMEWORK_EXPORT celix_status_t bundle_getCurrentModule(bundle_pt bundle, module_pt *module);
+
 FRAMEWORK_EXPORT array_list_pt bundle_getModules(bundle_pt bundle);
-FRAMEWORK_EXPORT void * bundle_getHandle(bundle_pt bundle);
-FRAMEWORK_EXPORT void bundle_setHandle(bundle_pt bundle, void * handle);
+
+FRAMEWORK_EXPORT void *bundle_getHandle(bundle_pt bundle);
+
+FRAMEWORK_EXPORT void bundle_setHandle(bundle_pt bundle, void *handle);
+
 FRAMEWORK_EXPORT activator_pt bundle_getActivator(bundle_pt bundle);
+
 FRAMEWORK_EXPORT celix_status_t bundle_setActivator(bundle_pt bundle, activator_pt activator);
+
 FRAMEWORK_EXPORT celix_status_t bundle_getContext(bundle_pt bundle, bundle_context_pt *context);
+
 FRAMEWORK_EXPORT celix_status_t bundle_setContext(bundle_pt bundle, bundle_context_pt context);
-FRAMEWORK_EXPORT celix_status_t bundle_getEntry(bundle_pt bundle, const char* name, char** entry);
+
+FRAMEWORK_EXPORT celix_status_t bundle_getEntry(bundle_pt bundle, const char *name, char **entry);
 
 FRAMEWORK_EXPORT celix_status_t bundle_start(bundle_pt bundle);
+
 FRAMEWORK_EXPORT celix_status_t bundle_startWithOptions(bundle_pt bundle, int options);
-FRAMEWORK_EXPORT celix_status_t bundle_update(bundle_pt bundle, const char* inputFile);
+
+FRAMEWORK_EXPORT celix_status_t bundle_update(bundle_pt bundle, const char *inputFile);
+
 FRAMEWORK_EXPORT celix_status_t bundle_stop(bundle_pt bundle);
+
 FRAMEWORK_EXPORT celix_status_t bundle_stopWithOptions(bundle_pt bundle, int options);
+
 FRAMEWORK_EXPORT celix_status_t bundle_uninstall(bundle_pt bundle);
 
 FRAMEWORK_EXPORT celix_status_t bundle_setState(bundle_pt bundle, bundle_state_e state);
+
 FRAMEWORK_EXPORT celix_status_t bundle_setPersistentStateInactive(bundle_pt bundle);
+
 FRAMEWORK_EXPORT celix_status_t bundle_setPersistentStateUninstalled(bundle_pt bundle);
 
 FRAMEWORK_EXPORT void uninstallBundle(bundle_pt bundle);
 
-FRAMEWORK_EXPORT celix_status_t bundle_revise(bundle_pt bundle, const char* location, const char* inputFile);
+FRAMEWORK_EXPORT celix_status_t bundle_revise(bundle_pt bundle, const char *location, const char *inputFile);
+
 FRAMEWORK_EXPORT celix_status_t bundle_addModule(bundle_pt bundle, module_pt module);
+
 FRAMEWORK_EXPORT celix_status_t bundle_closeModules(bundle_pt bundle);
 
 // Service Reference Functions
@@ -79,24 +105,35 @@ FRAMEWORK_EXPORT array_list_pt getUsingBundles(service_reference_pt reference);
 FRAMEWORK_EXPORT int compareTo(service_reference_pt a, service_reference_pt b);
 
 FRAMEWORK_EXPORT celix_status_t bundle_getState(bundle_pt bundle, bundle_state_e *state);
+
 FRAMEWORK_EXPORT celix_status_t bundle_isLockable(bundle_pt bundle, bool *lockable);
+
 FRAMEWORK_EXPORT celix_status_t bundle_getLockingThread(bundle_pt bundle, celix_thread_t *thread);
+
 FRAMEWORK_EXPORT celix_status_t bundle_lock(bundle_pt bundle, bool *locked);
+
 FRAMEWORK_EXPORT celix_status_t bundle_unlock(bundle_pt bundle, bool *unlocked);
 
 FRAMEWORK_EXPORT celix_status_t bundle_closeAndDelete(bundle_pt bundle);
+
 FRAMEWORK_EXPORT celix_status_t bundle_close(bundle_pt bundle);
 
 FRAMEWORK_EXPORT celix_status_t bundle_refresh(bundle_pt bundle);
+
 FRAMEWORK_EXPORT celix_status_t bundle_getBundleId(bundle_pt bundle, long *id);
 
 FRAMEWORK_EXPORT celix_status_t bundle_getRegisteredServices(bundle_pt bundle, array_list_pt *list);
+
 FRAMEWORK_EXPORT celix_status_t bundle_getServicesInUse(bundle_pt bundle, array_list_pt *list);
 
 FRAMEWORK_EXPORT celix_status_t bundle_setFramework(bundle_pt bundle, framework_pt framework);
+
 FRAMEWORK_EXPORT celix_status_t bundle_getFramework(bundle_pt bundle, framework_pt *framework);
 
-FRAMEWORK_EXPORT celix_status_t bundle_getBundleLocation(bundle_pt bundle, const char** location);
+FRAMEWORK_EXPORT celix_status_t bundle_getBundleLocation(bundle_pt bundle, const char **location);
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* BUNDLE_H_ */

--- a/framework/public/include/bundle_activator.h
+++ b/framework/public/include/bundle_activator.h
@@ -40,6 +40,10 @@
 #include "bundle_context.h"
 #include "framework_exports.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * Called when this bundle is started so the bundle can create an instance for its activator.
  * The framework does not assume any type for the activator instance, this is implementation specific.
@@ -108,7 +112,12 @@ ACTIVATOR_EXPORT celix_status_t bundleActivator_stop(void *userData, bundle_cont
  * 		- Any other status code will mark the bundle as stopped and the framework will remove this
  * 		  bundle's listeners, unregister all services, and release all services used by this bundle.
  */
-ACTIVATOR_EXPORT celix_status_t bundleActivator_destroy(void *userData, bundle_context_pt  __attribute__((unused))  __attribute__((unused)) context);
+ACTIVATOR_EXPORT celix_status_t
+bundleActivator_destroy(void *userData, bundle_context_pt  __attribute__((unused))  __attribute__((unused)) context);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* BUNDLE_ACTIVATOR_H_ */
 

--- a/framework/public/include/bundle_archive.h
+++ b/framework/public/include/bundle_archive.h
@@ -36,33 +36,58 @@
 #include "framework_exports.h"
 #include "celix_log.h"
 
-typedef struct bundleArchive * bundle_archive_pt;
+#ifdef __cplusplus
+extern "C" {
+#endif
 
-celix_status_t bundleArchive_create(const char* archiveRoot, long id, const char* location, const char* inputFile, bundle_archive_pt *bundle_archive);
+typedef struct bundleArchive *bundle_archive_pt;
+
+celix_status_t bundleArchive_create(const char *archiveRoot, long id, const char *location, const char *inputFile,
+                                    bundle_archive_pt *bundle_archive);
+
 celix_status_t bundleArchive_createSystemBundleArchive(bundle_archive_pt *bundle_archive);
-celix_status_t bundleArchive_recreate(const char* archiveRoot, bundle_archive_pt *bundle_archive);
+
+celix_status_t bundleArchive_recreate(const char *archiveRoot, bundle_archive_pt *bundle_archive);
 
 celix_status_t bundleArchive_destroy(bundle_archive_pt archive);
 
 FRAMEWORK_EXPORT celix_status_t bundleArchive_getId(bundle_archive_pt archive, long *id);
+
 FRAMEWORK_EXPORT celix_status_t bundleArchive_getLocation(bundle_archive_pt archive, const char **location);
+
 FRAMEWORK_EXPORT celix_status_t bundleArchive_getArchiveRoot(bundle_archive_pt archive, const char **archiveRoot);
 
-FRAMEWORK_EXPORT celix_status_t bundleArchive_revise(bundle_archive_pt archive, const char* location, const char* inputFile);
+FRAMEWORK_EXPORT celix_status_t
+bundleArchive_revise(bundle_archive_pt archive, const char *location, const char *inputFile);
+
 FRAMEWORK_EXPORT celix_status_t bundleArchive_rollbackRevise(bundle_archive_pt archive, bool *rolledback);
-FRAMEWORK_EXPORT celix_status_t bundleArchive_getRevision(bundle_archive_pt archive, long revNr, bundle_revision_pt *revision);
-FRAMEWORK_EXPORT celix_status_t bundleArchive_getCurrentRevision(bundle_archive_pt archive, bundle_revision_pt *revision);
+
+FRAMEWORK_EXPORT celix_status_t
+bundleArchive_getRevision(bundle_archive_pt archive, long revNr, bundle_revision_pt *revision);
+
+FRAMEWORK_EXPORT celix_status_t
+bundleArchive_getCurrentRevision(bundle_archive_pt archive, bundle_revision_pt *revision);
+
 FRAMEWORK_EXPORT celix_status_t bundleArchive_getCurrentRevisionNumber(bundle_archive_pt archive, long *revisionNumber);
 
 FRAMEWORK_EXPORT celix_status_t bundleArchive_getRefreshCount(bundle_archive_pt archive, long *refreshCount);
+
 FRAMEWORK_EXPORT celix_status_t bundleArchive_setRefreshCount(bundle_archive_pt archive);
 
 FRAMEWORK_EXPORT celix_status_t bundleArchive_close(bundle_archive_pt archive);
+
 FRAMEWORK_EXPORT celix_status_t bundleArchive_closeAndDelete(bundle_archive_pt archive);
 
 FRAMEWORK_EXPORT celix_status_t bundleArchive_setLastModified(bundle_archive_pt archive, time_t lastModifiedTime);
+
 FRAMEWORK_EXPORT celix_status_t bundleArchive_getLastModified(bundle_archive_pt archive, time_t *lastModified);
+
 FRAMEWORK_EXPORT celix_status_t bundleArchive_setPersistentState(bundle_archive_pt archive, bundle_state_e state);
+
 FRAMEWORK_EXPORT celix_status_t bundleArchive_getPersistentState(bundle_archive_pt archive, bundle_state_e *state);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* BUNDLE_ARCHIVE_H_ */

--- a/framework/public/include/bundle_context.h
+++ b/framework/public/include/bundle_context.h
@@ -41,19 +41,32 @@ typedef struct bundleContext *bundle_context_pt;
 #include "properties.h"
 #include "array_list.h"
 
-celix_status_t bundleContext_create(framework_pt framework, framework_logger_pt, bundle_pt bundle, bundle_context_pt *bundle_context);
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+celix_status_t
+bundleContext_create(framework_pt framework, framework_logger_pt, bundle_pt bundle, bundle_context_pt *bundle_context);
+
 celix_status_t bundleContext_destroy(bundle_context_pt context);
 
 FRAMEWORK_EXPORT celix_status_t bundleContext_getBundle(bundle_context_pt context, bundle_pt *bundle);
+
 FRAMEWORK_EXPORT celix_status_t bundleContext_getFramework(bundle_context_pt context, framework_pt *framework);
 
-FRAMEWORK_EXPORT celix_status_t bundleContext_installBundle(bundle_context_pt context, const char* location, bundle_pt *bundle);
-FRAMEWORK_EXPORT celix_status_t bundleContext_installBundle2(bundle_context_pt context, const char* location, const char* inputFile, bundle_pt *bundle);
+FRAMEWORK_EXPORT celix_status_t
+bundleContext_installBundle(bundle_context_pt context, const char *location, bundle_pt *bundle);
 
-FRAMEWORK_EXPORT celix_status_t bundleContext_registerService(bundle_context_pt context, const char* serviceName, const void * svcObj,
-        properties_pt properties, service_registration_pt *service_registration);
-FRAMEWORK_EXPORT celix_status_t bundleContext_registerServiceFactory(bundle_context_pt context, const char* serviceName, service_factory_pt factory,
-        properties_pt properties, service_registration_pt *service_registration);
+FRAMEWORK_EXPORT celix_status_t
+bundleContext_installBundle2(bundle_context_pt context, const char *location, const char *inputFile, bundle_pt *bundle);
+
+FRAMEWORK_EXPORT celix_status_t
+bundleContext_registerService(bundle_context_pt context, const char *serviceName, const void *svcObj,
+                              properties_pt properties, service_registration_pt *service_registration);
+
+FRAMEWORK_EXPORT celix_status_t
+bundleContext_registerServiceFactory(bundle_context_pt context, const char *serviceName, service_factory_pt factory,
+                                     properties_pt properties, service_registration_pt *service_registration);
 
 /**
  * Get a service reference for the bundle context. When the service reference is no longer needed use bundleContext_ungetServiceReference.
@@ -64,7 +77,8 @@ FRAMEWORK_EXPORT celix_status_t bundleContext_registerServiceFactory(bundle_cont
  * @param service_reference _output_ The found service reference, or NULL when no service is found.
  * @return CELIX_SUCCESS on success
  */
-FRAMEWORK_EXPORT celix_status_t bundleContext_getServiceReference(bundle_context_pt context, const char * serviceName, service_reference_pt *service_reference);
+FRAMEWORK_EXPORT celix_status_t bundleContext_getServiceReference(bundle_context_pt context, const char *serviceName,
+                                                                  service_reference_pt *service_reference);
 
 /** Same as bundleContext_getServiceReference, but than for a optional serviceName combined with a optional filter.
  * The resulting array_list should be destroyed by the caller. For all service references return a unget should be called.
@@ -75,7 +89,9 @@ FRAMEWORK_EXPORT celix_status_t bundleContext_getServiceReference(bundle_context
  * @param service_references _output_ a array list, can be size 0. 
  * @return CELIX_SUCCESS on success
  */
-FRAMEWORK_EXPORT celix_status_t bundleContext_getServiceReferences(bundle_context_pt context, const char * serviceName, const char * filter, array_list_pt *service_references);
+FRAMEWORK_EXPORT celix_status_t
+bundleContext_getServiceReferences(bundle_context_pt context, const char *serviceName, const char *filter,
+                                   array_list_pt *service_references);
 
 /**
  * Retains (increases the ref count) the provided service reference. Can be used to retain a service reference.
@@ -85,7 +101,8 @@ FRAMEWORK_EXPORT celix_status_t bundleContext_getServiceReferences(bundle_contex
  * @param reference the service reference to retain
  * @return CELIX_SUCCES on success
  */
-FRAMEWORK_EXPORT celix_status_t bundleContext_retainServiceReference(bundle_context_pt context, service_reference_pt reference);
+FRAMEWORK_EXPORT celix_status_t
+bundleContext_retainServiceReference(bundle_context_pt context, service_reference_pt reference);
 
 /**
  * Ungets the service references. If the ref counter of the service refernce goes to 0, the reference will be destroyed.
@@ -96,24 +113,45 @@ FRAMEWORK_EXPORT celix_status_t bundleContext_retainServiceReference(bundle_cont
  * @param reference the service reference to unget
  * @return CELIX_SUCCESS on success.
  */
-FRAMEWORK_EXPORT celix_status_t bundleContext_ungetServiceReference(bundle_context_pt context, service_reference_pt reference);
+FRAMEWORK_EXPORT celix_status_t
+bundleContext_ungetServiceReference(bundle_context_pt context, service_reference_pt reference);
 
-FRAMEWORK_EXPORT celix_status_t bundleContext_getService(bundle_context_pt context, service_reference_pt reference, void** service_instance);
-FRAMEWORK_EXPORT celix_status_t bundleContext_ungetService(bundle_context_pt context, service_reference_pt reference, bool* result);
+FRAMEWORK_EXPORT celix_status_t
+bundleContext_getService(bundle_context_pt context, service_reference_pt reference, void **service_instance);
 
-FRAMEWORK_EXPORT celix_status_t bundleContext_getBundles(bundle_context_pt context, array_list_pt* bundles);
-FRAMEWORK_EXPORT celix_status_t bundleContext_getBundleById(bundle_context_pt context, long id, bundle_pt* bundle);
+FRAMEWORK_EXPORT celix_status_t
+bundleContext_ungetService(bundle_context_pt context, service_reference_pt reference, bool *result);
 
-FRAMEWORK_EXPORT celix_status_t bundleContext_addServiceListener(bundle_context_pt context, service_listener_pt listener, const char* filter);
-FRAMEWORK_EXPORT celix_status_t bundleContext_removeServiceListener(bundle_context_pt context, service_listener_pt listener);
+FRAMEWORK_EXPORT celix_status_t bundleContext_getBundles(bundle_context_pt context, array_list_pt *bundles);
+
+FRAMEWORK_EXPORT celix_status_t bundleContext_getBundleById(bundle_context_pt context, long id, bundle_pt *bundle);
+
+FRAMEWORK_EXPORT celix_status_t
+bundleContext_addServiceListener(bundle_context_pt context, service_listener_pt listener, const char *filter);
+
+FRAMEWORK_EXPORT celix_status_t
+bundleContext_removeServiceListener(bundle_context_pt context, service_listener_pt listener);
 
 FRAMEWORK_EXPORT celix_status_t bundleContext_addBundleListener(bundle_context_pt context, bundle_listener_pt listener);
-FRAMEWORK_EXPORT celix_status_t bundleContext_removeBundleListener(bundle_context_pt context, bundle_listener_pt listener);
 
-FRAMEWORK_EXPORT celix_status_t bundleContext_addFrameworkListener(bundle_context_pt context, framework_listener_pt listener);
-FRAMEWORK_EXPORT celix_status_t bundleContext_removeFrameworkListener(bundle_context_pt context, framework_listener_pt listener);
+FRAMEWORK_EXPORT celix_status_t
+bundleContext_removeBundleListener(bundle_context_pt context, bundle_listener_pt listener);
 
-FRAMEWORK_EXPORT celix_status_t bundleContext_getProperty(bundle_context_pt context, const char* name, const char** value);
-FRAMEWORK_EXPORT celix_status_t bundleContext_getPropertyWithDefault(bundle_context_pt context, const char* name, const char* defaultValue, const char** value);
+FRAMEWORK_EXPORT celix_status_t
+bundleContext_addFrameworkListener(bundle_context_pt context, framework_listener_pt listener);
+
+FRAMEWORK_EXPORT celix_status_t
+bundleContext_removeFrameworkListener(bundle_context_pt context, framework_listener_pt listener);
+
+FRAMEWORK_EXPORT celix_status_t
+bundleContext_getProperty(bundle_context_pt context, const char *name, const char **value);
+
+FRAMEWORK_EXPORT celix_status_t
+bundleContext_getPropertyWithDefault(bundle_context_pt context, const char *name, const char *defaultValue,
+                                     const char **value);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* BUNDLE_CONTEXT_H_ */

--- a/framework/public/include/bundle_event.h
+++ b/framework/public/include/bundle_event.h
@@ -27,8 +27,11 @@
 #ifndef BUNDLE_EVENT_H_
 #define BUNDLE_EVENT_H_
 
-enum bundle_event_type
-{
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+enum bundle_event_type {
 	OSGI_FRAMEWORK_BUNDLE_EVENT_INSTALLED = 0x00000001,
 	OSGI_FRAMEWORK_BUNDLE_EVENT_STARTED = 0x00000002,
 	OSGI_FRAMEWORK_BUNDLE_EVENT_STOPPED = 0x00000004,
@@ -48,9 +51,13 @@ typedef struct bundle_event *bundle_event_pt;
 #include "bundle.h"
 
 struct bundle_event {
-    long bundleId;
-    char* bundleSymbolicName;
+	long bundleId;
+	char *bundleSymbolicName;
 	bundle_event_type_e type;
 };
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* BUNDLE_EVENT_H_ */

--- a/framework/public/include/bundle_listener.h
+++ b/framework/public/include/bundle_listener.h
@@ -34,11 +34,20 @@ typedef struct bundle_listener *bundle_listener_pt;
 #include "celix_errno.h"
 #include "bundle_event.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
 struct bundle_listener {
-	void * handle;
-	celix_status_t (*bundleChanged)(void * listener, bundle_event_pt event);
+	void *handle;
+
+	celix_status_t (*bundleChanged)(void *listener, bundle_event_pt event);
 };
 
+#ifdef __cplusplus
+}
+#endif
 
 
 #endif /* service_listener_t_H_ */

--- a/framework/public/include/bundle_revision.h
+++ b/framework/public/include/bundle_revision.h
@@ -36,6 +36,10 @@
 #include "celix_log.h"
 #include "array_list.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * Typedef for bundle_revision_pt.
  *
@@ -44,7 +48,7 @@
  *
  * In a revision the content of a bundle (ZIP file) is extracted to a specified location inside the archive.
  */
-typedef struct bundleRevision * bundle_revision_pt;
+typedef struct bundleRevision *bundle_revision_pt;
 
 /**
  * Creates a new revision for the given inputFile or location.
@@ -62,7 +66,8 @@ typedef struct bundleRevision * bundle_revision_pt;
  * 		- CELIX_SUCCESS when no errors are encountered.
  * 		- CELIX_ENOMEM If allocating memory for <code>bundle_revision</code> failed.
  */
-celix_status_t bundleRevision_create(const char* root, const char* location, long revisionNr, const char* inputFile, bundle_revision_pt *bundle_revision);
+celix_status_t bundleRevision_create(const char *root, const char *location, long revisionNr, const char *inputFile,
+                                     bundle_revision_pt *bundle_revision);
 
 celix_status_t bundleRevision_destroy(bundle_revision_pt revision);
 
@@ -88,7 +93,7 @@ celix_status_t bundleRevision_getNumber(bundle_revision_pt revision, long *revis
  * 		- CELIX_SUCCESS when no errors are encountered.
  * 		- CELIX_ILLEGAL_ARGUMENT If <code>revision</code> is illegal.
  */
-celix_status_t bundleRevision_getLocation(bundle_revision_pt revision, const char** location);
+celix_status_t bundleRevision_getLocation(bundle_revision_pt revision, const char **location);
 
 /**
  * Retrieves the root of the given revision.
@@ -100,7 +105,7 @@ celix_status_t bundleRevision_getLocation(bundle_revision_pt revision, const cha
  * 		- CELIX_SUCCESS when no errors are encountered.
  * 		- CELIX_ILLEGAL_ARGUMENT If <code>revision</code> is illegal.
  */
-celix_status_t bundleRevision_getRoot(bundle_revision_pt revision, const char** root);
+celix_status_t bundleRevision_getRoot(bundle_revision_pt revision, const char **root);
 
 /**
  * Retrieves the manifest of the given revision.
@@ -125,6 +130,10 @@ celix_status_t bundleRevision_getManifest(bundle_revision_pt revision, manifest_
  *      - CELIX_ILLEGAL_ARGUMENT If <code>revision</code> is illegal.
  */
 celix_status_t bundleRevision_getHandles(bundle_revision_pt revision, array_list_pt *handles);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* BUNDLE_REVISION_H_ */
 

--- a/framework/public/include/bundle_state.h
+++ b/framework/public/include/bundle_state.h
@@ -27,8 +27,11 @@
 #ifndef BUNDLE_STATE_H_
 #define BUNDLE_STATE_H_
 
-enum bundleState
-{
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+enum bundleState {
 	OSGI_FRAMEWORK_BUNDLE_UNKNOWN = 0x00000000,
 	OSGI_FRAMEWORK_BUNDLE_UNINSTALLED = 0x00000001,
 	OSGI_FRAMEWORK_BUNDLE_INSTALLED = 0x00000002,
@@ -39,5 +42,8 @@ enum bundleState
 };
 
 typedef enum bundleState bundle_state_e;
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* BUNDLE_STATE_H_ */

--- a/framework/public/include/capability.h
+++ b/framework/public/include/capability.h
@@ -32,10 +32,23 @@ typedef struct capability *capability_pt;
 #include "hash_map.h"
 #include "module.h"
 
-celix_status_t capability_create(module_pt module, hash_map_pt directives, hash_map_pt attributes, capability_pt *capability);
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+celix_status_t
+capability_create(module_pt module, hash_map_pt directives, hash_map_pt attributes, capability_pt *capability);
+
 celix_status_t capability_destroy(capability_pt capability);
-celix_status_t capability_getServiceName(capability_pt capability, const char** serviceName);
+
+celix_status_t capability_getServiceName(capability_pt capability, const char **serviceName);
+
 celix_status_t capability_getVersion(capability_pt capability, version_pt *version);
+
 celix_status_t capability_getModule(capability_pt capability, module_pt *module);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* CAPABILITY_H_ */

--- a/framework/public/include/celix_launcher.h
+++ b/framework/public/include/celix_launcher.h
@@ -30,13 +30,24 @@
 #include <stdio.h>
 #include "framework.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 int celixLauncher_launch(const char *configFile, framework_pt *framework);
+
 int celixLauncher_launchWithStream(FILE *config, framework_pt *framework);
+
 int celixLauncher_launchWithProperties(properties_pt config, framework_pt *framework);
 
 void celixLauncher_stop(framework_pt framework);
+
 void celixLauncher_destroy(framework_pt framework);
 
 void celixLauncher_waitForShutdown(framework_pt framework);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif //CELIX_LAUNCHER_H

--- a/framework/public/include/celix_log.h
+++ b/framework/public/include/celix_log.h
@@ -32,8 +32,11 @@
 #include "celix_errno.h"
 #include "framework_exports.h"
 
-enum framework_log_level
-{
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+enum framework_log_level {
     OSGI_FRAMEWORK_LOG_ERROR = 0x00000001,
     OSGI_FRAMEWORK_LOG_WARNING = 0x00000002,
     OSGI_FRAMEWORK_LOG_INFO = 0x00000003,
@@ -46,7 +49,8 @@ typedef struct framework_logger *framework_logger_pt;
 
 extern framework_logger_pt logger;
 
-typedef celix_status_t (*framework_log_function_pt)(framework_log_level_t level, const char* func, const char* file, int line, const char* msg);
+typedef celix_status_t (*framework_log_function_pt)(framework_log_level_t level, const char *func, const char *file,
+                                                    int line, const char *msg);
 
 struct framework_logger {
     framework_log_function_pt logFunction;
@@ -63,8 +67,19 @@ struct framework_logger {
         } \
     }
 
-FRAMEWORK_EXPORT celix_status_t frameworkLogger_log(framework_log_level_t level, const char *func, const char *file, int line, const char* fmsg);
-FRAMEWORK_EXPORT void framework_log(framework_logger_pt logger, framework_log_level_t level, const char *func, const char *file, int line, const char* fmsg, ...);
-FRAMEWORK_EXPORT void framework_logCode(framework_logger_pt logger, framework_log_level_t level, const char* func, const char* file, int line, celix_status_t code, const char* fmsg, ...);
+FRAMEWORK_EXPORT celix_status_t
+frameworkLogger_log(framework_log_level_t level, const char *func, const char *file, int line, const char *fmsg);
+
+FRAMEWORK_EXPORT void
+framework_log(framework_logger_pt logger, framework_log_level_t level, const char *func, const char *file, int line,
+              const char *fmsg, ...);
+
+FRAMEWORK_EXPORT void
+framework_logCode(framework_logger_pt logger, framework_log_level_t level, const char *func, const char *file, int line,
+                  celix_status_t code, const char *fmsg, ...);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* CELIX_LOG_H_ */

--- a/framework/public/include/constants.h
+++ b/framework/public/include/constants.h
@@ -27,34 +27,41 @@
 #ifndef CONSTANTS_H_
 #define CONSTANTS_H_
 
-static const char * const OSGI_FRAMEWORK_OBJECTCLASS = "objectClass";
-static const char * const OSGI_FRAMEWORK_SERVICE_ID = "service.id";
-static const char * const OSGI_FRAMEWORK_SERVICE_PID = "service.pid";
-static const char * const OSGI_FRAMEWORK_SERVICE_RANKING = "service.ranking";
+#ifdef __cplusplus
+extern "C" {
+#endif
 
-static const char * const CELIX_FRAMEWORK_SERVICE_VERSION = "service.version";
-static const char * const CELIX_FRAMEWORK_SERVICE_LANGUAGE = "service.lang";
-static const char * const CELIX_FRAMEWORK_SERVICE_C_LANGUAGE = "C";
-static const char * const CELIX_FRAMEWORK_SERVICE_CXX_LANGUAGE = "C++";
-static const char * const CELIX_FRAMEWORK_SERVICE_SHARED_LANGUAGE = "shared"; //e.g. marker services
+static const char *const OSGI_FRAMEWORK_OBJECTCLASS = "objectClass";
+static const char *const OSGI_FRAMEWORK_SERVICE_ID = "service.id";
+static const char *const OSGI_FRAMEWORK_SERVICE_PID = "service.pid";
+static const char *const OSGI_FRAMEWORK_SERVICE_RANKING = "service.ranking";
 
-static const char * const OSGI_FRAMEWORK_BUNDLE_ACTIVATOR = "Bundle-Activator";
-static const char * const OSGI_FRAMEWORK_BUNDLE_ACTIVATOR_CREATE = "bundleActivator_create";
-static const char * const OSGI_FRAMEWORK_BUNDLE_ACTIVATOR_START = "bundleActivator_start";
-static const char * const OSGI_FRAMEWORK_BUNDLE_ACTIVATOR_STOP = "bundleActivator_stop";
-static const char * const OSGI_FRAMEWORK_BUNDLE_ACTIVATOR_DESTROY = "bundleActivator_destroy";
+static const char *const CELIX_FRAMEWORK_SERVICE_VERSION = "service.version";
+static const char *const CELIX_FRAMEWORK_SERVICE_LANGUAGE = "service.lang";
+static const char *const CELIX_FRAMEWORK_SERVICE_C_LANGUAGE = "C";
+static const char *const CELIX_FRAMEWORK_SERVICE_CXX_LANGUAGE = "C++";
+static const char *const CELIX_FRAMEWORK_SERVICE_SHARED_LANGUAGE = "shared"; //e.g. marker services
 
-static const char * const OSGI_FRAMEWORK_BUNDLE_SYMBOLICNAME = "Bundle-SymbolicName";
-static const char * const OSGI_FRAMEWORK_BUNDLE_VERSION = "Bundle-Version";
-static const char * const OSGI_FRAMEWORK_PRIVATE_LIBRARY = "Private-Library";
-static const char * const OSGI_FRAMEWORK_EXPORT_LIBRARY = "Export-Library";
-static const char * const OSGI_FRAMEWORK_IMPORT_LIBRARY = "Import-Library";
+static const char *const OSGI_FRAMEWORK_BUNDLE_ACTIVATOR = "Bundle-Activator";
+static const char *const OSGI_FRAMEWORK_BUNDLE_ACTIVATOR_CREATE = "bundleActivator_create";
+static const char *const OSGI_FRAMEWORK_BUNDLE_ACTIVATOR_START = "bundleActivator_start";
+static const char *const OSGI_FRAMEWORK_BUNDLE_ACTIVATOR_STOP = "bundleActivator_stop";
+static const char *const OSGI_FRAMEWORK_BUNDLE_ACTIVATOR_DESTROY = "bundleActivator_destroy";
+
+static const char *const OSGI_FRAMEWORK_BUNDLE_SYMBOLICNAME = "Bundle-SymbolicName";
+static const char *const OSGI_FRAMEWORK_BUNDLE_VERSION = "Bundle-Version";
+static const char *const OSGI_FRAMEWORK_PRIVATE_LIBRARY = "Private-Library";
+static const char *const OSGI_FRAMEWORK_EXPORT_LIBRARY = "Export-Library";
+static const char *const OSGI_FRAMEWORK_IMPORT_LIBRARY = "Import-Library";
 
 
-static const char * const OSGI_FRAMEWORK_FRAMEWORK_STORAGE = "org.osgi.framework.storage";
-static const char * const OSGI_FRAMEWORK_FRAMEWORK_STORAGE_CLEAN = "org.osgi.framework.storage.clean";
-static const char * const OSGI_FRAMEWORK_FRAMEWORK_STORAGE_CLEAN_ONFIRSTINIT = "onFirstInit";
-static const char * const OSGI_FRAMEWORK_FRAMEWORK_UUID = "org.osgi.framework.uuid";
+static const char *const OSGI_FRAMEWORK_FRAMEWORK_STORAGE = "org.osgi.framework.storage";
+static const char *const OSGI_FRAMEWORK_FRAMEWORK_STORAGE_CLEAN = "org.osgi.framework.storage.clean";
+static const char *const OSGI_FRAMEWORK_FRAMEWORK_STORAGE_CLEAN_ONFIRSTINIT = "onFirstInit";
+static const char *const OSGI_FRAMEWORK_FRAMEWORK_UUID = "org.osgi.framework.uuid";
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* CONSTANTS_H_ */

--- a/framework/public/include/filter.h
+++ b/framework/public/include/filter.h
@@ -32,14 +32,24 @@
 #include "celixbool.h"
 #include "framework_exports.h"
 
-typedef struct filter * filter_pt;
+#ifdef __cplusplus
+extern "C" {
+#endif
 
-FRAMEWORK_EXPORT filter_pt filter_create(const char * filterString);
+typedef struct filter *filter_pt;
+
+FRAMEWORK_EXPORT filter_pt filter_create(const char *filterString);
+
 FRAMEWORK_EXPORT void filter_destroy(filter_pt filter);
 
 FRAMEWORK_EXPORT celix_status_t filter_match(filter_pt filter, properties_pt properties, bool *result);
+
 FRAMEWORK_EXPORT celix_status_t filter_match_filter(filter_pt src, filter_pt dest, bool *result);
 
-FRAMEWORK_EXPORT celix_status_t filter_getString(filter_pt filter, const char** filterStr);
+FRAMEWORK_EXPORT celix_status_t filter_getString(filter_pt filter, const char **filterStr);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* FILTER_H_ */

--- a/framework/public/include/framework.h
+++ b/framework/public/include/framework.h
@@ -35,13 +35,23 @@ typedef struct framework * framework_pt;
 #include "bundle.h"
 #include "properties.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 // #TODO: Move to FrameworkFactory according the OSGi Spec
 FRAMEWORK_EXPORT celix_status_t framework_create(framework_pt *framework, properties_pt config);
+
 FRAMEWORK_EXPORT celix_status_t framework_destroy(framework_pt framework);
 
 FRAMEWORK_EXPORT celix_status_t fw_init(framework_pt framework);
+
 FRAMEWORK_EXPORT celix_status_t framework_waitForStop(framework_pt framework);
 
 FRAMEWORK_EXPORT celix_status_t framework_getFrameworkBundle(framework_pt framework, bundle_pt *bundle);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* FRAMEWORK_H_ */

--- a/framework/public/include/framework_event.h
+++ b/framework/public/include/framework_event.h
@@ -27,8 +27,11 @@
 #ifndef FRAMEWORK_EVENT_H_
 #define FRAMEWORK_EVENT_H_
 
-enum framework_event_type
-{
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+enum framework_event_type {
 	OSGI_FRAMEWORK_EVENT_STARTED = 0x00000001,
 	OSGI_FRAMEWORK_EVENT_ERROR = 0x00000002,
 	OSGI_FRAMEWORK_EVENT_PACKAGES_REFRESHED = 0x00000004,
@@ -43,16 +46,26 @@ enum framework_event_type
 
 typedef enum framework_event_type framework_event_type_e;
 typedef struct framework_event *framework_event_pt;
+#ifdef __cplusplus
+}
+#endif
 
 #include "service_reference.h"
 #include "bundle.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct framework_event {
 	long bundleId;
-	char* bundleSymbolicName;
+	char *bundleSymbolicName;
 	framework_event_type_e type;
 	celix_status_t errorCode;
 	char *error;
 };
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* FRAMEWORK_EVENT_H_ */

--- a/framework/public/include/framework_listener.h
+++ b/framework/public/include/framework_listener.h
@@ -33,12 +33,19 @@ typedef struct framework_listener *framework_listener_pt;
 
 #include "celix_errno.h"
 #include "framework_event.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 struct framework_listener {
-	void * handle;
-	celix_status_t (*frameworkEvent)(void * listener, framework_event_pt event);
+	void *handle;
+
+	celix_status_t (*frameworkEvent)(void *listener, framework_event_pt event);
 };
 
+#ifdef __cplusplus
+}
+#endif
 
 
 #endif /* FRAMEWORK_LISTENER_H_ */

--- a/framework/public/include/listener_hook_service.h
+++ b/framework/public/include/listener_hook_service.h
@@ -35,6 +35,9 @@ typedef struct listener_hook_service *listener_hook_service_pt;
 #include "bundle_context.h"
 
 #define OSGI_FRAMEWORK_LISTENER_HOOK_SERVICE_NAME "listener_hook_service"
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 struct listener_hook_info {
 	bundle_context_pt context;
@@ -44,8 +47,14 @@ struct listener_hook_info {
 
 struct listener_hook_service {
 	void *handle;
+
 	celix_status_t (*added)(void *hook, array_list_pt listeners);
+
 	celix_status_t (*removed)(void *hook, array_list_pt listeners);
 };
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* LISTENER_HOOK_SERVICE_H_ */

--- a/framework/public/include/manifest.h
+++ b/framework/public/include/manifest.h
@@ -31,24 +31,37 @@
 #include "celix_errno.h"
 #include "framework_exports.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct manifest {
 	properties_pt mainAttributes;
 	hash_map_pt attributes;
 };
 
-typedef struct manifest * manifest_pt;
+typedef struct manifest *manifest_pt;
 
 FRAMEWORK_EXPORT celix_status_t manifest_create(manifest_pt *manifest);
-FRAMEWORK_EXPORT celix_status_t manifest_createFromFile(const char* filename, manifest_pt *manifest);
+
+FRAMEWORK_EXPORT celix_status_t manifest_createFromFile(const char *filename, manifest_pt *manifest);
+
 FRAMEWORK_EXPORT celix_status_t manifest_destroy(manifest_pt manifest);
 
 FRAMEWORK_EXPORT void manifest_clear(manifest_pt manifest);
+
 FRAMEWORK_EXPORT properties_pt manifest_getMainAttributes(manifest_pt manifest);
+
 FRAMEWORK_EXPORT celix_status_t manifest_getEntries(manifest_pt manifest, hash_map_pt *map);
 
-FRAMEWORK_EXPORT celix_status_t manifest_read(manifest_pt manifest, const char* filename);
-FRAMEWORK_EXPORT void manifest_write(manifest_pt manifest, const char*  filename);
+FRAMEWORK_EXPORT celix_status_t manifest_read(manifest_pt manifest, const char *filename);
 
-FRAMEWORK_EXPORT const char* manifest_getValue(manifest_pt manifest, const char* name);
+FRAMEWORK_EXPORT void manifest_write(manifest_pt manifest, const char *filename);
+
+FRAMEWORK_EXPORT const char *manifest_getValue(manifest_pt manifest, const char *name);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* MANIFEST_H_ */

--- a/framework/public/include/module.h
+++ b/framework/public/include/module.h
@@ -37,35 +37,58 @@ typedef struct module *module_pt;
 #include "bundle.h"
 #include "framework_exports.h"
 
-module_pt module_create(manifest_pt headerMap, const char* moduleId, bundle_pt bundle);
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+module_pt module_create(manifest_pt headerMap, const char *moduleId, bundle_pt bundle);
+
 module_pt module_createFrameworkModule(bundle_pt bundle);
+
 void module_destroy(module_pt module);
 
-FRAMEWORK_EXPORT unsigned int module_hash(void * module);
-FRAMEWORK_EXPORT int module_equals(void * module, void * compare);
+FRAMEWORK_EXPORT unsigned int module_hash(void *module);
 
-FRAMEWORK_EXPORT wire_pt module_getWire(module_pt module, const char* serviceName);
+FRAMEWORK_EXPORT int module_equals(void *module, void *compare);
+
+FRAMEWORK_EXPORT wire_pt module_getWire(module_pt module, const char *serviceName);
 
 FRAMEWORK_EXPORT version_pt module_getVersion(module_pt module);
-FRAMEWORK_EXPORT celix_status_t module_getSymbolicName(module_pt module, const char** symbolicName);
-FRAMEWORK_EXPORT char * module_getId(module_pt module);
+
+FRAMEWORK_EXPORT celix_status_t module_getSymbolicName(module_pt module, const char **symbolicName);
+
+FRAMEWORK_EXPORT char *module_getId(module_pt module);
+
 FRAMEWORK_EXPORT linked_list_pt module_getWires(module_pt module);
+
 FRAMEWORK_EXPORT void module_setWires(module_pt module, linked_list_pt wires);
+
 FRAMEWORK_EXPORT bool module_isResolved(module_pt module);
+
 FRAMEWORK_EXPORT void module_setResolved(module_pt module);
+
 FRAMEWORK_EXPORT bundle_pt module_getBundle(module_pt module);
 
 FRAMEWORK_EXPORT linked_list_pt module_getRequirements(module_pt module);
+
 FRAMEWORK_EXPORT linked_list_pt module_getCapabilities(module_pt module);
 
 FRAMEWORK_EXPORT array_list_pt module_getDependentImporters(module_pt module);
+
 FRAMEWORK_EXPORT void module_addDependentImporter(module_pt module, module_pt importer);
+
 FRAMEWORK_EXPORT void module_removeDependentImporter(module_pt module, module_pt importer);
 
 FRAMEWORK_EXPORT array_list_pt module_getDependentRequirers(module_pt module);
+
 FRAMEWORK_EXPORT void module_addDependentRequirer(module_pt module, module_pt requirer);
+
 FRAMEWORK_EXPORT void module_removeDependentRequirer(module_pt module, module_pt requirer);
 
 FRAMEWORK_EXPORT array_list_pt module_getDependents(module_pt module);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* MODULE_H_ */

--- a/framework/public/include/requirement.h
+++ b/framework/public/include/requirement.h
@@ -32,12 +32,22 @@ typedef struct requirement *requirement_pt;
 #include "capability.h"
 #include "hash_map.h"
 #include "version_range.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 celix_status_t requirement_create(hash_map_pt directives, hash_map_pt attributes, requirement_pt *requirement);
+
 celix_status_t requirement_destroy(requirement_pt requirement);
+
 celix_status_t requirement_getVersionRange(requirement_pt requirement, version_range_pt *range);
-celix_status_t requirement_getTargetName(requirement_pt requirement, const char** targetName);
+
+celix_status_t requirement_getTargetName(requirement_pt requirement, const char **targetName);
 
 celix_status_t requirement_isSatisfied(requirement_pt requirement, capability_pt capability, bool *inRange);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* REQUIREMENT_H_ */

--- a/framework/public/include/service_event.h
+++ b/framework/public/include/service_event.h
@@ -28,9 +28,11 @@
  */
 #ifndef SERVICE_EVENT_H_
 #define SERVICE_EVENT_H_
+#ifdef __cplusplus
+extern "C" {
+#endif
 
-enum serviceEventType
-{
+enum serviceEventType {
 	OSGI_FRAMEWORK_SERVICE_EVENT_REGISTERED = 0x00000001,
 	OSGI_FRAMEWORK_SERVICE_EVENT_MODIFIED = 0x00000002,
 	OSGI_FRAMEWORK_SERVICE_EVENT_UNREGISTERING = 0x00000004,
@@ -40,15 +42,24 @@ enum serviceEventType
 typedef enum serviceEventType service_event_type_e;
 
 typedef struct serviceEvent *service_event_pt;
+#ifdef __cplusplus
+}
+#endif
 
 #include "service_reference.h"
 
 #include "service_reference.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 struct serviceEvent {
 	service_reference_pt reference;
 	service_event_type_e type;
 };
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* SERVICE_EVENT_H_ */
 

--- a/framework/public/include/service_factory.h
+++ b/framework/public/include/service_factory.h
@@ -26,19 +26,35 @@
 
 #ifndef SERVICE_FACTORY_H_
 #define SERVICE_FACTORY_H_
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 typedef struct service_factory service_factory_t;
-typedef service_factory_t* service_factory_pt;
+typedef service_factory_t *service_factory_pt;
+#ifdef __cplusplus
+}
+#endif
 
 #include "celix_errno.h"
 #include "service_registration.h"
 #include "bundle.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct service_factory {
     void *handle;
+
     celix_status_t (*getService)(void *handle, bundle_pt bundle, service_registration_pt registration, void **service);
-    celix_status_t (*ungetService)(void *handle, bundle_pt bundle, service_registration_pt registration, void **service);
+
+    celix_status_t
+    (*ungetService)(void *handle, bundle_pt bundle, service_registration_pt registration, void **service);
 };
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* SERVICE_FACTORY_H_ */

--- a/framework/public/include/service_listener.h
+++ b/framework/public/include/service_listener.h
@@ -33,12 +33,19 @@ typedef struct serviceListener * service_listener_pt;
 
 #include "celix_errno.h"
 #include "service_event.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 struct serviceListener {
-	void * handle;
-	celix_status_t (*serviceChanged)(void * listener, service_event_pt event);
+	void *handle;
+
+	celix_status_t (*serviceChanged)(void *listener, service_event_pt event);
 };
 
+#ifdef __cplusplus
+}
+#endif
 
 
 #endif /* SERVICE_LISTENER_H_ */

--- a/framework/public/include/service_reference.h
+++ b/framework/public/include/service_reference.h
@@ -35,19 +35,38 @@ typedef struct serviceReference * service_reference_pt;
 #include "bundle.h"
 #include "framework_exports.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 FRAMEWORK_EXPORT celix_status_t serviceReference_getBundle(service_reference_pt reference, bundle_pt *bundle);
 
-FRAMEWORK_EXPORT bool serviceReference_isAssignableTo(service_reference_pt reference, bundle_pt requester, const char* serviceName);
+FRAMEWORK_EXPORT bool
+serviceReference_isAssignableTo(service_reference_pt reference, bundle_pt requester, const char *serviceName);
 
-FRAMEWORK_EXPORT celix_status_t serviceReference_getProperty(service_reference_pt reference, const char* key, const char** value);
-FRAMEWORK_EXPORT celix_status_t serviceReference_getPropertyKeys(service_reference_pt reference, char **keys[], unsigned int *size);
+FRAMEWORK_EXPORT celix_status_t
+serviceReference_getProperty(service_reference_pt reference, const char *key, const char **value);
 
-FRAMEWORK_EXPORT celix_status_t serviceReference_getServiceRegistration(service_reference_pt reference, service_registration_pt *registration);
+FRAMEWORK_EXPORT celix_status_t
+serviceReference_getPropertyKeys(service_reference_pt reference, char **keys[], unsigned int *size);
 
-FRAMEWORK_EXPORT celix_status_t serviceReference_equals(service_reference_pt reference, service_reference_pt compareTo, bool *equal);
-FRAMEWORK_EXPORT unsigned int serviceReference_hashCode(const void* referenceP);
-FRAMEWORK_EXPORT int serviceReference_equals2(const void* reference1, const void* reference2);
-FRAMEWORK_EXPORT celix_status_t serviceReference_compareTo(service_reference_pt reference, service_reference_pt compareTo, int *compare);
+FRAMEWORK_EXPORT celix_status_t
+serviceReference_getServiceRegistration(service_reference_pt reference, service_registration_pt *registration);
+
+FRAMEWORK_EXPORT celix_status_t
+serviceReference_equals(service_reference_pt reference, service_reference_pt compareTo, bool *equal);
+
+FRAMEWORK_EXPORT unsigned int serviceReference_hashCode(const void *referenceP);
+
+FRAMEWORK_EXPORT int serviceReference_equals2(const void *reference1, const void *reference2);
+
+FRAMEWORK_EXPORT celix_status_t
+serviceReference_compareTo(service_reference_pt reference, service_reference_pt compareTo, int *compare);
+
 FRAMEWORK_EXPORT celix_status_t serviceReference_getUsingBundles(service_reference_pt ref, array_list_pt *out);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* SERVICE_REFERENCE_H_ */

--- a/framework/public/include/service_registration.h
+++ b/framework/public/include/service_registration.h
@@ -36,10 +36,23 @@ typedef struct serviceRegistration * service_registration_pt;
 #include "bundle.h"
 #include "framework_exports.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 FRAMEWORK_EXPORT celix_status_t serviceRegistration_unregister(service_registration_pt registration);
-FRAMEWORK_EXPORT celix_status_t serviceRegistration_getProperties(service_registration_pt registration, properties_pt *properties);
-FRAMEWORK_EXPORT celix_status_t serviceRegistration_setProperties(service_registration_pt registration, properties_pt properties);
-FRAMEWORK_EXPORT celix_status_t serviceRegistration_getServiceName(service_registration_pt registration, const char **serviceName);
+
+FRAMEWORK_EXPORT celix_status_t
+serviceRegistration_getProperties(service_registration_pt registration, properties_pt *properties);
+
+FRAMEWORK_EXPORT celix_status_t
+serviceRegistration_setProperties(service_registration_pt registration, properties_pt properties);
+
+FRAMEWORK_EXPORT celix_status_t
+serviceRegistration_getServiceName(service_registration_pt registration, const char **serviceName);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* SERVICE_REGISTRATION_H_ */

--- a/framework/public/include/service_registry.h
+++ b/framework/public/include/service_registry.h
@@ -35,33 +35,69 @@ typedef struct serviceRegistry * service_registry_pt;
 #include "service_event.h"
 #include "array_list.h"
 #include "service_registration.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 typedef void (*serviceChanged_function_pt)(framework_pt, service_event_type_e, service_registration_pt, properties_pt);
 
-celix_status_t serviceRegistry_create(framework_pt framework, serviceChanged_function_pt serviceChanged, service_registry_pt *registry);
+celix_status_t serviceRegistry_create(framework_pt framework, serviceChanged_function_pt serviceChanged,
+                                      service_registry_pt *registry);
+
 celix_status_t serviceRegistry_destroy(service_registry_pt registry);
 
-celix_status_t serviceRegistry_getRegisteredServices(service_registry_pt registry, bundle_pt bundle, array_list_pt *services);
-celix_status_t serviceRegistry_getServicesInUse(service_registry_pt registry, bundle_pt bundle, array_list_pt *services);
+celix_status_t
+serviceRegistry_getRegisteredServices(service_registry_pt registry, bundle_pt bundle, array_list_pt *services);
 
-celix_status_t serviceRegistry_registerService(service_registry_pt registry, bundle_pt bundle, const char* serviceName, const void * serviceObject, properties_pt dictionary, service_registration_pt *registration);
-celix_status_t serviceRegistry_registerServiceFactory(service_registry_pt registry, bundle_pt bundle, const char* serviceName, service_factory_pt factory, properties_pt dictionary, service_registration_pt *registration);
+celix_status_t
+serviceRegistry_getServicesInUse(service_registry_pt registry, bundle_pt bundle, array_list_pt *services);
 
-celix_status_t serviceRegistry_unregisterService(service_registry_pt registry, bundle_pt bundle, service_registration_pt registration);
+celix_status_t serviceRegistry_registerService(service_registry_pt registry, bundle_pt bundle, const char *serviceName,
+                                               const void *serviceObject, properties_pt dictionary,
+                                               service_registration_pt *registration);
+
+celix_status_t
+serviceRegistry_registerServiceFactory(service_registry_pt registry, bundle_pt bundle, const char *serviceName,
+                                       service_factory_pt factory, properties_pt dictionary,
+                                       service_registration_pt *registration);
+
+celix_status_t
+serviceRegistry_unregisterService(service_registry_pt registry, bundle_pt bundle, service_registration_pt registration);
+
 celix_status_t serviceRegistry_clearServiceRegistrations(service_registry_pt registry, bundle_pt bundle);
 
-celix_status_t serviceRegistry_getServiceReference(service_registry_pt registry, bundle_pt bundle, service_registration_pt registration, service_reference_pt *reference);
-celix_status_t serviceRegistry_getServiceReferences(service_registry_pt registry, bundle_pt bundle, const char *serviceName, filter_pt filter, array_list_pt *references);
-celix_status_t serviceRegistry_retainServiceReference(service_registry_pt registry, bundle_pt bundle, service_reference_pt reference);
-celix_status_t serviceRegistry_ungetServiceReference(service_registry_pt registry, bundle_pt bundle, service_reference_pt reference);
+celix_status_t serviceRegistry_getServiceReference(service_registry_pt registry, bundle_pt bundle,
+                                                   service_registration_pt registration,
+                                                   service_reference_pt *reference);
 
-celix_status_t serviceRegistry_getService(service_registry_pt registry, bundle_pt bundle, service_reference_pt reference, const void **service);
-celix_status_t serviceRegistry_ungetService(service_registry_pt registry, bundle_pt bundle, service_reference_pt reference, bool *result);
+celix_status_t
+serviceRegistry_getServiceReferences(service_registry_pt registry, bundle_pt bundle, const char *serviceName,
+                                     filter_pt filter, array_list_pt *references);
+
+celix_status_t
+serviceRegistry_retainServiceReference(service_registry_pt registry, bundle_pt bundle, service_reference_pt reference);
+
+celix_status_t
+serviceRegistry_ungetServiceReference(service_registry_pt registry, bundle_pt bundle, service_reference_pt reference);
+
+celix_status_t
+serviceRegistry_getService(service_registry_pt registry, bundle_pt bundle, service_reference_pt reference,
+                           const void **service);
+
+celix_status_t
+serviceRegistry_ungetService(service_registry_pt registry, bundle_pt bundle, service_reference_pt reference,
+                             bool *result);
 
 celix_status_t serviceRegistry_clearReferencesFor(service_registry_pt registry, bundle_pt bundle);
 
 celix_status_t serviceRegistry_getListenerHooks(service_registry_pt registry, bundle_pt bundle, array_list_pt *hooks);
 
-celix_status_t serviceRegistry_servicePropertiesModified(service_registry_pt registry, service_registration_pt registration, properties_pt oldprops);
+celix_status_t
+serviceRegistry_servicePropertiesModified(service_registry_pt registry, service_registration_pt registration,
+                                          properties_pt oldprops);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* SERVICE_REGISTRY_H_ */

--- a/framework/public/include/service_tracker.h
+++ b/framework/public/include/service_tracker.h
@@ -33,22 +33,40 @@
 #include "service_tracker_customizer.h"
 #include "framework_exports.h"
 
-typedef struct serviceTracker * service_tracker_pt;
+#ifdef __cplusplus
+extern "C" {
+#endif
 
-FRAMEWORK_EXPORT celix_status_t serviceTracker_create(bundle_context_pt context, const char* service, service_tracker_customizer_pt customizer, service_tracker_pt *tracker);
-FRAMEWORK_EXPORT celix_status_t serviceTracker_createWithFilter(bundle_context_pt context, const char* filter, service_tracker_customizer_pt customizer, service_tracker_pt *tracker);
+typedef struct serviceTracker *service_tracker_pt;
+
+FRAMEWORK_EXPORT celix_status_t
+serviceTracker_create(bundle_context_pt context, const char *service, service_tracker_customizer_pt customizer,
+                      service_tracker_pt *tracker);
+
+FRAMEWORK_EXPORT celix_status_t
+serviceTracker_createWithFilter(bundle_context_pt context, const char *filter, service_tracker_customizer_pt customizer,
+                                service_tracker_pt *tracker);
 
 FRAMEWORK_EXPORT celix_status_t serviceTracker_open(service_tracker_pt tracker);
+
 FRAMEWORK_EXPORT celix_status_t serviceTracker_close(service_tracker_pt tracker);
+
 FRAMEWORK_EXPORT celix_status_t serviceTracker_destroy(service_tracker_pt tracker);
 
 FRAMEWORK_EXPORT service_reference_pt serviceTracker_getServiceReference(service_tracker_pt tracker);
+
 FRAMEWORK_EXPORT array_list_pt serviceTracker_getServiceReferences(service_tracker_pt tracker);
 
-FRAMEWORK_EXPORT void * serviceTracker_getService(service_tracker_pt tracker);
+FRAMEWORK_EXPORT void *serviceTracker_getService(service_tracker_pt tracker);
+
 FRAMEWORK_EXPORT array_list_pt serviceTracker_getServices(service_tracker_pt tracker);
-FRAMEWORK_EXPORT void * serviceTracker_getServiceByReference(service_tracker_pt tracker, service_reference_pt reference);
+
+FRAMEWORK_EXPORT void *serviceTracker_getServiceByReference(service_tracker_pt tracker, service_reference_pt reference);
 
 FRAMEWORK_EXPORT void serviceTracker_serviceChanged(service_listener_pt listener, service_event_pt event);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* SERVICE_TRACKER_H_ */

--- a/framework/public/include/service_tracker_customizer.h
+++ b/framework/public/include/service_tracker_customizer.h
@@ -31,23 +31,46 @@
 #include <celix_errno.h>
 #include <service_reference.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef celix_status_t (*adding_callback_pt)(void *handle, service_reference_pt reference, void **service);
-typedef celix_status_t (*added_callback_pt)(void * handle, service_reference_pt reference, void * service);
-typedef celix_status_t (*modified_callback_pt)(void * handle, service_reference_pt reference, void * service);
-typedef celix_status_t (*removed_callback_pt)(void * handle, service_reference_pt reference, void * service);
+
+typedef celix_status_t (*added_callback_pt)(void *handle, service_reference_pt reference, void *service);
+
+typedef celix_status_t (*modified_callback_pt)(void *handle, service_reference_pt reference, void *service);
+
+typedef celix_status_t (*removed_callback_pt)(void *handle, service_reference_pt reference, void *service);
 
 typedef struct serviceTrackerCustomizer *service_tracker_customizer_pt;
 
 FRAMEWORK_EXPORT celix_status_t serviceTrackerCustomizer_create(void *handle,
-		adding_callback_pt addingFunction, added_callback_pt addedFunction,
-		modified_callback_pt modifiedFunction, removed_callback_pt removedFunction,
-		service_tracker_customizer_pt *customizer);
+																adding_callback_pt addingFunction,
+																added_callback_pt addedFunction,
+																modified_callback_pt modifiedFunction,
+																removed_callback_pt removedFunction,
+																service_tracker_customizer_pt *customizer);
+
 FRAMEWORK_EXPORT celix_status_t serviceTrackerCustomizer_destroy(service_tracker_customizer_pt customizer);
 
-FRAMEWORK_EXPORT celix_status_t serviceTrackerCustomizer_getHandle(service_tracker_customizer_pt customizer, void **handle);
-FRAMEWORK_EXPORT celix_status_t serviceTrackerCustomizer_getAddingFunction(service_tracker_customizer_pt customizer, adding_callback_pt *function);
-FRAMEWORK_EXPORT celix_status_t serviceTrackerCustomizer_getAddedFunction(service_tracker_customizer_pt customizer, added_callback_pt *function);
-FRAMEWORK_EXPORT celix_status_t serviceTrackerCustomizer_getModifiedFunction(service_tracker_customizer_pt customizer, modified_callback_pt *function);
-FRAMEWORK_EXPORT celix_status_t serviceTrackerCustomizer_getRemovedFunction(service_tracker_customizer_pt customizer, removed_callback_pt *function);
+FRAMEWORK_EXPORT celix_status_t
+serviceTrackerCustomizer_getHandle(service_tracker_customizer_pt customizer, void **handle);
+
+FRAMEWORK_EXPORT celix_status_t
+serviceTrackerCustomizer_getAddingFunction(service_tracker_customizer_pt customizer, adding_callback_pt *function);
+
+FRAMEWORK_EXPORT celix_status_t
+serviceTrackerCustomizer_getAddedFunction(service_tracker_customizer_pt customizer, added_callback_pt *function);
+
+FRAMEWORK_EXPORT celix_status_t
+serviceTrackerCustomizer_getModifiedFunction(service_tracker_customizer_pt customizer, modified_callback_pt *function);
+
+FRAMEWORK_EXPORT celix_status_t
+serviceTrackerCustomizer_getRemovedFunction(service_tracker_customizer_pt customizer, removed_callback_pt *function);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* service_tracker_customizer_t_H_ */

--- a/framework/public/include/wire.h
+++ b/framework/public/include/wire.h
@@ -35,6 +35,10 @@ typedef struct wire *wire_pt;
 #include "linked_list.h"
 #include "module.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @defgroup Version Version
  * @ingroup framework
@@ -54,7 +58,7 @@ typedef struct wire *wire_pt;
  * 		- CELIX_ENOMEM If allocating memory for <code>wire</code> failed.
  */
 celix_status_t wire_create(module_pt importer, requirement_pt requirement,
-		module_pt exporter, capability_pt capability, wire_pt *wire);
+						   module_pt exporter, capability_pt capability, wire_pt *wire);
 
 /**
  * Getter for the capability of the exporting module.
@@ -109,5 +113,8 @@ celix_status_t wire_getExporter(wire_pt wire, module_pt *exporter);
 /**
  * @}
  */
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* WIRE_H_ */

--- a/utils/public/include/array_list.h
+++ b/utils/public/include/array_list.h
@@ -31,39 +31,69 @@
 #include "exports.h"
 #include "celix_errno.h"
 
-typedef struct arrayList * array_list_pt;
+#ifdef __cplusplus
+extern "C" {
+#endif
 
-typedef struct arrayListIterator * array_list_iterator_pt;
+typedef struct arrayList *array_list_pt;
 
-typedef celix_status_t (*array_list_element_equals_pt)(const void*, const void*, bool *equals);
+typedef struct arrayListIterator *array_list_iterator_pt;
+
+typedef celix_status_t (*array_list_element_equals_pt)(const void *, const void *, bool *equals);
 
 UTILS_EXPORT celix_status_t arrayList_create(array_list_pt *list);
+
 UTILS_EXPORT celix_status_t arrayList_createWithEquals(array_list_element_equals_pt equals, array_list_pt *list);
 
 UTILS_EXPORT void arrayList_destroy(array_list_pt list);
+
 UTILS_EXPORT void arrayList_trimToSize(array_list_pt list);
+
 UTILS_EXPORT void arrayList_ensureCapacity(array_list_pt list, int capacity);
+
 UTILS_EXPORT unsigned int arrayList_size(array_list_pt list);
+
 UTILS_EXPORT bool arrayList_isEmpty(array_list_pt list);
-UTILS_EXPORT bool arrayList_contains(array_list_pt list, void * element);
-UTILS_EXPORT int arrayList_indexOf(array_list_pt list, void * element);
-UTILS_EXPORT int arrayList_lastIndexOf(array_list_pt list, void * element);
-UTILS_EXPORT void * arrayList_get(array_list_pt list, unsigned int index);
-UTILS_EXPORT void * arrayList_set(array_list_pt list, unsigned int index, void * element);
-UTILS_EXPORT bool arrayList_add(array_list_pt list, void * element);
-UTILS_EXPORT int arrayList_addIndex(array_list_pt list, unsigned int index, void * element);
+
+UTILS_EXPORT bool arrayList_contains(array_list_pt list, void *element);
+
+UTILS_EXPORT int arrayList_indexOf(array_list_pt list, void *element);
+
+UTILS_EXPORT int arrayList_lastIndexOf(array_list_pt list, void *element);
+
+UTILS_EXPORT void *arrayList_get(array_list_pt list, unsigned int index);
+
+UTILS_EXPORT void *arrayList_set(array_list_pt list, unsigned int index, void *element);
+
+UTILS_EXPORT bool arrayList_add(array_list_pt list, void *element);
+
+UTILS_EXPORT int arrayList_addIndex(array_list_pt list, unsigned int index, void *element);
+
 UTILS_EXPORT bool arrayList_addAll(array_list_pt list, array_list_pt toAdd);
-UTILS_EXPORT void * arrayList_remove(array_list_pt list, unsigned int index);
-UTILS_EXPORT bool arrayList_removeElement(array_list_pt list, void * element);
+
+UTILS_EXPORT void *arrayList_remove(array_list_pt list, unsigned int index);
+
+UTILS_EXPORT bool arrayList_removeElement(array_list_pt list, void *element);
+
 UTILS_EXPORT void arrayList_clear(array_list_pt list);
+
 UTILS_EXPORT array_list_pt arrayList_clone(array_list_pt list);
 
 UTILS_EXPORT array_list_iterator_pt arrayListIterator_create(array_list_pt list);
+
 UTILS_EXPORT void arrayListIterator_destroy(array_list_iterator_pt iterator);
+
 UTILS_EXPORT bool arrayListIterator_hasNext(array_list_iterator_pt iterator);
-UTILS_EXPORT void * arrayListIterator_next(array_list_iterator_pt iterator);
+
+UTILS_EXPORT void *arrayListIterator_next(array_list_iterator_pt iterator);
+
 UTILS_EXPORT bool arrayListIterator_hasPrevious(array_list_iterator_pt iterator);
-UTILS_EXPORT void * arrayListIterator_previous(array_list_iterator_pt iterator);
+
+UTILS_EXPORT void *arrayListIterator_previous(array_list_iterator_pt iterator);
+
 UTILS_EXPORT void arrayListIterator_remove(array_list_iterator_pt iterator);
 
+#ifdef __cplusplus
+}
+#endif
 #endif /* ARRAY_LIST_H_ */

--- a/utils/public/include/celix_errno.h
+++ b/utils/public/include/celix_errno.h
@@ -36,6 +36,10 @@
 
 #include "exports.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*!
  * Helper macro which check the current status and executes the provided expression if the
  * status is still CELIX_SUCCESS (0)
@@ -108,5 +112,8 @@ UTILS_EXPORT char *celix_strerror(celix_status_t errorcode, char *buffer, size_t
 /**
  * \}
  */
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* CELIX_ERRNO_H_ */

--- a/utils/public/include/celix_threads.h
+++ b/utils/public/include/celix_threads.h
@@ -32,6 +32,9 @@
 
 #include "celix_errno.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 struct celix_thread {
 	bool threadInitialized;
@@ -44,17 +47,25 @@ typedef pthread_once_t celix_thread_once_t;
 typedef struct celix_thread celix_thread_t;
 typedef pthread_attr_t celix_thread_attr_t;
 
-typedef void *(*celix_thread_start_t)(void*);
+typedef void *(*celix_thread_start_t)(void *);
 
-static const celix_thread_t celix_thread_default = { 0, 0 };
+static const celix_thread_t celix_thread_default = {0, 0};
 
-celix_status_t celixThread_create(celix_thread_t *new_thread, celix_thread_attr_t *attr, celix_thread_start_t func, void *data);
+celix_status_t
+celixThread_create(celix_thread_t *new_thread, celix_thread_attr_t *attr, celix_thread_start_t func, void *data);
+
 void celixThread_exit(void *exitStatus);
+
 celix_status_t celixThread_detach(celix_thread_t thread);
+
 celix_status_t celixThread_join(celix_thread_t thread, void **status);
+
 celix_status_t celixThread_kill(celix_thread_t thread, int sig);
+
 celix_thread_t celixThread_self(void);
+
 int celixThread_equals(celix_thread_t thread1, celix_thread_t thread2);
+
 bool celixThread_initalized(celix_thread_t thread);
 
 
@@ -71,12 +82,17 @@ enum {
 
 
 celix_status_t celixThreadMutex_create(celix_thread_mutex_t *mutex, celix_thread_mutexattr_t *attr);
+
 celix_status_t celixThreadMutex_destroy(celix_thread_mutex_t *mutex);
+
 celix_status_t celixThreadMutex_lock(celix_thread_mutex_t *mutex);
+
 celix_status_t celixThreadMutex_unlock(celix_thread_mutex_t *mutex);
 
 celix_status_t celixThreadMutexAttr_create(celix_thread_mutexattr_t *attr);
+
 celix_status_t celixThreadMutexAttr_destroy(celix_thread_mutexattr_t *attr);
+
 celix_status_t celixThreadMutexAttr_settype(celix_thread_mutexattr_t *attr, int type);
 
 typedef pthread_rwlock_t celix_thread_rwlock_t;
@@ -85,11 +101,15 @@ typedef pthread_rwlockattr_t celix_thread_rwlockattr_t;
 celix_status_t celixThreadRwlock_create(celix_thread_rwlock_t *lock, celix_thread_rwlockattr_t *attr);
 
 celix_status_t celixThreadRwlock_destroy(celix_thread_rwlock_t *lock);
+
 celix_status_t celixThreadRwlock_readLock(celix_thread_rwlock_t *lock);
+
 celix_status_t celixThreadRwlock_writeLock(celix_thread_rwlock_t *lock);
+
 celix_status_t celixThreadRwlock_unlock(celix_thread_rwlock_t *lock);
 
 celix_status_t celixThreadRwlockAttr_create(celix_thread_rwlockattr_t *attr);
+
 celix_status_t celixThreadRwlockAttr_destroy(celix_thread_rwlockattr_t *attr);
 //NOTE: No support yet for setting specific rw lock attributes
 
@@ -98,11 +118,18 @@ typedef pthread_cond_t celix_thread_cond_t;
 typedef pthread_condattr_t celix_thread_condattr_t;
 
 celix_status_t celixThreadCondition_init(celix_thread_cond_t *condition, celix_thread_condattr_t *attr);
+
 celix_status_t celixThreadCondition_destroy(celix_thread_cond_t *condition);
+
 celix_status_t celixThreadCondition_wait(celix_thread_cond_t *cond, celix_thread_mutex_t *mutex);
+
 celix_status_t celixThreadCondition_broadcast(celix_thread_cond_t *cond);
+
 celix_status_t celixThreadCondition_signal(celix_thread_cond_t *cond);
 
 celix_status_t celixThread_once(celix_thread_once_t *once_control, void (*init_routine)(void));
 
+#ifdef __cplusplus
+}
+#endif
 #endif /* CELIX_THREADS_H_ */

--- a/utils/public/include/hash_map.h
+++ b/utils/public/include/hash_map.h
@@ -30,79 +30,129 @@
 #include "celixbool.h"
 #include "exports.h"
 
-typedef struct hashMapEntry * hash_map_entry_pt;
-typedef struct hashMap * hash_map_pt;
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct hashMapEntry *hash_map_entry_pt;
+typedef struct hashMap *hash_map_pt;
 
 struct hashMapIterator {
-    hash_map_pt map;
-    hash_map_entry_pt next;
-    hash_map_entry_pt current;
-    int expectedModCount;
-    int index;
+	hash_map_pt map;
+	hash_map_entry_pt next;
+	hash_map_entry_pt current;
+	int expectedModCount;
+	int index;
 };
 
 typedef struct hashMapIterator hash_map_iterator_t;
-typedef hash_map_iterator_t * hash_map_iterator_pt;
+typedef hash_map_iterator_t *hash_map_iterator_pt;
 
-typedef struct hashMapKeySet * hash_map_key_set_pt;
-typedef struct hashMapValues * hash_map_values_pt;
-typedef struct hashMapEntrySet * hash_map_entry_set_pt;
+typedef struct hashMapKeySet *hash_map_key_set_pt;
+typedef struct hashMapValues *hash_map_values_pt;
+typedef struct hashMapEntrySet *hash_map_entry_set_pt;
 
-UTILS_EXPORT hash_map_pt hashMap_create(unsigned int (*keyHash)(const void*), unsigned int (*valueHash)(const void*),
-		int (*keyEquals)(const void*, const void*), int (*valueEquals)(const void*, const void*));
+UTILS_EXPORT hash_map_pt hashMap_create(unsigned int (*keyHash)(const void *), unsigned int (*valueHash)(const void *),
+										int (*keyEquals)(const void *, const void *),
+										int (*valueEquals)(const void *, const void *));
+
 UTILS_EXPORT void hashMap_destroy(hash_map_pt map, bool freeKeys, bool freeValues);
+
 UTILS_EXPORT int hashMap_size(hash_map_pt map);
+
 UTILS_EXPORT bool hashMap_isEmpty(hash_map_pt map);
-UTILS_EXPORT void * hashMap_get(hash_map_pt map, const void* key);
-UTILS_EXPORT bool hashMap_containsKey(hash_map_pt map, const void* key);
-UTILS_EXPORT hash_map_entry_pt hashMap_getEntry(hash_map_pt map, const void* key);
-UTILS_EXPORT void * hashMap_put(hash_map_pt map, void* key, void* value);
-UTILS_EXPORT void * hashMap_remove(hash_map_pt map, const void* key);
+
+UTILS_EXPORT void *hashMap_get(hash_map_pt map, const void *key);
+
+UTILS_EXPORT bool hashMap_containsKey(hash_map_pt map, const void *key);
+
+UTILS_EXPORT hash_map_entry_pt hashMap_getEntry(hash_map_pt map, const void *key);
+
+UTILS_EXPORT void *hashMap_put(hash_map_pt map, void *key, void *value);
+
+UTILS_EXPORT void *hashMap_remove(hash_map_pt map, const void *key);
+
 UTILS_EXPORT void hashMap_clear(hash_map_pt map, bool freeKey, bool freeValue);
-UTILS_EXPORT bool hashMap_containsValue(hash_map_pt map, const void* value);
+
+UTILS_EXPORT bool hashMap_containsValue(hash_map_pt map, const void *value);
 
 UTILS_EXPORT hash_map_iterator_pt hashMapIterator_create(hash_map_pt map);
+
 UTILS_EXPORT void hashMapIterator_destroy(hash_map_iterator_pt iterator);
+
 UTILS_EXPORT hash_map_iterator_pt hashMapIterator_alloc(void);
+
 UTILS_EXPORT void hashMapIterator_dealloc(hash_map_iterator_pt iterator);
+
 UTILS_EXPORT void hashMapIterator_init(hash_map_pt map, hash_map_iterator_pt iterator);
+
 UTILS_EXPORT void hashMapIterator_deinit(hash_map_iterator_pt iterator);
+
 UTILS_EXPORT hash_map_iterator_t hashMapIterator_construct(hash_map_pt map);
 
 
 UTILS_EXPORT bool hashMapIterator_hasNext(hash_map_iterator_pt iterator);
+
 UTILS_EXPORT void hashMapIterator_remove(hash_map_iterator_pt iterator);
-UTILS_EXPORT void * hashMapIterator_nextValue(hash_map_iterator_pt iterator);
-UTILS_EXPORT void * hashMapIterator_nextKey(hash_map_iterator_pt iterator);
+
+UTILS_EXPORT void *hashMapIterator_nextValue(hash_map_iterator_pt iterator);
+
+UTILS_EXPORT void *hashMapIterator_nextKey(hash_map_iterator_pt iterator);
+
 UTILS_EXPORT hash_map_entry_pt hashMapIterator_nextEntry(hash_map_iterator_pt iterator);
 
 UTILS_EXPORT hash_map_key_set_pt hashMapKeySet_create(hash_map_pt map);
+
 UTILS_EXPORT void hashMapKeySet_destroy(hash_map_key_set_pt keySet);
+
 UTILS_EXPORT int hashMapKeySet_size(hash_map_key_set_pt keySet);
-UTILS_EXPORT bool hashMapKeySet_contains(hash_map_key_set_pt keySet, const void* key);
-UTILS_EXPORT bool hashMapKeySet_remove(hash_map_key_set_pt keySet, const void* key);
+
+UTILS_EXPORT bool hashMapKeySet_contains(hash_map_key_set_pt keySet, const void *key);
+
+UTILS_EXPORT bool hashMapKeySet_remove(hash_map_key_set_pt keySet, const void *key);
+
 UTILS_EXPORT void hashMapKeySet_clear(hash_map_key_set_pt keySet);
+
 UTILS_EXPORT bool hashMapKeySet_isEmpty(hash_map_key_set_pt keySet);
 
 UTILS_EXPORT hash_map_values_pt hashMapValues_create(hash_map_pt map);
+
 UTILS_EXPORT void hashMapValues_destroy(hash_map_values_pt values);
+
 UTILS_EXPORT hash_map_iterator_pt hashMapValues_iterator(hash_map_values_pt values);
+
 UTILS_EXPORT int hashMapValues_size(hash_map_values_pt values);
-UTILS_EXPORT bool hashMapValues_contains(hash_map_values_pt values, const void* o);
-UTILS_EXPORT void hashMapValues_toArray(hash_map_values_pt values, void* *array[], unsigned int *size);
-UTILS_EXPORT bool hashMapValues_remove(hash_map_values_pt values, const void* o);
+
+UTILS_EXPORT bool hashMapValues_contains(hash_map_values_pt values, const void *o);
+
+UTILS_EXPORT void hashMapValues_toArray(hash_map_values_pt values, void **array[], unsigned int *size);
+
+UTILS_EXPORT bool hashMapValues_remove(hash_map_values_pt values, const void *o);
+
 UTILS_EXPORT void hashMapValues_clear(hash_map_values_pt values);
+
 UTILS_EXPORT bool hashMapValues_isEmpty(hash_map_values_pt values);
 
 UTILS_EXPORT hash_map_entry_set_pt hashMapEntrySet_create(hash_map_pt map);
+
 UTILS_EXPORT void hashMapEntrySet_destroy(hash_map_entry_set_pt entrySet);
+
 UTILS_EXPORT int hashMapEntrySet_size(hash_map_entry_set_pt entrySet);
+
 UTILS_EXPORT bool hashMapEntrySet_contains(hash_map_entry_set_pt entrySet, hash_map_entry_pt entry);
+
 UTILS_EXPORT bool hashMapEntrySet_remove(hash_map_entry_set_pt entrySet, hash_map_entry_pt entry);
+
 UTILS_EXPORT void hashMapEntrySet_clear(hash_map_entry_set_pt entrySet);
+
 UTILS_EXPORT bool hashMapEntrySet_isEmpty(hash_map_entry_set_pt entrySet);
 
-UTILS_EXPORT void * hashMapEntry_getKey(hash_map_entry_pt entry);
-UTILS_EXPORT void * hashMapEntry_getValue(hash_map_entry_pt entry);
+UTILS_EXPORT void *hashMapEntry_getKey(hash_map_entry_pt entry);
+
+UTILS_EXPORT void *hashMapEntry_getValue(hash_map_entry_pt entry);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* HASH_MAP_H_ */

--- a/utils/public/include/linked_list.h
+++ b/utils/public/include/linked_list.h
@@ -32,32 +32,60 @@
 #include "celix_errno.h"
 #include "exports.h"
 
-typedef struct linked_list_entry * linked_list_entry_pt;
-typedef struct linked_list * linked_list_pt;
+#ifdef __cplusplus
+extern "C" {
+#endif
+typedef struct linked_list_entry *linked_list_entry_pt;
+typedef struct linked_list *linked_list_pt;
 
 UTILS_EXPORT celix_status_t linkedList_create(linked_list_pt *list);
-UTILS_EXPORT celix_status_t linkedList_destroy(linked_list_pt list);
-UTILS_EXPORT celix_status_t linkedList_clone(linked_list_pt list, linked_list_pt *clone);
-UTILS_EXPORT void * linkedList_getFirst(linked_list_pt list);
-UTILS_EXPORT void * linkedList_getLast(linked_list_pt list);
-UTILS_EXPORT void * linkedList_removeFirst(linked_list_pt list);
-UTILS_EXPORT void * linkedList_removeLast(linked_list_pt list);
-UTILS_EXPORT void linkedList_addFirst(linked_list_pt list, void * element);
-UTILS_EXPORT void linkedList_addLast(linked_list_pt list, void * element);
-UTILS_EXPORT bool linkedList_contains(linked_list_pt list, void * element);
-UTILS_EXPORT int linkedList_size(linked_list_pt list);
-UTILS_EXPORT bool linkedList_isEmpty(linked_list_pt list);
-UTILS_EXPORT bool linkedList_addElement(linked_list_pt list, void * element);
-UTILS_EXPORT bool linkedList_removeElement(linked_list_pt list, void * element);
-UTILS_EXPORT void linkedList_clear(linked_list_pt list);
-UTILS_EXPORT void * linkedList_get(linked_list_pt list, int index);
-UTILS_EXPORT void * linkedList_set(linked_list_pt list, int index, void * element);
-UTILS_EXPORT void linkedList_addIndex(linked_list_pt list, int index, void * element);
-UTILS_EXPORT void * linkedList_removeIndex(linked_list_pt list, int index);
-UTILS_EXPORT linked_list_entry_pt linkedList_entry(linked_list_pt list, int index);
-UTILS_EXPORT int linkedList_indexOf(linked_list_pt list, void * element);
-UTILS_EXPORT linked_list_entry_pt linkedList_addBefore(linked_list_pt list, void * element, linked_list_entry_pt entry);
-UTILS_EXPORT void * linkedList_removeEntry(linked_list_pt list, linked_list_entry_pt entry);
 
+UTILS_EXPORT celix_status_t linkedList_destroy(linked_list_pt list);
+
+UTILS_EXPORT celix_status_t linkedList_clone(linked_list_pt list, linked_list_pt *clone);
+
+UTILS_EXPORT void *linkedList_getFirst(linked_list_pt list);
+
+UTILS_EXPORT void *linkedList_getLast(linked_list_pt list);
+
+UTILS_EXPORT void *linkedList_removeFirst(linked_list_pt list);
+
+UTILS_EXPORT void *linkedList_removeLast(linked_list_pt list);
+
+UTILS_EXPORT void linkedList_addFirst(linked_list_pt list, void *element);
+
+UTILS_EXPORT void linkedList_addLast(linked_list_pt list, void *element);
+
+UTILS_EXPORT bool linkedList_contains(linked_list_pt list, void *element);
+
+UTILS_EXPORT int linkedList_size(linked_list_pt list);
+
+UTILS_EXPORT bool linkedList_isEmpty(linked_list_pt list);
+
+UTILS_EXPORT bool linkedList_addElement(linked_list_pt list, void *element);
+
+UTILS_EXPORT bool linkedList_removeElement(linked_list_pt list, void *element);
+
+UTILS_EXPORT void linkedList_clear(linked_list_pt list);
+
+UTILS_EXPORT void *linkedList_get(linked_list_pt list, int index);
+
+UTILS_EXPORT void *linkedList_set(linked_list_pt list, int index, void *element);
+
+UTILS_EXPORT void linkedList_addIndex(linked_list_pt list, int index, void *element);
+
+UTILS_EXPORT void *linkedList_removeIndex(linked_list_pt list, int index);
+
+UTILS_EXPORT linked_list_entry_pt linkedList_entry(linked_list_pt list, int index);
+
+UTILS_EXPORT int linkedList_indexOf(linked_list_pt list, void *element);
+
+UTILS_EXPORT linked_list_entry_pt linkedList_addBefore(linked_list_pt list, void *element, linked_list_entry_pt entry);
+
+UTILS_EXPORT void *linkedList_removeEntry(linked_list_pt list, linked_list_entry_pt entry);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* LINKED_LIST_H_ */

--- a/utils/public/include/linked_list_iterator.h
+++ b/utils/public/include/linked_list_iterator.h
@@ -32,19 +32,35 @@
 #include "linked_list.h"
 #include "exports.h"
 
-typedef struct linkedListIterator * linked_list_iterator_pt;
+#ifdef __cplusplus
+extern "C" {
+#endif
+typedef struct linkedListIterator *linked_list_iterator_pt;
 
 UTILS_EXPORT linked_list_iterator_pt linkedListIterator_create(linked_list_pt list, unsigned int index);
-UTILS_EXPORT void linkedListIterator_destroy(linked_list_iterator_pt iterator);
-UTILS_EXPORT bool linkedListIterator_hasNext(linked_list_iterator_pt iterator);
-UTILS_EXPORT void * linkedListIterator_next(linked_list_iterator_pt iterator);
-UTILS_EXPORT bool linkedListIterator_hasPrevious(linked_list_iterator_pt iterator);
-UTILS_EXPORT void * linkedListIterator_previous(linked_list_iterator_pt iterator);
-UTILS_EXPORT int linkedListIterator_nextIndex(linked_list_iterator_pt iterator);
-UTILS_EXPORT int linkedListIterator_previousIndex(linked_list_iterator_pt iterator);
-UTILS_EXPORT void linkedListIterator_remove(linked_list_iterator_pt iterator);
-UTILS_EXPORT void linkedListIterator_set(linked_list_iterator_pt iterator, void * element);
-UTILS_EXPORT void linkedListIterator_add(linked_list_iterator_pt iterator, void * element);
 
+UTILS_EXPORT void linkedListIterator_destroy(linked_list_iterator_pt iterator);
+
+UTILS_EXPORT bool linkedListIterator_hasNext(linked_list_iterator_pt iterator);
+
+UTILS_EXPORT void *linkedListIterator_next(linked_list_iterator_pt iterator);
+
+UTILS_EXPORT bool linkedListIterator_hasPrevious(linked_list_iterator_pt iterator);
+
+UTILS_EXPORT void *linkedListIterator_previous(linked_list_iterator_pt iterator);
+
+UTILS_EXPORT int linkedListIterator_nextIndex(linked_list_iterator_pt iterator);
+
+UTILS_EXPORT int linkedListIterator_previousIndex(linked_list_iterator_pt iterator);
+
+UTILS_EXPORT void linkedListIterator_remove(linked_list_iterator_pt iterator);
+
+UTILS_EXPORT void linkedListIterator_set(linked_list_iterator_pt iterator, void *element);
+
+UTILS_EXPORT void linkedListIterator_add(linked_list_iterator_pt iterator, void *element);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* LINKED_LIST_ITERATOR_H_ */

--- a/utils/public/include/properties.h
+++ b/utils/public/include/properties.h
@@ -32,23 +32,34 @@
 #include "hash_map.h"
 #include "exports.h"
 #include "celix_errno.h"
-
+#ifdef __cplusplus
+extern "C" {
+#endif
 typedef hash_map_pt properties_pt;
 
 UTILS_EXPORT properties_pt properties_create(void);
-UTILS_EXPORT void properties_destroy(properties_pt properties);
-UTILS_EXPORT properties_pt properties_load(const char* filename);
-UTILS_EXPORT properties_pt properties_loadWithStream(FILE *stream);
-UTILS_EXPORT void properties_store(properties_pt properties, const char* file, const char* header);
 
-UTILS_EXPORT const char* properties_get(properties_pt properties, const char* key);
-UTILS_EXPORT const char* properties_getWithDefault(properties_pt properties, const char* key, const char* defaultValue);
-UTILS_EXPORT void properties_set(properties_pt properties, const char* key, const char* value);
+UTILS_EXPORT void properties_destroy(properties_pt properties);
+
+UTILS_EXPORT properties_pt properties_load(const char *filename);
+
+UTILS_EXPORT properties_pt properties_loadWithStream(FILE *stream);
+
+UTILS_EXPORT void properties_store(properties_pt properties, const char *file, const char *header);
+
+UTILS_EXPORT const char *properties_get(properties_pt properties, const char *key);
+
+UTILS_EXPORT const char *properties_getWithDefault(properties_pt properties, const char *key, const char *defaultValue);
+
+UTILS_EXPORT void properties_set(properties_pt properties, const char *key, const char *value);
 
 UTILS_EXPORT celix_status_t properties_copy(properties_pt properties, properties_pt *copy);
 
 #define PROPERTIES_FOR_EACH(props, key) \
-	for(hash_map_iterator_t iter = hashMapIterator_construct(props); \
-		hashMapIterator_hasNext(&iter), (key) = (const char*)hashMapIterator_nextKey(&iter);) 
+    for(hash_map_iterator_t iter = hashMapIterator_construct(props); \
+        hashMapIterator_hasNext(&iter), (key) = (const char*)hashMapIterator_nextKey(&iter);)
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* PROPERTIES_H_ */

--- a/utils/public/include/thpool.h
+++ b/utils/public/include/thpool.h
@@ -8,13 +8,15 @@
 #define _THPOOL_
 
 
-
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 
 /* =================================== API ======================================= */
 
 
-typedef struct thpool_* threadpool;
+typedef struct thpool_ *threadpool;
 
 
 /**
@@ -64,7 +66,7 @@ threadpool thpool_init(int num_threads);
  * @param  arg_p         pointer to an argument
  * @return nothing
  */
-int thpool_add_work(threadpool, void *(*function_p)(void*), void* arg_p);
+int thpool_add_work(threadpool, void *(*function_p)(void *), void *arg_p);
 
 
 /**
@@ -159,6 +161,8 @@ void thpool_resume(threadpool);
 void thpool_destroy(threadpool);
 
 
-
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/utils/public/include/utils.h
+++ b/utils/public/include/utils.h
@@ -34,16 +34,28 @@
 #include "exports.h"
 #include "celix_threads.h"
 
-UTILS_EXPORT unsigned int utils_stringHash(const void* string);
-UTILS_EXPORT int utils_stringEquals(const void* string, const void* toCompare);
-UTILS_EXPORT char * string_ndup(const char *s, size_t n);
-UTILS_EXPORT char * utils_stringTrim(char * string);
-UTILS_EXPORT bool utils_isStringEmptyOrNull(const char * const str);
+#ifdef __cplusplus
+extern "C" {
+#endif
 
-UTILS_EXPORT int utils_compareServiceIdsAndRanking(unsigned long servId, long servRank, unsigned long otherServId, long otherServRank);
+UTILS_EXPORT unsigned int utils_stringHash(const void *string);
+
+UTILS_EXPORT int utils_stringEquals(const void *string, const void *toCompare);
+
+UTILS_EXPORT char *string_ndup(const char *s, size_t n);
+
+UTILS_EXPORT char *utils_stringTrim(char *string);
+
+UTILS_EXPORT bool utils_isStringEmptyOrNull(const char *const str);
+
+UTILS_EXPORT int
+utils_compareServiceIdsAndRanking(unsigned long servId, long servRank, unsigned long otherServId, long otherServRank);
 
 UTILS_EXPORT celix_status_t thread_equalsSelf(celix_thread_t thread, bool *equals);
 
 UTILS_EXPORT celix_status_t utils_isNumeric(const char *number, bool *ret);
 
+#ifdef __cplusplus
+}
+#endif
 #endif /* UTILS_H_ */

--- a/utils/public/include/version.h
+++ b/utils/public/include/version.h
@@ -29,10 +29,15 @@
 
 #include "celix_errno.h"
 #include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * The definition of the version_pt abstract data type.
  */
-typedef struct version * version_pt;
+typedef struct version *version_pt;
 
 /**
  * Creates a new version_pt using the supplied arguments.
@@ -50,7 +55,7 @@ typedef struct version * version_pt;
  * 		- CELIX_ILLEGAL_ARGUMENT If the numerical components are negative
  * 		  or the qualifier string is invalid.
  */
-celix_status_t version_createVersion(int major, int minor, int micro, char * qualifier, version_pt *version);
+celix_status_t version_createVersion(int major, int minor, int micro, char *qualifier, version_pt *version);
 
 celix_status_t version_destroy(version_pt version);
 
@@ -93,7 +98,7 @@ celix_status_t version_clone(version_pt version, version_pt *clone);
  * 		- CELIX_ILLEGAL_ARGUMENT If the numerical components are negative,
  * 		  	the qualifier string is invalid or <code>versionStr</code> is improperly formatted.
  */
-celix_status_t version_createVersionFromString(const char * versionStr, version_pt *version);
+celix_status_t version_createVersionFromString(const char *versionStr, version_pt *version);
 
 /**
  * The empty version "0.0.0".
@@ -108,8 +113,11 @@ celix_status_t version_createVersionFromString(const char * versionStr, version_
 celix_status_t version_createEmptyVersion(version_pt *version);
 
 celix_status_t version_getMajor(version_pt version, int *major);
+
 celix_status_t version_getMinor(version_pt version, int *minor);
+
 celix_status_t version_getMicro(version_pt version, int *micro);
+
 celix_status_t version_getQualifier(version_pt version, const char **qualifier);
 
 /**
@@ -169,11 +177,10 @@ celix_status_t version_toString(version_pt version, char **string);
  * @return Status code indication failure or success:
  * 		- CELIX_SUCCESS when no errors are encountered.
  */
-celix_status_t version_isCompatible(version_pt user, version_pt provider, bool* isCompatible);
+celix_status_t version_isCompatible(version_pt user, version_pt provider, bool *isCompatible);
 
-
-/**
- * @}
- */
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* VERSION_H_ */

--- a/utils/public/include/version_range.h
+++ b/utils/public/include/version_range.h
@@ -37,10 +37,13 @@
 #include "celix_errno.h"
 #include "version.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 /**
  * Type definition for the version_range_pt abstract data type.
  */
-typedef struct versionRange * version_range_pt;
+typedef struct versionRange *version_range_pt;
 
 /**
  * Creates a new <code>version_range_pt</code>.
@@ -54,7 +57,9 @@ typedef struct versionRange * version_range_pt;
  * 		- CELIX_SUCCESS when no errors are encountered.
  * 		- CELIX_ENOMEM If allocating memory for <code>versionRange</code> failed.
  */
-celix_status_t versionRange_createVersionRange(version_pt low, bool isLowInclusive, version_pt high, bool isHighInclusive, version_range_pt *versionRange);
+celix_status_t
+versionRange_createVersionRange(version_pt low, bool isLowInclusive, version_pt high, bool isHighInclusive,
+                                version_range_pt *versionRange);
 
 /**
  * Creates an infinite version range using ::version_createEmptyVersion for the low version,
@@ -146,10 +151,10 @@ celix_status_t versionRange_getHighVersion(version_range_pt versionRange, versio
  * 		- CELIX_ILLEGAL_ARGUMENT If the numerical components are negative,
  * 		  	the qualifier string is invalid or <code>versionStr</code> is impropertly formatted.
  */
-celix_status_t versionRange_parse(const char* rangeStr, version_range_pt *range);
+celix_status_t versionRange_parse(const char *rangeStr, version_range_pt *range);
 
-/**
- * @}
- */
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* VERSION_RANGE_H_ */


### PR DESCRIPTION
Added the precompiler directive stated below to all public headers.

Developers using celix in an C++ environment don't have to to put these directives around the inclusion of the headers any more if this pull request is merged.

I tested it with some examples.
```

#ifdef __cplusplus
extern "C" {
#endif   
<<original code>>
#ifdef __cplusplus
}
#endif   


```