### PR TITLE
- Fix TCP example.

### DIFF
--- a/bundles/pubsub/examples/pubsub/publisher/private/include/pubsub_publisher_private.h
+++ b/bundles/pubsub/examples/pubsub/publisher/private/include/pubsub_publisher_private.h
@@ -29,6 +29,7 @@ struct pubsub_sender {
     const char *ident;
     hash_map_pt tid_map; //service -> tid
     long bundleId;
+    bool stop;
 };
 
 typedef struct pubsub_sender * pubsub_sender_pt;

--- a/bundles/pubsub/pubsub_admin_tcp/src/pubsub_tcp_handler.c
+++ b/bundles/pubsub/pubsub_admin_tcp/src/pubsub_tcp_handler.c
@@ -72,11 +72,13 @@ struct pubsub_tcpHandler {
   int fd;
   char *url;
   pubsub_tcpHandler_connectMessage_callback_t connectMessageCallback;
-  pubsub_tcpHandler_disconnectMessage_callback_t disconnectMessageCallback;
-  void* connectPayload;
+  pubsub_tcpHandler_connectMessage_callback_t disconnectMessageCallback;
+  void *connectPayload;
   pubsub_tcpHandler_processMessage_callback_t processMessageCallback;
   void *processMessagePayload;
   log_helper_t *logHelper;
+  unsigned int default_bufferSize;
+  unsigned int default_buffer;
 };
 
 typedef struct pubsub_tcpBufferPartList {
@@ -94,25 +96,29 @@ typedef struct psa_tcp_connection_entry {
 } psa_tcp_connection_entry_t;
 
 static inline int pubsub_tcpHandler_setInAddr(pubsub_tcpHandler_pt handle, const char *hostname, int port, struct sockaddr_in *inp);
+static inline int pubsub_tcpHandler_closeConnectionEntry(pubsub_tcpHandler_pt handle, psa_tcp_connection_entry_t *entry, bool lock);
+static inline int pubsub_tcpHandler_closeConnection(pubsub_tcpHandler_pt handle, int fd);
 
 
 //
 // Create a handle
 //
 pubsub_tcpHandler_pt pubsub_tcpHandler_create(log_helper_t *logHelper) {
-  pubsub_tcpHandler_pt handle = calloc(sizeof(*handle), 1);
-  if (handle != NULL) {
-    handle->fd = -1;
-    handle->efd = epoll_create1(0);
-    handle->bufferIdx = 0;
-    handle->url_map = hashMap_create(utils_stringHash, NULL, utils_stringEquals, NULL);
-    handle->fd_map = hashMap_create(NULL, NULL, NULL, NULL);
-    handle->timeout = 500;
-    handle->logHelper = logHelper;
-    celixThreadRwlock_create(&handle->dbLock, 0);
-    signal(SIGPIPE, SIG_IGN);
-  }
-  return handle;
+    pubsub_tcpHandler_pt handle = calloc(sizeof(*handle), 1);
+    if (handle != NULL) {
+        handle->fd = -1;
+        handle->efd = epoll_create1(0);
+        handle->bufferIdx = 0;
+        handle->url_map = hashMap_create(utils_stringHash, NULL, utils_stringEquals, NULL);
+        handle->fd_map = hashMap_create(NULL, NULL, NULL, NULL);
+        handle->timeout = 500;
+        handle->logHelper = logHelper;
+        handle->default_bufferSize =sizeof(handle->default_buffer);
+        handle->default_buffer = 0;
+        celixThreadRwlock_create(&handle->dbLock, 0);
+        //signal(SIGPIPE, SIG_IGN);
+    }
+    return handle;
 }
 
 
@@ -120,402 +126,423 @@ pubsub_tcpHandler_pt pubsub_tcpHandler_create(log_helper_t *logHelper) {
 // Destroys the handle
 //
 void pubsub_tcpHandler_destroy(pubsub_tcpHandler_pt handle) {
-  printf("### Destroying BufferHAndler TCP\n");
-  if (handle != NULL) {
-    pubsub_tcpHandler_close(handle);
-    celixThreadRwlock_writeLock(&handle->dbLock);
-    hash_map_iterator_t iter = hashMapIterator_construct(handle->url_map);
-    while (hashMapIterator_hasNext(&iter)) {
-      psa_tcp_connection_entry_t *entry = hashMapIterator_nextValue(&iter);
-      if (entry != NULL) {
-        pubsub_tcpHandler_closeConnection(handle, entry->url);
-      }
-    }
-    if (handle->efd >= 0) close(handle->efd);
-    if (handle->url) free(handle->url);
-    hashMap_destroy(handle->url_map, false, false);
-    hashMap_destroy(handle->fd_map, false, false);
-
-    if (handle->bufferLists != NULL) {
-      int listSize = arrayList_size(handle->bufferLists);
-      int i;
-      for (i = 0; i < listSize; i++) {
-        pubsub_tcpBufferPartList_pt item = arrayList_get(handle->bufferLists, i);
-        if (item) {
-          if (item->buffer) {
-            free(item->buffer);
-            item->buffer = NULL;
-          }
-          free(item);
+    printf("### Destroying BufferHandler TCP\n");
+    if (handle != NULL) {
+        celixThreadRwlock_writeLock(&handle->dbLock);
+        pubsub_tcpHandler_close(handle);
+        hash_map_iterator_t iter = hashMapIterator_construct(handle->url_map);
+        while (hashMapIterator_hasNext(&iter)) {
+            psa_tcp_connection_entry_t *entry = hashMapIterator_nextValue(&iter);
+            if (entry != NULL) {
+                pubsub_tcpHandler_closeConnectionEntry(handle, entry, true);
+            }
         }
-      }
-      arrayList_destroy(handle->bufferLists);
+
+        if (handle->efd >= 0) close(handle->efd);
+        if (handle->url) free(handle->url);
+        hashMap_destroy(handle->url_map, false, false);
+        hashMap_destroy(handle->fd_map, false, false);
+
+        if (handle->bufferLists != NULL) {
+            int listSize = arrayList_size(handle->bufferLists);
+            int i;
+            for (i = 0; i < listSize; i++) {
+                pubsub_tcpBufferPartList_pt item = arrayList_get(handle->bufferLists, i);
+                if (item) {
+                    if (item->buffer) {
+                        free(item->buffer);
+                        item->buffer = NULL;
+                    }
+                    free(item);
+                }
+            }
+            arrayList_destroy(handle->bufferLists);
+        }
+        handle->bufferLists = NULL;
+        celixThreadRwlock_unlock(&handle->dbLock);
+        celixThreadRwlock_destroy(&handle->dbLock);
+        free(handle);
     }
-    handle->bufferLists = NULL;
-    celixThreadRwlock_unlock(&handle->dbLock);
-    celixThreadRwlock_destroy(&handle->dbLock);
-    free(handle);
-  }
 }
 
 // Destroys the handle
 //
 int pubsub_tcpHandler_open(pubsub_tcpHandler_pt handle, char *url) {
-  int rc = 0;
-  celixThreadRwlock_readLock(&handle->dbLock);
-  int fd = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
-  if (rc >= 0) {
-    int setting = 1;
-    if (rc == 0) {
-      rc = setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &setting, sizeof(setting));
-      if (rc != 0) {
-        close(fd);
-        L_ERROR("[TCP Socket] Error setsockopt(SO_REUSEADDR): %s\n", strerror(errno));
-      }
+    int rc = 0;
+    celixThreadRwlock_readLock(&handle->dbLock);
+    int fd = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+    if (rc >= 0) {
+        int setting = 1;
+        if (rc == 0) {
+            rc = setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &setting, sizeof(setting));
+            if (rc != 0) {
+                close(fd);
+                L_ERROR("[TCP Socket] Error setsockopt(SO_REUSEADDR): %s\n", strerror(errno));
+            }
+        }
+        if (rc == 0) {
+            rc = setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &setting, sizeof(setting));
+            if (rc != 0) {
+                close(fd);
+                L_ERROR("[TCP Socket] Error setsockopt(TCP_NODELAY): %s\n", strerror(errno));
+            }
+        } else {
+            L_ERROR("[TCP Socket] Error creating socket: %s\n", strerror(errno));
+        }
+        struct sockaddr_in addr; // connector's address information
+        pubsub_tcpHandler_url_t url_info;
+        pubsub_tcpHandler_setUrlInfo(url, &url_info);
+        rc = pubsub_tcpHandler_setInAddr(handle, url_info.hostname, url_info.portnr, &addr);
+        if (rc == 0) {
+            rc = bind(fd, (struct sockaddr *) &addr, sizeof(struct sockaddr));
+            if (rc != 0) {
+                close(fd);
+                L_ERROR("[TCP Socket] Error bind: %s\n", strerror(errno));
+            }
+        }
+        pubsub_tcpHandler_free_setUrlInfo(&url_info);
     }
-    if (rc == 0) {
-      rc = setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &setting, sizeof(setting));
-      if (rc != 0) {
-        close(fd);
-        L_ERROR("[TCP Socket] Error setsockopt(TCP_NODELAY): %s\n", strerror(errno));
-      }
-    } else {
-      L_ERROR("[TCP Socket] Error creating socket: %s\n", strerror(errno));
-    }
-    struct sockaddr_in addr; // connector's address information
-    pubsub_tcpHandler_url_t url_info;
-    pubsub_tcpHandler_setUrlInfo(url, &url_info);
-    rc = pubsub_tcpHandler_setInAddr(handle, url_info.hostname, url_info.portnr, &addr);
-    if (rc == 0) {
-      rc = bind(fd, (struct sockaddr *) &addr, sizeof(struct sockaddr));
-      if (rc != 0) {
-        close(fd);
-        L_ERROR("[TCP Socket] Error bind: %s\n", strerror(errno));
-      }
-    }
-    pubsub_tcpHandler_free_setUrlInfo(&url_info);
-  }
-  celixThreadRwlock_unlock(&handle->dbLock);
-  return (!rc) ? fd : rc;
+    celixThreadRwlock_unlock(&handle->dbLock);
+    return (!rc) ? fd : rc;
 }
 
 
 // Destroys the handle
 //
 int pubsub_tcpHandler_close(pubsub_tcpHandler_pt handle) {
-  int rc = 0;
-  if (handle != NULL) {
-    celixThreadRwlock_writeLock(&handle->dbLock);
-    if ((handle->efd >= 0)&&(handle->fd >=0)) {
-      struct epoll_event event;
-      bzero(&event, sizeof(struct epoll_event)); // zero the struct
-      rc = epoll_ctl(handle->efd, EPOLL_CTL_DEL, handle->fd, &event);
-      if (rc < 0) {
-        L_ERROR("[PSA TCP] Error disconnecting %s\n", strerror(errno));
-      }
+    int rc = 0;
+    if (handle != NULL) {
+        celixThreadRwlock_writeLock(&handle->dbLock);
+        if ((handle->efd >= 0) && (handle->fd >= 0)) {
+            struct epoll_event event;
+            bzero(&event, sizeof(struct epoll_event)); // zero the struct
+            rc = epoll_ctl(handle->efd, EPOLL_CTL_DEL, handle->fd, &event);
+            if (rc < 0) {
+                L_ERROR("[PSA TCP] Error disconnecting %s\n", strerror(errno));
+            }
+        }
+        if (handle->url) {
+            free(handle->url);
+            handle->url = NULL;
+        }
+        if (handle->fd >= 0) {
+            close(handle->fd);
+            handle->fd = -1;
+        }
+        celixThreadRwlock_unlock(&handle->dbLock);
     }
-    if (handle->url) {
-      free(handle->url);
-      handle->url = NULL;
-    }
-    if (handle->fd >= 0) {
-      close(handle->fd);
-      handle->fd = -1;
-    }
-    celixThreadRwlock_unlock(&handle->dbLock);
-  }
-  return rc;
+    return rc;
 }
 
 int pubsub_tcpHandler_connect(pubsub_tcpHandler_pt handle, char *url) {
-  pubsub_tcpHandler_url_t url_info;
-  pubsub_tcpHandler_setUrlInfo(url, &url_info);
-  psa_tcp_connection_entry_t *entry = NULL;
-  int fd = pubsub_tcpHandler_open(handle, NULL);
-  celixThreadRwlock_writeLock(&handle->dbLock);
-  int rc = fd;
-  struct sockaddr_in addr; // connector's address information
-  if (rc >= 0) {
-    rc = pubsub_tcpHandler_setInAddr(handle, url_info.hostname, url_info.portnr, &addr);
-    if (rc < 0) {
-      L_ERROR("[TCP Socket] Cannot create url\n");
-      close(fd);
-    }
-  }
-  if (rc >= 0) {
-    rc = connect(fd, (struct sockaddr *) &addr, sizeof(struct sockaddr));
-    if (rc < 0) {
-      L_ERROR("[TCP Socket] Cannot connect to %s:%d\n", url_info.hostname, url_info.portnr);
-      close(fd);
-      fd = -1;
-    } else {
-      struct sockaddr_in sin;
-      socklen_t  len = sizeof(sin);
-      entry = calloc(1, sizeof(*entry));
-      entry->url = strndup(url, 1024 * 1024);
-      entry->fd = fd;
-      if (getsockname(fd,(struct sockaddr *) &sin, &len) < 0) {
-        L_ERROR("[TCP Socket] getsockname %s\n",strerror(errno));
-      } else if (handle->url == NULL){
-        char* address = inet_ntoa(sin.sin_addr);
-        unsigned int port = ntohs(sin.sin_port);
-        asprintf(&handle->url, "tcp://%s:%u", address, port);
-      }
-    }
-  }
-  if (rc >= 0) {
-    struct epoll_event event;
-    bzero(&event, sizeof(struct epoll_event)); // zero the struct
-    event.events = EPOLLIN | EPOLLRDHUP | EPOLLERR | EPOLLET | EPOLLOUT;
-    event.data.fd = entry->fd;
-    rc = epoll_ctl(handle->efd, EPOLL_CTL_ADD, entry->fd, &event);
-    if (rc < 0) {
-      close(entry->fd);
-      free(entry->url);
-      free(entry);
-      L_ERROR("[TCP Socket] Cannot create epoll\n");
-    }
-  }
-  if ((rc >= 0) && (entry)) {
-    if (handle->connectMessageCallback) handle->connectMessageCallback(handle->connectPayload, entry->url, false);
-    hashMap_put(handle->url_map, entry->url, entry);
-    hashMap_put(handle->fd_map, (void *) (intptr_t) entry->fd, entry);
-  }
-  pubsub_tcpHandler_free_setUrlInfo(&url_info);
-  celixThreadRwlock_unlock(&handle->dbLock);
-  return rc;
-}
-
-// Destroys the handle
-//
-int pubsub_tcpHandler_closeConnection(pubsub_tcpHandler_pt handle, char *url) {
-  int rc = 0;
-  if (handle != NULL) {
-    celixThreadRwlock_writeLock(&handle->dbLock);
-    psa_tcp_connection_entry_t *entry = hashMap_remove(handle->url_map, url);
-    hashMap_remove(handle->fd_map, (void *) (intptr_t) entry->fd);
-    if ((handle->efd >= 0)) {
-      struct epoll_event event;
-      bzero(&event, sizeof(struct epoll_event)); // zero the struct
-      rc = epoll_ctl(handle->efd, EPOLL_CTL_DEL, entry->fd, &event);
-      if (rc < 0) {
-        L_ERROR("[PSA TCP] Error disconnecting %s\n", strerror(errno));
-      }
-    }
-    if (entry->fd >= 0) {
-      if (handle->disconnectMessageCallback) handle->disconnectMessageCallback(handle->connectPayload, entry->url);
-      close(entry->fd);
-      free(entry->url);
-      entry->url = NULL;
-      free(entry);
-    }
-    celixThreadRwlock_unlock(&handle->dbLock);
-  }
-  return rc;
-}
-
-// Destroys the handle
-//
-int pubsub_tcpHandler_closeConnectionFd(pubsub_tcpHandler_pt handle, int fd) {
-  int rc = 0;
-  if (handle != NULL) {
-    bool use_handle_fd = false;
+    pubsub_tcpHandler_url_t url_info;
+    pubsub_tcpHandler_setUrlInfo(url, &url_info);
     psa_tcp_connection_entry_t *entry = NULL;
-    celixThreadRwlock_readLock(&handle->dbLock);
-    if (fd != handle->fd) {
-      entry = hashMap_get(handle->fd_map, (void *) (intptr_t) fd);
-    } else {
-      use_handle_fd = true;
+    int fd = pubsub_tcpHandler_open(handle, NULL);
+    celixThreadRwlock_writeLock(&handle->dbLock);
+    int rc = fd;
+    struct sockaddr_in addr; // connector's address information
+    if (rc >= 0) {
+        rc = pubsub_tcpHandler_setInAddr(handle, url_info.hostname, url_info.portnr, &addr);
+        if (rc < 0) {
+            L_ERROR("[TCP Socket] Cannot create url\n");
+            close(fd);
+        }
     }
+    if (rc >= 0) {
+        rc = connect(fd, (struct sockaddr *) &addr, sizeof(struct sockaddr));
+        if (rc < 0) {
+            //L_ERROR("[TCP Socket] Cannot connect to %s:%d\n", url_info.hostname, url_info.portnr);
+            close(fd);
+            fd = -1;
+        } else {
+            struct sockaddr_in sin;
+            socklen_t len = sizeof(sin);
+            entry = calloc(1, sizeof(*entry));
+            entry->url = strndup(url, 1024 * 1024);
+            entry->fd = fd;
+            if (getsockname(fd, (struct sockaddr *) &sin, &len) < 0) {
+                L_ERROR("[TCP Socket] getsockname %s\n", strerror(errno));
+            } else if (handle->url == NULL) {
+                char *address = inet_ntoa(sin.sin_addr);
+                unsigned int port = ntohs(sin.sin_port);
+                asprintf(&handle->url, "tcp://%s:%u", address, port);
+            }
+        }
+    }
+    if (rc >= 0) {
+        struct epoll_event event;
+        bzero(&event, sizeof(struct epoll_event)); // zero the struct
+        event.events = EPOLLIN | EPOLLRDHUP | EPOLLERR | EPOLLET | EPOLLOUT;
+        event.data.fd = entry->fd;
+        rc = epoll_ctl(handle->efd, EPOLL_CTL_ADD, entry->fd, &event);
+        if (rc < 0) {
+            close(entry->fd);
+            free(entry->url);
+            free(entry);
+            L_ERROR("[TCP Socket] Cannot create epoll\n");
+        }
+    }
+    if ((rc >= 0) && (entry)) {
+        if (handle->connectMessageCallback) handle->connectMessageCallback(handle->connectPayload, entry->url, false);
+        hashMap_put(handle->url_map, entry->url, entry);
+        hashMap_put(handle->fd_map, (void *) (intptr_t) entry->fd, entry);
+    }
+    pubsub_tcpHandler_free_setUrlInfo(&url_info);
     celixThreadRwlock_unlock(&handle->dbLock);
-    if (use_handle_fd) {
-      rc = pubsub_tcpHandler_close(handle);
-    } else {
-      rc = pubsub_tcpHandler_closeConnection(handle, entry->url);
+    return rc;
+}
+
+// Destroys the handle
+//
+int pubsub_tcpHandler_disconnect(pubsub_tcpHandler_pt handle, char *url) {
+    int rc = 0;
+    if (handle != NULL) {
+        celixThreadRwlock_writeLock(&handle->dbLock);
+        psa_tcp_connection_entry_t *entry = hashMap_remove(handle->url_map, url);
+        pubsub_tcpHandler_closeConnectionEntry(handle, entry, false);
+        celixThreadRwlock_unlock(&handle->dbLock);
     }
-  }
-  return rc;
+    return rc;
+}
+
+
+// Destroys the handle
+//
+static inline
+int pubsub_tcpHandler_closeConnectionEntry(pubsub_tcpHandler_pt handle, psa_tcp_connection_entry_t *entry, bool lock) {
+    int rc = 0;
+    if (handle != NULL && entry != NULL) {
+        fprintf(stdout, "[TCP Socket] Close connection to url: %s: \n", entry->url);
+        hashMap_remove(handle->fd_map, (void *) (intptr_t) entry->fd);
+        if ((handle->efd >= 0)) {
+            struct epoll_event event;
+            bzero(&event, sizeof(struct epoll_event)); // zero the struct
+            rc = epoll_ctl(handle->efd, EPOLL_CTL_DEL, entry->fd, &event);
+            if (rc < 0) {
+                L_ERROR("[PSA TCP] Error disconnecting %s\n", strerror(errno));
+            }
+        }
+        if (entry->fd >= 0) {
+            if (handle->disconnectMessageCallback)
+                handle->disconnectMessageCallback(handle->connectPayload, entry->url, lock);
+            close(entry->fd);
+            free(entry->url);
+            entry->url = NULL;
+            free(entry);
+        }
+    }
+    return rc;
+}
+
+
+// Destroys the handle
+//
+static inline
+int pubsub_tcpHandler_closeConnection(pubsub_tcpHandler_pt handle, int fd) {
+    int rc = 0;
+    if (handle != NULL) {
+        bool use_handle_fd = false;
+        psa_tcp_connection_entry_t *entry = NULL;
+        celixThreadRwlock_readLock(&handle->dbLock);
+        if (fd != handle->fd) {
+            entry = hashMap_get(handle->fd_map, (void *) (intptr_t) fd);
+        } else {
+            use_handle_fd = true;
+        }
+        celixThreadRwlock_unlock(&handle->dbLock);
+        if (use_handle_fd) {
+            rc = pubsub_tcpHandler_close(handle);
+        } else if (entry){
+            celixThreadRwlock_writeLock(&handle->dbLock);
+            entry = hashMap_remove(handle->url_map, (void *) (intptr_t) entry->url);
+            rc = pubsub_tcpHandler_closeConnectionEntry(handle, entry, true);
+            celixThreadRwlock_unlock(&handle->dbLock);
+        }
+    }
+    return rc;
 }
 
 int pubsub_tcpHandler_listen(pubsub_tcpHandler_pt handle, char *url) {
-  handle->fd = pubsub_tcpHandler_open(handle, url);
-  handle->url = strndup(url, 1024*1024);
-  int rc = handle->fd;
-  celixThreadRwlock_writeLock(&handle->dbLock);
-  if (rc >= 0) {
-    rc = listen(handle->fd, SOMAXCONN);
-    if (rc != 0) {
-      L_ERROR("[TCP Socket] Error listen: %s\n", strerror(errno));
-      close(handle->fd);
-      handle->fd = -1;
-      free(handle->url);
-      handle->url = NULL;
+    handle->fd = pubsub_tcpHandler_open(handle, url);
+    handle->url = strndup(url, 1024 * 1024);
+    int rc = handle->fd;
+    celixThreadRwlock_writeLock(&handle->dbLock);
+    if (rc >= 0) {
+        rc = listen(handle->fd, SOMAXCONN);
+        if (rc != 0) {
+            L_ERROR("[TCP Socket] Error listen: %s\n", strerror(errno));
+            close(handle->fd);
+            handle->fd = -1;
+            free(handle->url);
+            handle->url = NULL;
+        }
     }
-  }
-  if (rc >=0) {
-    int flags = fcntl(handle->fd, F_GETFL, 0);
-    if (flags == -1) {
-      rc = flags;
-    } else {
-      rc = fcntl(handle->fd, F_SETFL, flags | O_NONBLOCK);
-      if (rc < 0) {
-        L_ERROR("[TCP Socket] Cannot set to NON_BLOCKING epoll\n");
-        close(handle->fd);
-        handle->fd = -1;
-        free(handle->url);
-        handle->url = NULL;
-      }
+    if (rc >= 0) {
+        int flags = fcntl(handle->fd, F_GETFL, 0);
+        if (flags == -1) {
+            rc = flags;
+        } else {
+            rc = fcntl(handle->fd, F_SETFL, flags | O_NONBLOCK);
+            if (rc < 0) {
+                L_ERROR("[TCP Socket] Cannot set to NON_BLOCKING epoll\n");
+                close(handle->fd);
+                handle->fd = -1;
+                free(handle->url);
+                handle->url = NULL;
+            }
+        }
     }
-  }
 
-  if ((rc >= 0) && (handle->efd >= 0)) {
-    struct epoll_event event;
-    bzero(&event, sizeof(event)); // zero the struct
-    event.events = EPOLLIN | EPOLLRDHUP | EPOLLERR | EPOLLET | EPOLLOUT;
-    event.data.fd = handle->fd;
-    rc = epoll_ctl(handle->efd, EPOLL_CTL_ADD, handle->fd, &event);
-    if (rc < 0) {
-      L_ERROR("[TCP Socket] Cannot create epoll\n");
+    if ((rc >= 0) && (handle->efd >= 0)) {
+        struct epoll_event event;
+        bzero(&event, sizeof(event)); // zero the struct
+        event.events = EPOLLIN | EPOLLRDHUP | EPOLLERR | EPOLLET | EPOLLOUT;
+        event.data.fd = handle->fd;
+        rc = epoll_ctl(handle->efd, EPOLL_CTL_ADD, handle->fd, &event);
+        if (rc < 0) {
+            L_ERROR("[TCP Socket] Cannot create epoll\n");
+        }
     }
-  }
-  celixThreadRwlock_unlock(&handle->dbLock);
-  return  rc;
+    celixThreadRwlock_unlock(&handle->dbLock);
+    return rc;
 }
 
 
 int pubsub_tcpHandler_setInAddr(pubsub_tcpHandler_pt handle, const char *hostname, int port, struct sockaddr_in *inp) {
-  struct hostent *hp;
-  bzero(inp, sizeof(struct sockaddr_in)); // zero the struct
-  if (hostname == 0 || hostname[0] == 0) {
-    inp->sin_addr.s_addr = INADDR_ANY;
-  } else {
-    if (!inet_aton(hostname, &inp->sin_addr)) {
-      hp = gethostbyname(hostname);
-      if (hp == NULL) {
-        L_ERROR("[TCP Socket] set_in_addr: Unknown host name %s\n", hostname);
-        return -1;
-      }
-      inp->sin_addr = *(struct in_addr *) hp->h_addr;
+    struct hostent *hp;
+    bzero(inp, sizeof(struct sockaddr_in)); // zero the struct
+    if (hostname == 0 || hostname[0] == 0) {
+        inp->sin_addr.s_addr = INADDR_ANY;
+    } else {
+        if (!inet_aton(hostname, &inp->sin_addr)) {
+            hp = gethostbyname(hostname);
+            if (hp == NULL) {
+                L_ERROR("[TCP Socket] set_in_addr: Unknown host name %s\n", hostname);
+                return -1;
+            }
+            inp->sin_addr = *(struct in_addr *) hp->h_addr;
+        }
     }
-  }
-  inp->sin_family = AF_INET;
-  inp->sin_port = htons(port);
-  return 0;
+    inp->sin_family = AF_INET;
+    inp->sin_port = htons(port);
+    return 0;
 }
 
 
 void pubsub_tcpHandler_setUrlInfo(char *url, pubsub_tcpHandler_url_t *url_info) {
-  if (url_info) {
-    url_info->url = NULL;
-    url_info->protocol = NULL;
-    url_info->hostname = NULL;
-    url_info->portnr = 0;
-  }
+    if (url_info) {
+        url_info->url = NULL;
+        url_info->protocol = NULL;
+        url_info->hostname = NULL;
+        url_info->portnr = 0;
+    }
 
-  if (url && url_info) {
-    url_info->url = strdup(url);
-    url_info->protocol = strtok(strdup(url_info->url) , "://");
-    if (url_info->protocol) {
-      url = strstr(url, "://");
-      if (url) {
-        url += 3;
-      }
+    if (url && url_info) {
+        url_info->url = strdup(url);
+        url_info->protocol = strtok(strdup(url_info->url), "://");
+        if (url_info->protocol) {
+            url = strstr(url, "://");
+            if (url) {
+                url += 3;
+            }
+        }
+        char *hostname = strdup(url);
+        if (hostname) {
+            char *port = strstr(hostname, ":");
+            url_info->hostname = strtok(strdup(hostname), ":");
+            if (port) {
+                port += 1;
+                if (isdigit(atoi(port)) == 0) url_info->portnr = atoi(port);
+            }
+            free(hostname);
+        }
     }
-    char* hostname  = strdup(url);
-    if (hostname) {
-      char* port = strstr(hostname, ":");
-      url_info->hostname = strtok(strdup(hostname),":");
-      if (port) {
-        port += 1;
-        if (isdigit(atoi(port)) == 0) url_info->portnr = atoi(port);
-      }
-      free(hostname);
-    }
-  }
 }
 
 void pubsub_tcpHandler_free_setUrlInfo(pubsub_tcpHandler_url_t *url_info) {
-  if (url_info->hostname) free(url_info->hostname);
-  if (url_info->protocol) free(url_info->protocol);
-  if (url_info->url) free(url_info->url);
-  url_info->hostname = NULL;
-  url_info->protocol = NULL;
-  url_info->portnr = 0;
+    if (url_info->hostname) free(url_info->hostname);
+    if (url_info->protocol) free(url_info->protocol);
+    if (url_info->url) free(url_info->url);
+    url_info->hostname = NULL;
+    url_info->protocol = NULL;
+    url_info->portnr = 0;
 }
 
 
 int pubsub_tcpHandler_createReceiveBufferStore(pubsub_tcpHandler_pt handle, unsigned int maxNofBuffers,
-                                                  unsigned int bufferSize) {
-  if (handle != NULL) {
-    int i = 0;
-    celixThreadRwlock_writeLock(&handle->dbLock);
-    if (arrayList_create(&handle->bufferLists) != CELIX_SUCCESS) {
-      return -1;
+                                               unsigned int bufferSize) {
+    if (handle != NULL) {
+        int i = 0;
+        celixThreadRwlock_writeLock(&handle->dbLock);
+        if (arrayList_create(&handle->bufferLists) != CELIX_SUCCESS) {
+            return -1;
+        }
+        for (i = 0; i < maxNofBuffers; i++) {
+            pubsub_tcpBufferPartList_pt item = calloc(1, sizeof(struct pubsub_tcpBufferPartList));
+            item->buffer = calloc(sizeof(char), bufferSize);
+            item->bufferSize = bufferSize;
+            arrayList_add(handle->bufferLists, item);
+        }
+        celixThreadRwlock_unlock(&handle->dbLock);
     }
-    for (i = 0; i < maxNofBuffers; i++) {
-      pubsub_tcpBufferPartList_pt item = calloc(1, sizeof(struct pubsub_tcpBufferPartList));
-      item->buffer = calloc(sizeof(char), bufferSize);
-      item->bufferSize = bufferSize;
-      arrayList_add(handle->bufferLists, item);
-    }
-    celixThreadRwlock_unlock(&handle->dbLock);
-  }
-  return 0;
+    return 0;
 }
 
 void pubsub_tcpHandler_setTimeout(pubsub_tcpHandler_pt handle, unsigned int timeout) {
-  if (handle != NULL) {
-    celixThreadRwlock_writeLock(&handle->dbLock);
-    handle->timeout = timeout;
-    celixThreadRwlock_unlock(&handle->dbLock);
-  }
+    if (handle != NULL) {
+        celixThreadRwlock_writeLock(&handle->dbLock);
+        handle->timeout = timeout;
+        celixThreadRwlock_unlock(&handle->dbLock);
+    }
 }
-
 
 
 //
 // Reads data from the filedescriptor which has date (determined by epoll()) and stores it in the internal structure
 // If the message is completely reassembled true is returned and the index and size have valid values
 //
-int  pubsub_tcpHandler_dataAvailable(pubsub_tcpHandler_pt handle, int fd, unsigned int *index, unsigned int *size) {
-  celixThreadRwlock_writeLock(&handle->dbLock);
-  if (handle->bufferLists == NULL) {
-    return -1;
-  }
-  int listSize = arrayList_size(handle->bufferLists);
-  pubsub_tcpBufferPartList_pt item = arrayList_get(handle->bufferLists, handle->bufferIdx);
-  if (!handle->bypassHeader) {
-    // Only read the header, we don't know yet where to store the payload
-    int nbytes = recv(fd, item->buffer, sizeof(pubsub_tcp_msg_header_t) + sizeof(unsigned int), MSG_PEEK);
+int pubsub_tcpHandler_dataAvailable(pubsub_tcpHandler_pt handle, int fd, unsigned int *index, unsigned int *size) {
+    celixThreadRwlock_writeLock(&handle->dbLock);
+    if (handle->bufferLists == NULL) {
+        int nbytes = recv(fd, &handle->default_buffer, handle->default_bufferSize, MSG_PEEK);
+        celixThreadRwlock_unlock(&handle->dbLock);
+        return nbytes;
+    }
+    int listSize = arrayList_size(handle->bufferLists);
+    pubsub_tcpBufferPartList_pt item = arrayList_get(handle->bufferLists, handle->bufferIdx);
+    if (!handle->bypassHeader) {
+        // Only read the header, we don't know yet where to store the payload
+        int nbytes = recv(fd, item->buffer, sizeof(pubsub_tcp_msg_header_t) + sizeof(unsigned int), MSG_PEEK);
+        if (nbytes < 0) {
+            L_ERROR("[TCP Socket] read error \n");
+            celixThreadRwlock_unlock(&handle->dbLock);
+            return nbytes;
+        }
+        unsigned int *pBuffer_size = ((unsigned int *) &item->buffer[sizeof(pubsub_tcp_msg_header_t)]);
+        unsigned int buffer_size = *pBuffer_size + sizeof(pubsub_tcp_msg_header_t) + sizeof(unsigned int);
+        if (buffer_size > item->bufferSize) {
+            free(item->buffer);
+            item->buffer = calloc(buffer_size, sizeof(char));
+            item->bufferSize = buffer_size;
+        }
+    }
+    int nbytes = recv(fd, item->buffer, item->bufferSize, 0);
     if (nbytes < 0) {
-      L_ERROR("[TCP Socket] read error \n");
-      celixThreadRwlock_unlock(&handle->dbLock);
-      return nbytes;
+        L_ERROR("[TCP Socket] read error \n");
+        celixThreadRwlock_unlock(&handle->dbLock);
+        return nbytes;
     }
-    unsigned int *pBuffer_size = ((unsigned int *) &item->buffer[sizeof(pubsub_tcp_msg_header_t)]);
-    unsigned int buffer_size = *pBuffer_size + sizeof(pubsub_tcp_msg_header_t) + sizeof(unsigned int);
-    if (buffer_size > item->bufferSize) {
-      free(item->buffer);
-      item->buffer = calloc(buffer_size, sizeof(char));
-      item->bufferSize = buffer_size;
+    if (!handle->bypassHeader) {
+        nbytes -= sizeof(pubsub_tcp_msg_header_t) + sizeof(unsigned int);
     }
-  }
-  int nbytes = recv(fd, item->buffer, item->bufferSize, 0);
-  if (nbytes < 0) {
-    L_ERROR("[TCP Socket] read error \n");
+
+    *index = handle->bufferIdx;
+    *size = nbytes;
+    handle->bufferIdx++;
+    handle->bufferIdx = handle->bufferIdx % listSize;
     celixThreadRwlock_unlock(&handle->dbLock);
     return nbytes;
-  }
-  if (!handle->bypassHeader) {
-    nbytes-= sizeof(pubsub_tcp_msg_header_t) + sizeof(unsigned int);
-  }
-
-  *index = handle->bufferIdx;
-  *size  = nbytes;
-  handle->bufferIdx++;
-  handle->bufferIdx = handle->bufferIdx % listSize;
-  celixThreadRwlock_unlock(&handle->dbLock);
-  return nbytes;
 }
 
 //
@@ -523,47 +550,49 @@ int  pubsub_tcpHandler_dataAvailable(pubsub_tcpHandler_pt handle, int fd, unsign
 //
 int
 pubsub_tcpHandler_read(pubsub_tcpHandler_pt handle, unsigned int index, pubsub_tcp_msg_header_t **header,
-                             void **buffer, unsigned int size) {
-  int result = 0;
-  celixThreadRwlock_readLock(&handle->dbLock);
-  pubsub_tcpBufferPartList_pt item = arrayList_get(handle->bufferLists, index);
-  if (item) {
-    if (handle->bypassHeader) {
-      *header = &item->default_header;
-      *buffer = item->buffer;
-      item->default_header.type = (unsigned int) item->buffer[handle->msgIdOffset];
-      item->default_header.seqNr = handle->readSeqNr++;
-      item->default_header.sendTimeNanoseconds = 0;
-      item->default_header.sendTimeNanoseconds = 0;
-    } else
-    {
-      *header = (pubsub_tcp_msg_header_t *) item->buffer;
-      *buffer = &item->buffer[sizeof(pubsub_tcp_msg_header_t) + sizeof(unsigned int)];
+                       void **buffer, unsigned int size) {
+    int result = 0;
+    celixThreadRwlock_readLock(&handle->dbLock);
+    pubsub_tcpBufferPartList_pt item = arrayList_get(handle->bufferLists, index);
+    if (item) {
+        if (handle->bypassHeader) {
+            *header = &item->default_header;
+            *buffer = item->buffer;
+            item->default_header.type = (unsigned int) item->buffer[handle->msgIdOffset];
+            item->default_header.seqNr = handle->readSeqNr++;
+            item->default_header.sendTimeNanoseconds = 0;
+            item->default_header.sendTimeNanoseconds = 0;
+        } else {
+            *header = (pubsub_tcp_msg_header_t *) item->buffer;
+            *buffer = &item->buffer[sizeof(pubsub_tcp_msg_header_t) + sizeof(unsigned int)];
+        }
+    } else {
+        result = -1;
     }
-  } else {
-    result = -1;
-  }
-  celixThreadRwlock_unlock(&handle->dbLock);
-  return result;
+    celixThreadRwlock_unlock(&handle->dbLock);
+    return result;
 }
 
-int pubsub_tcpHandler_addMessageHandler(pubsub_tcpHandler_pt handle, void* payload, pubsub_tcpHandler_processMessage_callback_t processMessageCallback){
-  int result = 0;
-  celixThreadRwlock_writeLock(&handle->dbLock);
-  handle->processMessageCallback = processMessageCallback;
-  handle->processMessagePayload = payload;
-  celixThreadRwlock_unlock(&handle->dbLock);
-  return result;
+int pubsub_tcpHandler_addMessageHandler(pubsub_tcpHandler_pt handle, void *payload,
+                                        pubsub_tcpHandler_processMessage_callback_t processMessageCallback) {
+    int result = 0;
+    celixThreadRwlock_writeLock(&handle->dbLock);
+    handle->processMessageCallback = processMessageCallback;
+    handle->processMessagePayload = payload;
+    celixThreadRwlock_unlock(&handle->dbLock);
+    return result;
 }
 
-int pubsub_tcpHandler_addConnectionCallback(pubsub_tcpHandler_pt handle, void* payload,  pubsub_tcpHandler_connectMessage_callback_t connectMessageCallback, pubsub_tcpHandler_disconnectMessage_callback_t disconnectMessageCallback){
-  int result = 0;
-  celixThreadRwlock_writeLock(&handle->dbLock);
-  handle->connectMessageCallback = connectMessageCallback;
-  handle->disconnectMessageCallback = disconnectMessageCallback;
-  handle->connectPayload = payload;
-  celixThreadRwlock_unlock(&handle->dbLock);
-  return result;
+int pubsub_tcpHandler_addConnectionCallback(pubsub_tcpHandler_pt handle, void *payload,
+                                            pubsub_tcpHandler_connectMessage_callback_t connectMessageCallback,
+                                            pubsub_tcpHandler_connectMessage_callback_t disconnectMessageCallback) {
+    int result = 0;
+    celixThreadRwlock_writeLock(&handle->dbLock);
+    handle->connectMessageCallback = connectMessageCallback;
+    handle->disconnectMessageCallback = disconnectMessageCallback;
+    handle->connectPayload = payload;
+    celixThreadRwlock_unlock(&handle->dbLock);
+    return result;
 }
 
 
@@ -571,173 +600,175 @@ int pubsub_tcpHandler_addConnectionCallback(pubsub_tcpHandler_pt handle, void* p
 // Write large data to TCP. .
 //
 int pubsub_tcpHandler_write(pubsub_tcpHandler_pt handle, pubsub_tcp_msg_header_t *header, void *buffer,
-                                  unsigned int size, int flags) {
-  celixThreadRwlock_readLock(&handle->dbLock);
-  int result = 0;
-  int written = 0;
+                            unsigned int size, int flags) {
+    celixThreadRwlock_readLock(&handle->dbLock);
+    int result = 0;
+    int written = 0;
 
-  hash_map_iterator_t iter = hashMapIterator_construct(handle->fd_map);
-  while (hashMapIterator_hasNext(&iter)) {
-    psa_tcp_connection_entry_t *entry = hashMapIterator_nextValue(&iter);
+    hash_map_iterator_t iter = hashMapIterator_construct(handle->fd_map);
+    while (hashMapIterator_hasNext(&iter)) {
+        psa_tcp_connection_entry_t *entry = hashMapIterator_nextValue(&iter);
 
-    // struct iovec *largeMsg_iovec, int len, ,
-    struct iovec msg_iovec[MAX_MSG_VECTOR_LEN];
-    struct msghdr msg;
-    msg.msg_name = &entry->addr;
-    msg.msg_namelen = entry->len;
-    msg.msg_flags = flags;
-    msg.msg_iov = msg_iovec;
+        // struct iovec *largeMsg_iovec, int len, ,
+        struct iovec msg_iovec[MAX_MSG_VECTOR_LEN];
+        struct msghdr msg;
+        msg.msg_name = &entry->addr;
+        msg.msg_namelen = entry->len;
+        msg.msg_flags = flags;
+        msg.msg_iov = msg_iovec;
 
-    msg.msg_control = NULL;
-    msg.msg_controllen = 0;
-    if (!handle->bypassHeader) {
-      msg.msg_iov[0].iov_base = header;
-      msg.msg_iov[0].iov_len = sizeof(*header);
-      msg.msg_iov[1].iov_base = &size;
-      msg.msg_iov[1].iov_len = sizeof(size);
-      msg.msg_iov[2].iov_base = buffer;
-      msg.msg_iov[2].iov_len = size;
-      msg.msg_iovlen = 3;
-    } else {
-      msg.msg_iov[0].iov_base = buffer;
-      msg.msg_iov[0].iov_len = size;
-      msg.msg_iovlen = 1;
+        msg.msg_control = NULL;
+        msg.msg_controllen = 0;
+        if (!handle->bypassHeader) {
+            msg.msg_iov[0].iov_base = header;
+            msg.msg_iov[0].iov_len = sizeof(*header);
+            msg.msg_iov[1].iov_base = &size;
+            msg.msg_iov[1].iov_len = sizeof(size);
+            msg.msg_iov[2].iov_base = buffer;
+            msg.msg_iov[2].iov_len = size;
+            msg.msg_iovlen = 3;
+        } else {
+            msg.msg_iov[0].iov_base = buffer;
+            msg.msg_iov[0].iov_len = size;
+            msg.msg_iovlen = 1;
+        }
+
+        int nbytes = 0; //
+        if (entry->fd >= 0) nbytes = sendmsg(entry->fd, &msg, MSG_NOSIGNAL);
+
+        //  Several errors are OK. When speculative write is being done we may not
+        //  be able to write a single byte from the socket. Also, SIGSTOP issued
+        //  by a debugging tool can result in EINTR error.
+        if (nbytes == -1
+            && (errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR)) {
+            result = 0;
+            break;
+        }
+        if (nbytes == -1) {
+            L_ERROR("[TCP Socket] Cannot send msg %s\n", strerror(errno));
+            result = -1;
+            break;
+        }
+        written += nbytes;
+        handle->writeSeqNr++;
     }
-
-    int nbytes = 0;
-    if (entry->fd >=0) nbytes = sendmsg(entry->fd, &msg, 0);
-
-    //  Several errors are OK. When speculative write is being done we may not
-    //  be able to write a single byte from the socket. Also, SIGSTOP issued
-    //  by a debugging tool can result in EINTR error.
-    if (nbytes == -1
-        && (errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR)) {
-      result = 0;
-      break;
-    }
-    if (nbytes == -1) {
-      L_ERROR("[TCP Socket] Cannot send msg %s\n", strerror(errno));
-      result = -1;
-      break;
-    }
-    written += nbytes;
-    handle->writeSeqNr++;
-  }
-  celixThreadRwlock_unlock(&handle->dbLock);
-  return (result == 0 ? written : result);
+    celixThreadRwlock_unlock(&handle->dbLock);
+    return (result == 0 ? written : result);
 }
 
-const char* pubsub_tcpHandler_url(pubsub_tcpHandler_pt handle) {
-  return handle->url;
+const char *pubsub_tcpHandler_url(pubsub_tcpHandler_pt handle) {
+    return handle->url;
 }
 
 int pubsub_tcpHandler_handler(pubsub_tcpHandler_pt handle) {
-  int rc = 0;
-  if (handle->efd >= 0) {
-    struct epoll_event events[MAX_EPOLL_EVENTS];
-    int nof_events = epoll_wait(handle->efd, events, MAX_EPOLL_EVENTS, handle->timeout);
-    if (nof_events < 0) {
-      L_ERROR("[TCP Socket] Cannot create epoll wait\n");
-      return nof_events;
-    }
-    int i = 0;
-    for (i = 0; i < nof_events; i++) {
-      if ((handle->fd >= 0) && (events[i].data.fd == handle->fd)) {
-        celixThreadRwlock_writeLock(&handle->dbLock);
-        // new connection available
-        struct sockaddr_in their_addr;
-        socklen_t len = sizeof(struct sockaddr_in);
-        rc = accept(handle->fd, &their_addr, &len);
-        if (rc == -1) {
-          if ((errno == EAGAIN) || (errno == EWOULDBLOCK)) {
-            // already closed
-          } else L_ERROR("[TCP Socket] accept failed: %s\n", strerror(errno));
-        } else {
-          // handle new connection:
-          // add it to reactor, etc
-          struct epoll_event event;
-          bzero(&event, sizeof(event)); // zero the struct
+    int rc = 0;
+    if (handle->efd >= 0) {
+        struct epoll_event events[MAX_EPOLL_EVENTS];
+        int nof_events = epoll_wait(handle->efd, events, MAX_EPOLL_EVENTS, handle->timeout);
+        if (nof_events < 0) {
+            L_ERROR("[TCP Socket] Cannot create epoll wait\n");
+            return nof_events;
+        }
+        int i = 0;
+        for (i = 0; i < nof_events; i++) {
+            if ((handle->fd >= 0) && (events[i].data.fd == handle->fd)) {
+                celixThreadRwlock_writeLock(&handle->dbLock);
+                // new connection available
+                struct sockaddr_in their_addr;
+                socklen_t len = sizeof(struct sockaddr_in);
+                rc = accept(handle->fd, &their_addr, &len);
+                if (rc == -1) {
+                    if ((errno == EAGAIN) || (errno == EWOULDBLOCK)) {
+                        // already closed
+                    } else
+                        L_ERROR("[TCP Socket] accept failed: %s\n", strerror(errno));
+                } else {
+                    // handle new connection:
+                    // add it to reactor, etc
+                    struct epoll_event event;
+                    bzero(&event, sizeof(event)); // zero the struct
 
-          char* address = inet_ntoa(their_addr.sin_addr);
-          unsigned int port = ntohs(their_addr.sin_port);
-          char* url = NULL;
-          asprintf(&url, "tcp://%s:%u", address, port);
-          psa_tcp_connection_entry_t *entry = calloc(1, sizeof(*entry));
-          entry->addr = their_addr;
-          entry->len = len;
-          entry->url = url;
-          entry->fd = rc;
-          event.events = EPOLLIN | EPOLLRDHUP | EPOLLERR | EPOLLET | EPOLLOUT;
-          event.data.fd = entry->fd;
-          rc = epoll_ctl(handle->efd, EPOLL_CTL_ADD, entry->fd, &event);
-          if (rc < 0) {
-            close(entry->fd);
-            free(entry->url);
-            free(entry);
-            L_ERROR("[TCP Socket] Cannot create epoll\n");
-          } else {
-            if (handle->connectMessageCallback) handle->connectMessageCallback(handle->connectPayload, entry->url, true);
-            hashMap_put(handle->fd_map, (void *) (intptr_t) entry->fd, entry);
-            hashMap_put(handle->url_map, entry->url, entry);
-            fprintf(stdout, "[TCP Socket] New connection to url: %s: \n", url);
-          }
+                    char *address = inet_ntoa(their_addr.sin_addr);
+                    unsigned int port = ntohs(their_addr.sin_port);
+                    char *url = NULL;
+                    asprintf(&url, "tcp://%s:%u", address, port);
+                    psa_tcp_connection_entry_t *entry = calloc(1, sizeof(*entry));
+                    entry->addr = their_addr;
+                    entry->len = len;
+                    entry->url = url;
+                    entry->fd = rc;
+                    event.events = EPOLLIN | EPOLLRDHUP | EPOLLERR | EPOLLET | EPOLLOUT;
+                    event.data.fd = entry->fd;
+                    rc = epoll_ctl(handle->efd, EPOLL_CTL_ADD, entry->fd, &event);
+                    if (rc < 0) {
+                        close(entry->fd);
+                        free(entry->url);
+                        free(entry);
+                        L_ERROR("[TCP Socket] Cannot create epoll\n");
+                    } else {
+                        if (handle->connectMessageCallback)
+                            handle->connectMessageCallback(handle->connectPayload, entry->url, true);
+                        hashMap_put(handle->fd_map, (void *) (intptr_t) entry->fd, entry);
+                        hashMap_put(handle->url_map, entry->url, entry);
+                        fprintf(stdout, "[TCP Socket] New connection to url: %s: \n", url);
+                    }
+                }
+                celixThreadRwlock_unlock(&handle->dbLock);
+            } else if (events[i].events & EPOLLIN) {
+                int err = 0;
+                socklen_t len = sizeof(int);
+                rc = getsockopt(events[i].data.fd, SOL_SOCKET, SO_ERROR, &err, &len);
+                if (rc != 0) {
+                    L_ERROR("[TCP Socket]: ERROR read from socket \n");
+                    continue;
+                }
+                unsigned int index = 0;
+                unsigned int size = 0;
+                rc = pubsub_tcpHandler_dataAvailable(handle, events[i].data.fd, &index, &size);
+                if (rc == 0) {
+                    pubsub_tcpHandler_closeConnection(handle, events[i].data.fd);
+                    continue;
+                } else if (rc < 0) {
+                    continue;
+                }
+                // Handle data
+                pubsub_tcp_msg_header_t *msgHeader = NULL;
+                void *buffer = NULL;
+                rc = pubsub_tcpHandler_read(handle, index, &msgHeader, &buffer, size);
+                if (rc != 0) {
+                    L_ERROR("[TCP Socket]: ERROR read with index %d\n", index);
+                    continue;
+                }
+                celixThreadRwlock_readLock(&handle->dbLock);
+                if (handle->processMessageCallback) {
+                    struct timespec receiveTime;
+                    clock_gettime(CLOCK_REALTIME, &receiveTime);
+                    handle->processMessageCallback(handle->processMessagePayload, msgHeader, buffer, size,
+                                                   &receiveTime);
+                }
+                celixThreadRwlock_unlock(&handle->dbLock);
+            } else if (events[i].events & EPOLLOUT) {
+                int err = 0;
+                socklen_t len = sizeof(int);
+                rc = getsockopt(events[i].data.fd, SOL_SOCKET, SO_ERROR, &err, &len);
+                if (rc != 0) {
+                    L_ERROR("[TCP Socket]: ERROR read from socket \n");
+                    continue;
+                }
+            } else if (events[i].events & EPOLLRDHUP) {
+                int err = 0;
+                socklen_t len = sizeof(int);
+                rc = getsockopt(events[i].data.fd, SOL_SOCKET, SO_ERROR, &err, &len);
+                if (rc != 0) {
+                    L_ERROR("[TCP Socket]: ERROR read from socket \n");
+                    continue;
+                }
+                pubsub_tcpHandler_closeConnection(handle, events[i].data.fd);
+            } else if (events[i].events & EPOLLERR) {
+                L_ERROR("[TCP Socket]: ERROR read from socket \n");
+                continue;
+            }
         }
-        celixThreadRwlock_unlock(&handle->dbLock);
-      } else if (events[i].events & EPOLLIN) {
-        int err = 0;
-        socklen_t len = sizeof(int);
-        rc = getsockopt(events[i].data.fd, SOL_SOCKET, SO_ERROR, &err, &len);
-        if (rc != 0) {
-          L_ERROR("[TCP Socket]: ERROR read from socket \n");
-          continue;
-        }
-        unsigned int index = 0;
-        unsigned int size = 0;
-        //printf("pubsub_tcpHandler_handler: FD: %d read:\n", events[i].data.fd);
-        rc = pubsub_tcpHandler_dataAvailable(handle, events[i].data.fd, &index, &size);
-        if (rc == 0) {
-          pubsub_tcpHandler_closeConnectionFd(handle, events[i].data.fd);
-          continue;
-        } else if (rc < 0) {
-          continue;
-        }
-        // Handle data
-        pubsub_tcp_msg_header_t *msgHeader = NULL;
-        void *buffer = NULL;
-        rc = pubsub_tcpHandler_read(handle, index, &msgHeader, &buffer, size);
-        if (rc != 0) {
-          L_ERROR("[TCP Socket]: ERROR read with index %d\n", index);
-          continue;
-        }
-        celixThreadRwlock_readLock(&handle->dbLock);
-        if (handle->processMessageCallback) {
-          struct timespec receiveTime;
-          clock_gettime(CLOCK_REALTIME, &receiveTime);
-          handle->processMessageCallback(handle->processMessagePayload, msgHeader, buffer, size, &receiveTime);
-         }
-        celixThreadRwlock_unlock(&handle->dbLock);
-      } else if (events[i].events & EPOLLOUT)  {
-        int err = 0;
-        socklen_t len = sizeof(int);
-        rc = getsockopt(events[i].data.fd, SOL_SOCKET, SO_ERROR, &err, &len);
-        if (rc != 0) {
-          L_ERROR("[TCP Socket]: ERROR read from socket \n");
-          continue;
-        }
-      } else if (events[i].events & EPOLLRDHUP)  {
-        int err = 0;
-        socklen_t len = sizeof(int);
-        rc = getsockopt(events[i].data.fd, SOL_SOCKET, SO_ERROR, &err, &len);
-        if (rc != 0) {
-          L_ERROR("[TCP Socket]: ERROR read from socket \n");
-          continue;
-        }
-        pubsub_tcpHandler_closeConnectionFd(handle, events[i].data.fd);
-      } else if (events[i].events & EPOLLERR) {
-        L_ERROR("[TCP Socket]: ERROR read from socket \n");
-        continue;
-      }
     }
-  }
-  return rc;
+    return rc;
 }

--- a/bundles/pubsub/pubsub_admin_tcp/src/pubsub_tcp_handler.h
+++ b/bundles/pubsub/pubsub_admin_tcp/src/pubsub_tcp_handler.h
@@ -47,14 +47,13 @@ typedef struct pubsub_tcpHandler  pubsub_tcpHandler_t;
 typedef struct pubsub_tcpHandler *pubsub_tcpHandler_pt;
 typedef void (*pubsub_tcpHandler_processMessage_callback_t)(void* payload, const pubsub_tcp_msg_header_t* header, const unsigned char * buffer, size_t size, struct timespec *receiveTime);
 typedef void (*pubsub_tcpHandler_connectMessage_callback_t)(void* payload, const char *url, bool lock);
-typedef void (*pubsub_tcpHandler_disconnectMessage_callback_t)(void* payload, const char *url);
 
 pubsub_tcpHandler_pt pubsub_tcpHandler_create(log_helper_t *logHelper);
 void pubsub_tcpHandler_destroy(pubsub_tcpHandler_pt handle);
 int pubsub_tcpHandler_open(pubsub_tcpHandler_pt handle, char* url);
 int pubsub_tcpHandler_close(pubsub_tcpHandler_pt handle);
 int pubsub_tcpHandler_connect(pubsub_tcpHandler_pt handle, char* url);
-int pubsub_tcpHandler_closeConnection(pubsub_tcpHandler_pt handle, char* url);
+int pubsub_tcpHandler_disconnect(pubsub_tcpHandler_pt handle, char* url);
 int pubsub_tcpHandler_listen(pubsub_tcpHandler_pt handle, char* url);
 
 int pubsub_tcpHandler_createReceiveBufferStore(pubsub_tcpHandler_pt handle, unsigned int maxNofBuffers, unsigned int bufferSize);
@@ -65,7 +64,7 @@ int pubsub_tcpHandler_read(pubsub_tcpHandler_pt handle, unsigned int index, pubs
 int pubsub_tcpHandler_handler(pubsub_tcpHandler_pt handle);
 int pubsub_tcpHandler_write(pubsub_tcpHandler_pt handle, pubsub_tcp_msg_header_t* header, void* buffer, unsigned int size, int flags);
 int pubsub_tcpHandler_addMessageHandler(pubsub_tcpHandler_pt handle, void* payload, pubsub_tcpHandler_processMessage_callback_t processMessageCallback);
-int pubsub_tcpHandler_addConnectionCallback(pubsub_tcpHandler_pt handle, void* payload, pubsub_tcpHandler_connectMessage_callback_t connectMessageCallback, pubsub_tcpHandler_disconnectMessage_callback_t disconnectMessageCallback);
+int pubsub_tcpHandler_addConnectionCallback(pubsub_tcpHandler_pt handle, void* payload, pubsub_tcpHandler_connectMessage_callback_t connectMessageCallback, pubsub_tcpHandler_connectMessage_callback_t disconnectMessageCallback);
 
 const char* pubsub_tcpHandler_url(pubsub_tcpHandler_pt handle);
 void pubsub_tcpHandler_setUrlInfo(char *url, pubsub_tcpHandler_url_t *url_info);

--- a/bundles/pubsub/pubsub_admin_tcp/src/pubsub_tcp_topic_receiver.c
+++ b/bundles/pubsub/pubsub_admin_tcp/src/pubsub_tcp_topic_receiver.c
@@ -131,7 +131,7 @@ static void psa_tcp_initializeAllSubscribers(pubsub_tcp_topic_receiver_t *receiv
 
 static void processMsg(void *handle, const pubsub_tcp_msg_header_t *hdr, const unsigned char *payload, size_t payloadSize, struct timespec *receiveTime);
 static void psa_tcp_connectHandler(void *handle, const char *url, bool lock);
-static void psa_tcp_disConnectHandler(void *handle, const char *url);
+static void psa_tcp_disConnectHandler(void *handle, const char *url, bool lock);
 
 
 pubsub_tcp_topic_receiver_t *pubsub_tcpTopicReceiver_create(celix_bundle_context_t *ctx,
@@ -206,19 +206,21 @@ pubsub_tcp_topic_receiver_t *pubsub_tcpTopicReceiver_create(celix_bundle_context
     receiver->requestedConnections.allConnected = false;
 
     if ((staticConnectUrls != NULL) && (receiver->socketHandler != NULL) && (staticBindUrl == NULL)) {
-        char *urlsCopy = strndup(staticConnectUrls, 1024 * 1024);
-        char *url;
-        char *save = urlsCopy;
-        while ((url = strtok_r(save, " ", &save))) {
-            psa_tcp_requested_connection_entry_t *entry = calloc(1, sizeof(*entry));
-            entry->statically = true;
-            entry->connected = false;
-            entry->url = strndup(url, 1024 * 1024);
-            entry->parent = receiver;
-            hashMap_put(receiver->requestedConnections.map, entry->url, entry);
-        }
-        free(urlsCopy);
+      char *urlsCopy = strndup(staticConnectUrls, 1024 * 1024);
+      char *url;
+      char *save = urlsCopy;
+      while ((url = strtok_r(save, " ", &save))) {
+        psa_tcp_requested_connection_entry_t *entry = calloc(1, sizeof(*entry));
+        entry->statically = true;
+        entry->connected = false;
+        entry->url = strndup(url, 1024 * 1024);
+        entry->parent = receiver;
+        hashMap_put(receiver->requestedConnections.map, entry->url, entry);
+      }
+      free(urlsCopy);
+    }
 
+    if ((receiver->socketHandler != NULL) && (staticBindUrl == NULL)) {
         // Configure Receiver thread
         receiver->thread.running = true;
         celixThread_create(&receiver->thread.thread, NULL, psa_tcp_recvThread, receiver);
@@ -258,7 +260,7 @@ void pubsub_tcpTopicReceiver_destroy(pubsub_tcp_topic_receiver_t *receiver) {
 
 
         celixThreadMutex_lock(&receiver->thread.mutex);
-        if (!receiver->thread.running) {
+        if (receiver->thread.running) {
             receiver->thread.running = false;
             celixThreadMutex_unlock(&receiver->thread.mutex);
             celixThread_join(receiver->thread.thread, NULL);
@@ -373,7 +375,7 @@ void pubsub_tcpTopicReceiver_disconnectFrom(pubsub_tcp_topic_receiver_t *receive
     celixThreadMutex_lock(&receiver->requestedConnections.mutex);
     psa_tcp_requested_connection_entry_t *entry = hashMap_remove(receiver->requestedConnections.map, url);
     if (entry != NULL) {
-        int rc = pubsub_tcpHandler_closeConnection(receiver->socketHandler, entry->url);
+        int rc = pubsub_tcpHandler_disconnect(receiver->socketHandler, entry->url);
         if (rc < 0) L_WARN("[PSA_TCP] Error disconnecting from tcp url %s. (%s)", url, strerror(errno));
     }
     if (entry != NULL) {
@@ -677,7 +679,7 @@ static void psa_tcp_connectToAllRequestedConnections(pubsub_tcp_topic_receiver_t
             if (!entry->connected) {
                 entry->fd = pubsub_tcpHandler_connect(entry->parent->socketHandler, entry->url);
                 if (entry->fd < 0) {
-                    L_WARN("[PSA_TCP] Error connecting to tcp url %s\n", entry->url);
+                    //L_WARN("[PSA_TCP] Error connecting to tcp url %s\n", entry->url);
                     allConnected = false;
                 }
             }
@@ -704,16 +706,16 @@ static void psa_tcp_connectHandler(void *handle, const char *url, bool lock) {
     if (lock) celixThreadMutex_unlock(&receiver->requestedConnections.mutex);
 }
 
-static void psa_tcp_disConnectHandler(void *handle, const char *url) {
+static void psa_tcp_disConnectHandler(void *handle, const char *url, bool lock) {
     pubsub_tcp_topic_receiver_t *receiver = handle;
     L_DEBUG("[PSA TCP] TopicReceiver %s/%s disconnect from tcp url %s", receiver->scope, receiver->topic, url);
-    celixThreadMutex_lock(&receiver->requestedConnections.mutex);
+    if (lock) celixThreadMutex_lock(&receiver->requestedConnections.mutex);
     psa_tcp_requested_connection_entry_t *entry = hashMap_remove(receiver->requestedConnections.map, url);
     if (entry != NULL) {
         free(entry->url);
         free(entry);
     }
-    celixThreadMutex_unlock(&receiver->requestedConnections.mutex);
+    if (lock) celixThreadMutex_unlock(&receiver->requestedConnections.mutex);
 }
 
 

--- a/bundles/pubsub/pubsub_admin_tcp/src/pubsub_tcp_topic_sender.c
+++ b/bundles/pubsub/pubsub_admin_tcp/src/pubsub_tcp_topic_sender.c
@@ -195,7 +195,7 @@ pubsub_tcp_topic_sender_t *pubsub_tcpTopicSender_create(
                 char *url = NULL;
                 asprintf(&url, "tcp://%s:%u", bindIP, port);
                 char *bindUrl = NULL;
-                asprintf(&bindUrl, "tcp://127.0.0.1:%u", port);
+                asprintf(&bindUrl, "tcp://0.0.0.0:%u", port);
                 int rv = pubsub_tcpHandler_listen(sender->socketHandler, bindUrl);
                 if (rv == -1) {
                     L_WARN("Error for tcp_bind using dynamic bind url '%s'. %s", bindUrl, strerror(errno));


### PR DESCRIPTION
- Remove TCP crash after unloading tcp admin service
  (Problem in pubsub topology admin)
- Enable pubsub sending after unloading pubsub tcp admin
  (Problem in pubsub topology admin)