### PR TITLE
migrated readdir_r (deprecated) to readdir.

### DIFF
--- a/deployment_admin/private/src/deployment_admin.c
+++ b/deployment_admin/private/src/deployment_admin.c
@@ -505,15 +505,15 @@ static celix_status_t deploymentAdmin_deleteTree(char * directory) {
 	    status = CELIX_FILE_IO_EXCEPTION;
 	} else {
 
-		struct dirent dp;
-		struct dirent *result = NULL;
-		int rc = readdir_r(dir, &dp, &result);
-		while (rc == 0 && result != NULL) {
-			if ((strcmp((dp.d_name), ".") != 0) && (strcmp((dp.d_name), "..") != 0)) {
+		struct dirent *dp;
+		errno = 0;
+		dp = readdir(dir);
+		while (dp != NULL) {
+			if ((strcmp((dp->d_name), ".") != 0) && (strcmp((dp->d_name), "..") != 0)) {
 				char subdir[512];
-				snprintf(subdir, sizeof(subdir), "%s/%s", directory, dp.d_name);
+				snprintf(subdir, sizeof(subdir), "%s/%s", directory, dp->d_name);
 
-				if (dp.d_type == DT_DIR) {
+				if (dp->d_type == DT_DIR) {
 					status = deploymentAdmin_deleteTree(subdir);
 				} else {
 					if (remove(subdir) != 0) {
@@ -522,10 +522,11 @@ static celix_status_t deploymentAdmin_deleteTree(char * directory) {
 					}
 				}
 			}
-			rc = readdir_r(dir, &dp, &result);
+			errno = 0;
+			dp = readdir(dir);
 		}
 
-		if (rc != 0) {
+		if (errno != 0) {
 			status = CELIX_FILE_IO_EXCEPTION;
 		}
 

--- a/framework/private/src/bundle_archive.c
+++ b/framework/private/src/bundle_archive.c
@@ -202,23 +202,21 @@ celix_status_t bundleArchive_recreate(const char * archiveRoot, bundle_archive_p
 				long highestId = -1;
 				char *location = NULL;
 
-				struct dirent dent;
-				struct dirent *result = NULL;
+				struct dirent *dent;
 				struct stat st;
-				int rc;
 
-				rc = readdir_r(archive->archiveRootDir, &dent, &result);
-				while (rc == 0 && result != NULL) {
+				dent = readdir(archive->archiveRootDir);
+				while (dent != NULL) {
 					char subdir[512];
-					snprintf(subdir, 512, "%s/%s", archiveRoot, dent.d_name);
+					snprintf(subdir, 512, "%s/%s", archiveRoot, dent->d_name);
 					int rv = stat(subdir, &st);
-					if (rv == 0 && S_ISDIR(st.st_mode) && (strncmp(dent.d_name, "version", 7) == 0)) {
-						sscanf(dent.d_name, "version%*d.%ld", &idx);
+					if (rv == 0 && S_ISDIR(st.st_mode) && (strncmp(dent->d_name, "version", 7) == 0)) {
+						sscanf(dent->d_name, "version%*d.%ld", &idx);
 						if (idx > highestId) {
 							highestId = idx;
 						}
 					}
-					rc = readdir_r(archive->archiveRootDir, &dent, &result);
+					dent = readdir(archive->archiveRootDir);
 				}
 
 				status = CELIX_DO_IF(status, bundleArchive_getRevisionLocation(archive, 0, &location));
@@ -751,15 +749,13 @@ static celix_status_t bundleArchive_deleteTree(bundle_archive_pt archive, const 
 		status = CELIX_FILE_IO_EXCEPTION;
 	} else {
 
-		struct dirent dp;
-		struct dirent *result = NULL;
-		int rc = 0;
+		struct dirent *dp;
 
-		rc = readdir_r(dir, &dp, &result);
-		while (rc == 0 && result != NULL) {
-			if ((strcmp((dp.d_name), ".") != 0) && (strcmp((dp.d_name), "..") != 0)) {
+		dp = readdir(dir);
+		while (dp != NULL) {
+			if ((strcmp((dp->d_name), ".") != 0) && (strcmp((dp->d_name), "..") != 0)) {
 				char subdir[512];
-				snprintf(subdir, 512, "%s/%s", directory, dp.d_name);
+				snprintf(subdir, 512, "%s/%s", directory, dp->d_name);
 
 				struct stat st;
 				if (stat(subdir, &st) == 0) {
@@ -773,7 +769,7 @@ static celix_status_t bundleArchive_deleteTree(bundle_archive_pt archive, const 
 					}
 				}
 			}
-			rc = readdir_r(dir, &dp, &result);
+			dp = readdir(dir);
 		}
 
 		if (closedir(dir) != 0) {


### PR DESCRIPTION
Compilation of celix using gcc 7.1.1 (standard settings) fails due to readdir_r(3) being deprecated (see http://man7.org/linux/man-pages/man3/readdir_r.3.html).
This commit replaces all calls to readdir_r(3) with calls to readdir(3). With these changes, celix compiles just fine and the celix framework runs as expected.

Please note that I have not tested these changes extensively.