### PR TITLE
Feature/handle hooks in registry

### DIFF
--- a/bundles/pubsub/test/CMakeLists.txt
+++ b/bundles/pubsub/test/CMakeLists.txt
@@ -38,7 +38,7 @@ celix_bundle_files(pubsub_endpoint_sut
 add_celix_bundle(pubsub_endpoint_tst
         #Test bundle containing cpputests and uses celix_test_runner launcher instead of the celix launcher
         SOURCES
-        test/tst_endpoint_activator.cc
+        test/tst_endpoint_activator.c
         VERSION 1.0.0
         )
 target_link_libraries(pubsub_endpoint_tst PRIVATE Celix::framework Celix::pubsub_api)
@@ -93,7 +93,7 @@ celix_bundle_files(pubsub_sut
 add_celix_bundle(pubsub_tst
     #Test bundle containing cpputests and uses celix_test_runner launcher instead of the celix launcher
     SOURCES
-        test/tst_activator.cc
+        test/tst_activator.c
     VERSION 1.0.0
 )
 target_link_libraries(pubsub_tst PRIVATE Celix::framework Celix::pubsub_api)
@@ -121,7 +121,7 @@ add_celix_container(pubsub_udpmc_tests
             pubsub_tst
 )
 target_link_libraries(pubsub_udpmc_tests PRIVATE Celix::pubsub_api ${CPPUTEST_LIBRARIES} ${JANSSON_LIBRARIES} Celix::dfi)
-target_include_directories(pubsub_udpmc_tests PRIVATE ${CPPUTEST_INCLUDE_DIR})
+target_include_directories(pubsub_udpmc_tests PRIVATE ${CPPUTEST_INCLUDE_DIR} test)
 message(WARNING "TODO fix issues with UDPMC and reanble test again")
 #add_test(NAME pubsub_udpmc_tests COMMAND pubsub_udpmc_tests WORKING_DIRECTORY $<TARGET_PROPERTY:pubsub_udpmc_tests,CONTAINER_LOC>)
 #SETUP_TARGET_FOR_COVERAGE(pubsub_udpmc_tests_cov pubsub_udpmc_tests ${CMAKE_BINARY_DIR}/coverage/pubsub_udpmc_tests/pubsub_udpmc_tests ..)
@@ -142,7 +142,7 @@ add_celix_container(pubsub_tcp_tests
         pubsub_tst
         )
 target_link_libraries(pubsub_tcp_tests PRIVATE Celix::pubsub_api ${CPPUTEST_LIBRARIES} ${JANSSON_LIBRARIES} Celix::dfi)
-target_include_directories(pubsub_tcp_tests PRIVATE ${CPPUTEST_INCLUDE_DIR})
+target_include_directories(pubsub_tcp_tests PRIVATE ${CPPUTEST_INCLUDE_DIR} test)
 add_test(NAME pubsub_tcp_tests COMMAND pubsub_tcp_tests WORKING_DIRECTORY $<TARGET_PROPERTY:pubsub_tcp_tests,CONTAINER_LOC>)
 SETUP_TARGET_FOR_COVERAGE(pubsub_tcp_tests_cov pubsub_tcp_tests ${CMAKE_BINARY_DIR}/coverage/pubsub_tcp_tests/pubsub_tcp_tests ..)
 
@@ -164,7 +164,7 @@ add_celix_container(pubsub_tcp_endpoint_tests
         pubsub_endpoint_tst
         )
 target_link_libraries(pubsub_tcp_endpoint_tests PRIVATE Celix::pubsub_api ${CPPUTEST_LIBRARIES} ${JANSSON_LIBRARIES} Celix::dfi)
-target_include_directories(pubsub_tcp_endpoint_tests PRIVATE ${CPPUTEST_INCLUDE_DIR})
+target_include_directories(pubsub_tcp_endpoint_tests PRIVATE ${CPPUTEST_INCLUDE_DIR} test)
 
 #TCP Endpoint test is disabled because the test is not stable when running on Travis
 if (ENABLE_PUBSUB_PSA_TCP_ENDPOINT_TEST)
@@ -189,7 +189,7 @@ add_celix_container(pubsub_websocket_tests
             pubsub_tst
 )
 target_link_libraries(pubsub_websocket_tests PRIVATE Celix::pubsub_api ${CPPUTEST_LIBRARIES} ${JANSSON_LIBRARIES} Celix::dfi)
-target_include_directories(pubsub_websocket_tests PRIVATE ${CPPUTEST_INCLUDE_DIR})
+target_include_directories(pubsub_websocket_tests PRIVATE ${CPPUTEST_INCLUDE_DIR} test)
 add_test(NAME pubsub_websocket_tests COMMAND pubsub_websocket_tests WORKING_DIRECTORY $<TARGET_PROPERTY:pubsub_websocket_tests,CONTAINER_LOC>)
 SETUP_TARGET_FOR_COVERAGE(pubsub_websocket_tests_cov pubsub_websocket_tests ${CMAKE_BINARY_DIR}/coverage/pubsub_websocket_tests/pubsub_websocket_tests ..)
 
@@ -209,7 +209,7 @@ if (BUILD_PUBSUB_PSA_ZMQ)
     )
 
     target_link_libraries(pubsub_zmq_tests PRIVATE Celix::pubsub_api ${CPPUTEST_LIBRARIES} ${JANSSON_LIBRARIES} Celix::dfi)
-    target_include_directories(pubsub_zmq_tests PRIVATE ${CPPUTEST_INCLUDE_DIR})
+    target_include_directories(pubsub_zmq_tests PRIVATE ${CPPUTEST_INCLUDE_DIR} test)
     add_test(NAME pubsub_zmq_tests COMMAND pubsub_zmq_tests WORKING_DIRECTORY $<TARGET_PROPERTY:pubsub_zmq_tests,CONTAINER_LOC>)
     SETUP_TARGET_FOR_COVERAGE(pubsub_zmq_tests_cov pubsub_zmq_tests ${CMAKE_BINARY_DIR}/coverage/pubsub_zmq_tests/pubsub_zmq_tests ..)
 
@@ -229,7 +229,7 @@ if (BUILD_PUBSUB_PSA_ZMQ)
                 pubsub_tst
     )
     target_link_libraries(pubsub_zmq_zerocopy_tests PRIVATE Celix::pubsub_api ${CPPUTEST_LIBRARIES} ${JANSSON_LIBRARIES} Celix::dfi)
-    target_include_directories(pubsub_zmq_zerocopy_tests PRIVATE ${CPPUTEST_INCLUDE_DIR})
+    target_include_directories(pubsub_zmq_zerocopy_tests PRIVATE ${CPPUTEST_INCLUDE_DIR} test)
     add_test(NAME pubsub_zmq_zerocopy_tests COMMAND pubsub_zmq_zerocopy_tests WORKING_DIRECTORY $<TARGET_PROPERTY:pubsub_zmq_zerocopy_tests,CONTAINER_LOC>)
     SETUP_TARGET_FOR_COVERAGE(pubsub_zmq_zerocopy_tests_cov pubsub_zmq_zerocopy_tests ${CMAKE_BINARY_DIR}/coverage/pubsub_zmq_tests/pubsub_zmq_zerocopy_tests ..)
 endif ()

--- a/bundles/pubsub/test/test/receive_count_service.h
+++ b/bundles/pubsub/test/test/receive_count_service.h
@@ -1,0 +1,30 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef CELIX_RECEIVE_COUNT_SERVICE_H
+#define CELIX_RECEIVE_COUNT_SERVICE_H
+
+#define CELIX_RECEIVE_COUNT_SERVICE_NAME "celix_receive_count_service"
+
+typedef struct celix_receive_count_service {
+    void *handle;
+    size_t (*receiveCount)(void *handle);
+} celix_receive_count_service_t;
+
+#endif //CELIX_RECEIVE_COUNT_SERVICE_H

--- a/bundles/pubsub/test/test/test_runner.cc
+++ b/bundles/pubsub/test/test/test_runner.cc
@@ -18,20 +18,54 @@
  */
 
 #include "celix_api.h"
+#include <unistd.h>
+#include "receive_count_service.h"
 
 #include <CppUTest/TestHarness.h>
 #include <CppUTest/CommandLineTestRunner.h>
 
 int main(int argc, char **argv) {
-    celix_framework_t *fw = NULL;
-    celixLauncher_launch("config.properties", &fw);
-
     MemoryLeakWarningPlugin::turnOffNewDeleteOverloads();
     int rc = RUN_ALL_TESTS(argc, argv);
-
-    celixLauncher_stop(fw);
-    celixLauncher_waitForShutdown(fw);
-    celixLauncher_destroy(fw);
-
     return rc;
+}
+
+TEST_GROUP(PUBSUB_INT_GROUP) {
+    celix_framework_t *fw = NULL;
+    celix_bundle_context_t *ctx = NULL;
+    void setup() {
+        celixLauncher_launch("config.properties", &fw);
+        ctx = celix_framework_getFrameworkContext(fw);
+    }
+
+        void teardown() {
+            celixLauncher_stop(fw);
+            celixLauncher_waitForShutdown(fw);
+            celixLauncher_destroy(fw);
+            ctx = NULL;
+            fw = NULL;
+        }
+        };
+
+TEST(PUBSUB_INT_GROUP, recvTest) {
+    constexpr int TRIES = 25;
+    constexpr int TIMEOUT = 250000;
+    constexpr int MSG_COUNT = 100;
+
+    int count = 0;
+
+    for (int i = 0; i < TRIES; ++i) {
+        count = 0;
+        celix_bundleContext_useService(ctx, CELIX_RECEIVE_COUNT_SERVICE_NAME, &count, [](void *handle, void *svc) {
+            auto* count_ptr = static_cast<int*>(handle);
+            auto* count = static_cast<celix_receive_count_service_t*>(svc);
+            *count_ptr = count->receiveCount(count->handle);
+        });
+        printf("Current msg count is %i, waiting for at least %i\n", count, MSG_COUNT);
+        if (count >= MSG_COUNT) {
+            break;
+        }
+        usleep(TIMEOUT);
+    }
+    CHECK(count >= MSG_COUNT);
 }

--- a/bundles/pubsub/test/test/tst_activator.c
+++ b/bundles/pubsub/test/test/tst_activator.c
@@ -26,41 +26,45 @@
 #include "pubsub/api.h"
 
 #include "msg.h"
-
-#include <CppUTest/TestHarness.h>
-#include <CppUTestExt/MockSupport.h>
-#include <constants.h>
-
-extern "C" {
+#include "receive_count_service.h"
 
 static int tst_receive(void *handle, const char *msgType, unsigned int msgTypeId, void *msg, bool *release);
+static size_t tst_count(void *handle);
 
 struct activator {
     pubsub_subscriber_t subSvc;
     long subSvcId;
 
-    pthread_mutex_t mutex;
-    unsigned int count = 0;
-};
+    celix_receive_count_service_t countSvc;
+    long countSvcId;
 
-static struct activator *g_act = NULL; //global
+    pthread_mutex_t mutex;
+    unsigned int count;
+};
 
 celix_status_t bnd_start(struct activator *act, celix_bundle_context_t *ctx) {
     pthread_mutex_init(&act->mutex, NULL);
 
-    celix_properties_t *props = celix_properties_create();
-    celix_properties_set(props, PUBSUB_SUBSCRIBER_TOPIC, "ping");
-    act->subSvc.handle = act;
-    act->subSvc.receive = tst_receive;
-    act->subSvcId = celix_bundleContext_registerService(ctx, &act->subSvc, PUBSUB_SUBSCRIBER_SERVICE_NAME, props);
+    {
+        celix_properties_t *props = celix_properties_create();
+        celix_properties_set(props, PUBSUB_SUBSCRIBER_TOPIC, "ping");
+        act->subSvc.handle = act;
+        act->subSvc.receive = tst_receive;
+        act->subSvcId = celix_bundleContext_registerService(ctx, &act->subSvc, PUBSUB_SUBSCRIBER_SERVICE_NAME, props);
+    }
 
-    g_act = act;
+    {
+        act->countSvc.handle = act;
+        act->countSvc.receiveCount = tst_count;
+        act->countSvcId = celix_bundleContext_registerService(ctx, &act->countSvc, CELIX_RECEIVE_COUNT_SERVICE_NAME, NULL);
+    }
 
     return CELIX_SUCCESS;
 }
 
 celix_status_t bnd_stop(struct activator *act, celix_bundle_context_t *ctx) {
     celix_bundleContext_unregisterService(ctx, act->subSvcId);
+    celix_bundleContext_unregisterService(ctx, act->countSvcId);
     pthread_mutex_destroy(&act->mutex);
     return CELIX_SUCCESS;
 }
@@ -68,10 +72,10 @@ celix_status_t bnd_stop(struct activator *act, celix_bundle_context_t *ctx) {
 CELIX_GEN_BUNDLE_ACTIVATOR(struct activator, bnd_start, bnd_stop) ;
 
 
-static int tst_receive(void *handle, const char * /*msgType*/, unsigned int /*msgTypeId*/, void * voidMsg, bool */*release*/) {
-    struct activator *act = static_cast<struct activator *>(handle);
+static int tst_receive(void *handle, const char * msgType __attribute__((unused)), unsigned int msgTypeId  __attribute__((unused)), void * voidMsg, bool *release  __attribute__((unused))) {
+    struct activator *act = handle;
 
-    msg_t *msg = static_cast<msg_t*>(voidMsg);
+    msg_t *msg = voidMsg;
     static int prevSeqNr = 0;
     int delta = msg->seqNr - prevSeqNr;
     if (delta != 1) {
@@ -85,36 +89,11 @@ static int tst_receive(void *handle, const char * /*msgType*/, unsigned int /*ms
     return CELIX_SUCCESS;
 }
 
-} //end extern C
-
-TEST_GROUP(PUBSUB_INT_GROUP)
-{
-    void setup() {
-        //nop
-    }
-
-    void teardown() {
-        //nop
-    }
-};
-
-TEST(PUBSUB_INT_GROUP, recvTest) {
-    constexpr int TRIES = 25;
-    constexpr int TIMEOUT = 250000;
-    constexpr int MSG_COUNT = 100;
-
-    int count = 0;
-
-    for (int i = 0; i < TRIES; ++i) {
-        pthread_mutex_lock(&g_act->mutex);
-        count = g_act->count;
-        pthread_mutex_unlock(&g_act->mutex);
-        printf("Current msg count is %i, waiting for at least %i\n", count, MSG_COUNT);
-        if (count >= MSG_COUNT) {
-            break;
-        }
-        usleep(TIMEOUT);
-    }
-    CHECK(count >= MSG_COUNT);
-
+static size_t tst_count(void *handle) {
+    struct activator *act = handle;
+    size_t count;
+    pthread_mutex_lock(&act->mutex);
+    count = act->count;
+    pthread_mutex_unlock(&act->mutex);
+    return count;
 }

--- a/bundles/pubsub/test/test/tst_endpoint_activator.c
+++ b/bundles/pubsub/test/test/tst_endpoint_activator.c
@@ -26,41 +26,48 @@
 #include "pubsub/api.h"
 
 #include "msg.h"
+#include "receive_count_service.h"
 
-#include <CppUTest/TestHarness.h>
-#include <CppUTestExt/MockSupport.h>
-#include <constants.h>
-
-extern "C" {
 
 static int tst_receive(void *handle, const char *msgType, unsigned int msgTypeId, void *msg, bool *release);
+static size_t tst_count(void *handle);
 
 struct activator {
     pubsub_subscriber_t subSvc;
     long subSvcId;
 
-    pthread_mutex_t mutex;
-    unsigned int count = 0;
-};
+    celix_receive_count_service_t countSvc;
+    long countSvcId;
 
-static struct activator *g_act = NULL; //global
+    pthread_mutex_t mutex;
+    unsigned int count;
+};
 
 celix_status_t bnd_start(struct activator *act, celix_bundle_context_t *ctx) {
     pthread_mutex_init(&act->mutex, NULL);
 
-    celix_properties_t *props = celix_properties_create();
-    celix_properties_set(props, PUBSUB_SUBSCRIBER_TOPIC, "ping2");
-    act->subSvc.handle = act;
-    act->subSvc.receive = tst_receive;
-    act->subSvcId = celix_bundleContext_registerService(ctx, &act->subSvc, PUBSUB_SUBSCRIBER_SERVICE_NAME, props);
+    {
+        celix_properties_t *props = celix_properties_create();
+        celix_properties_set(props, PUBSUB_SUBSCRIBER_TOPIC, "ping2");
+        act->subSvc.handle = act;
+        act->subSvc.receive = tst_receive;
+        act->subSvcId = celix_bundleContext_registerService(ctx, &act->subSvc, PUBSUB_SUBSCRIBER_SERVICE_NAME, props);
+    }
 
-    g_act = act;
+
+    {
+        act->countSvc.handle = act;
+        act->countSvc.receiveCount = tst_count;
+        act->countSvcId = celix_bundleContext_registerService(ctx, &act->countSvc, CELIX_RECEIVE_COUNT_SERVICE_NAME, NULL);
+    }
+
 
     return CELIX_SUCCESS;
 }
 
 celix_status_t bnd_stop(struct activator *act, celix_bundle_context_t *ctx) {
     celix_bundleContext_unregisterService(ctx, act->subSvcId);
+    celix_bundleContext_unregisterService(ctx, act->countSvcId);
     pthread_mutex_destroy(&act->mutex);
     return CELIX_SUCCESS;
 }
@@ -68,10 +75,10 @@ celix_status_t bnd_stop(struct activator *act, celix_bundle_context_t *ctx) {
 CELIX_GEN_BUNDLE_ACTIVATOR(struct activator, bnd_start, bnd_stop) ;
 
 
-static int tst_receive(void *handle, const char * /*msgType*/, unsigned int /*msgTypeId*/, void * voidMsg, bool */*release*/) {
-    struct activator *act = static_cast<struct activator *>(handle);
+static int tst_receive(void *handle, const char * msgType __attribute__((unused)), unsigned int msgTypeId  __attribute__((unused)), void * voidMsg, bool *release  __attribute__((unused))) {
+    struct activator *act = handle;
 
-    msg_t *msg = static_cast<msg_t*>(voidMsg);
+    msg_t *msg = voidMsg;
     static int prevSeqNr = 0;
     int delta = msg->seqNr - prevSeqNr;
     if (delta != 1) {
@@ -85,36 +92,11 @@ static int tst_receive(void *handle, const char * /*msgType*/, unsigned int /*ms
     return CELIX_SUCCESS;
 }
 
-} //end extern C
-
-TEST_GROUP(PUBSUB_INT_GROUP)
-{
-	void setup() {
-	    //nop
-	}
-
-	void teardown() {
-		//nop
-	}
-};
-
-TEST(PUBSUB_INT_GROUP, recvTest) {
-    constexpr int TRIES = 25;
-    constexpr int TIMEOUT = 250000;
-    constexpr int MSG_COUNT = 100;
-
-    int count = 0;
-
-    for (int i = 0; i < TRIES; ++i) {
-        pthread_mutex_lock(&g_act->mutex);
-        count = g_act->count;
-        pthread_mutex_unlock(&g_act->mutex);
-        printf("Current msg count is %i, waiting for at least %i\n", count, MSG_COUNT);
-        if (count >= MSG_COUNT) {
-            break;
-        }
-        usleep(TIMEOUT);
-    }
-    CHECK(count >= MSG_COUNT);
-
+static size_t tst_count(void *handle) {
+    struct activator *act = handle;
+    size_t count;
+    pthread_mutex_lock(&act->mutex);
+    count = act->count;
+    pthread_mutex_unlock(&act->mutex);
+    return count;
 }

--- a/libs/framework/include/listener_hook_service.h
+++ b/libs/framework/include/listener_hook_service.h
@@ -16,20 +16,9 @@
  *specific language governing permissions and limitations
  *under the License.
  */
-/*
- * listener_hook_service.h
- *
- *  \date       Oct 28, 2011
- *  \author    	<a href="mailto:dev@celix.apache.org">Apache Celix Project Team</a>
- *  \copyright	Apache License, Version 2.0
- */
 
 #ifndef LISTENER_HOOK_SERVICE_H_
 #define LISTENER_HOOK_SERVICE_H_
-
-
-typedef struct listener_hook_info *listener_hook_info_pt;
-typedef struct listener_hook_service *listener_hook_service_pt;
 
 #include "bundle_context.h"
 
@@ -37,6 +26,12 @@ typedef struct listener_hook_service *listener_hook_service_pt;
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+
+typedef struct listener_hook_info *listener_hook_info_pt;
+typedef struct listener_hook_info celix_listener_hook_info_t;
+typedef struct listener_hook_service *listener_hook_service_pt;
+typedef struct listener_hook_service celix_listener_hook_service_t;
 
 struct listener_hook_info {
 	celix_bundle_context_t *context;
@@ -47,9 +42,19 @@ struct listener_hook_info {
 struct listener_hook_service {
 	void *handle;
 
-	celix_status_t (*added)(void *hook, celix_array_list_t *listeners);
+	/**
+	 * Called when a new service listener / service tracker is added.
+	 * @param handle The service handle.
+	 * @param listeners A list of celix_listener_hook_info_t* entries.
+	 */
+	celix_status_t (*added)(void *handle, celix_array_list_t *listeners);
 
-	celix_status_t (*removed)(void *hook, celix_array_list_t *listeners);
+    /**
+     * Called when a service listener / service tracker is removed.
+     * @param handle The service handle.
+     * @param listeners A list of celix_listener_hook_info_t* entries.
+     */
+	celix_status_t (*removed)(void *handle, celix_array_list_t *listeners);
 };
 
 #ifdef __cplusplus

--- a/libs/framework/include/service_registry.h
+++ b/libs/framework/include/service_registry.h
@@ -93,7 +93,9 @@ serviceRegistry_ungetService(service_registry_pt registry, celix_bundle_t *bundl
 
 celix_status_t serviceRegistry_clearReferencesFor(service_registry_pt registry, celix_bundle_t *bundle);
 
-celix_status_t serviceRegistry_getListenerHooks(service_registry_pt registry, celix_bundle_t *bundle, celix_array_list_t **hooks);
+void serviceRegistry_callHooksForListenerFilter(service_registry_pt registry, celix_bundle_t *owner, const char *filter, bool removed);
+
+size_t serviceRegistry_nrOfHooks(service_registry_pt registry);
 
 celix_status_t
 serviceRegistry_servicePropertiesModified(service_registry_pt registry, service_registration_pt registration,

--- a/libs/framework/private/mock/service_registry_mock.c
+++ b/libs/framework/private/mock/service_registry_mock.c
@@ -182,3 +182,15 @@ celix_serviceRegistry_registerServiceFactory(
 			->withOutputParameter("registration", registration);
 	return mock_c()->returnValue().value.intValue;
 }
+
+void serviceRegistry_callHooksForListenerFilter(
+        service_registry_pt registry,
+        celix_bundle_t *owner,
+        const char *filter,
+        bool removed) {
+    mock_c()->actualCall("serviceRegistry_callHooksForListenerFilter")
+            ->withPointerParameters("registry", registry)
+            ->withPointerParameters("owner", owner)
+            ->withStringParameters("filter", filter)
+            ->withBoolParameters("removed", removed);
+}

--- a/libs/framework/private/test/service_registry_test.cpp
+++ b/libs/framework/private/test/service_registry_test.cpp
@@ -1003,23 +1003,10 @@ TEST(service_registry, getListenerHooks) {
 	hashMap_put(usages, (void*)registration->serviceId, reference);
 	hashMap_put(registry->serviceReferences, bundle, usages);
 
-	mock()
-		.expectOneCall("serviceRegistration_retain")
-		.withParameter("registration", registration);
-	mock()
-		.expectOneCall("serviceReference_retain")
-		.withParameter("ref", reference);
-	mock()
-		.expectOneCall("serviceRegistration_release")
-		.withParameter("registration", registration);
-
-	array_list_pt hooks = NULL;
-	serviceRegistry_getListenerHooks(registry, bundle, &hooks);
-	LONGS_EQUAL(1, arrayList_size(hooks));
-	POINTERS_EQUAL(reference, arrayList_get(hooks, 0));
+    size_t nrOfHooks = serviceRegistry_nrOfHooks(registry);
+	LONGS_EQUAL(1, nrOfHooks);
 
 	hashMap_destroy(usages, false, false);
-	arrayList_destroy(hooks);
 	arrayList_remove(registry->listenerHooks, 0);
 	free(registration);
 	serviceRegistry_destroy(registry);

--- a/libs/framework/private/test/service_registry_test.cpp
+++ b/libs/framework/private/test/service_registry_test.cpp
@@ -264,6 +264,7 @@ TEST(service_registry, registerServiceListenerHook) {
 	char * serviceName = my_strdup(OSGI_FRAMEWORK_LISTENER_HOOK_SERVICE_NAME);
 	void *service = (void *) 0x20;
 	service_registration_pt reg = (service_registration_pt) 0x30;
+	long svcId = 11;
 
 	mock()
 		.expectOneCall("serviceRegistration_create")
@@ -281,11 +282,17 @@ TEST(service_registry, registerServiceListenerHook) {
 			.withParameter("registration", reg)
 			.withParameter("oldprops", (void*)NULL);
 
+    mock().expectOneCall("serviceRegistration_getServiceId")
+            .withParameter("registration", reg)
+            .andReturnValue(svcId);
+
 	service_registration_pt registration = NULL;
 	serviceRegistry_registerService(registry, bundle, serviceName, service, NULL, &registration);
 	POINTERS_EQUAL(reg, registration);
 	LONGS_EQUAL(1, arrayList_size(registry->listenerHooks));
-	POINTERS_EQUAL(reg, arrayList_get(registry->listenerHooks, 0));
+
+	auto* entry = (celix_service_registry_listener_hook_entry_t*)celix_arrayList_get(registry->listenerHooks, 0);
+	POINTERS_EQUAL(svcId, entry->svcId);
 
 	//cleanup
 	array_list_pt destroy_this = (array_list_pt) hashMap_remove(registry->serviceRegistrations, bundle);
@@ -313,6 +320,7 @@ TEST(service_registry, unregisterService) {
 	hashMap_put(references, (void*)registration->serviceId, reference);
 	hashMap_put(registry->serviceReferences, bundle, references);
 	properties_pt properties = (properties_pt) 0x40;
+	long svcId = 12;
 
 	mock()
 		.expectOneCall("serviceRegistration_getProperties")
@@ -325,12 +333,17 @@ TEST(service_registry, unregisterService) {
 		.withParameter("key", (char *)OSGI_FRAMEWORK_OBJECTCLASS)
 		.andReturnValue((char*)OSGI_FRAMEWORK_LISTENER_HOOK_SERVICE_NAME);
 
+    mock().expectOneCall("serviceRegistration_getServiceId")
+            .withParameter("registration", registration)
+            .andReturnValue(svcId);
+
 	mock()
 		.expectOneCall("serviceRegistryTest_serviceChanged")
 		.withParameter("framework", framework)
 		.withParameter("eventType", OSGI_FRAMEWORK_SERVICE_EVENT_UNREGISTERING)
 		.withParameter("registration", registration)
 		.withParameter("oldprops", (void*) NULL);
+
 	mock()
 		.expectOneCall("serviceReference_invalidate")
 		.withParameter("reference", reference);

--- a/libs/framework/src/bundle.c
+++ b/libs/framework/src/bundle.c
@@ -274,7 +274,6 @@ celix_status_t bundle_update(bundle_pt bundle, const char *inputFile) {
 		status = bundle_isSystemBundle(bundle, &systemBundle);
 		if (status == CELIX_SUCCESS) {
 			if (systemBundle) {
-				// #TODO: Support framework update
 				status = CELIX_BUNDLE_EXCEPTION;
 			} else {
 				status = framework_updateBundle(bundle->framework, bundle, inputFile);
@@ -461,8 +460,6 @@ celix_status_t bundle_closeAndDelete(bundle_pt bundle) {
 
 celix_status_t bundle_closeRevisions(bundle_pt bundle) {
     celix_status_t status = CELIX_SUCCESS;
-
-    // TODO implement this
     return status;
 }
 

--- a/libs/framework/src/bundle_context.c
+++ b/libs/framework/src/bundle_context.c
@@ -84,8 +84,6 @@ celix_status_t bundleContext_destroy(bundle_context_pt context) {
 	    bundleContext_cleanupServiceTrackers(context);
         bundleContext_cleanupServiceTrackerTrackers(context);
 
-        //TODO cleanup service registrations
-
 	    //NOTE still present service registrations will be cleared during bundle stop in the
 	    //service registry (serviceRegistry_clearServiceRegistrations).
         celixThreadMutex_unlock(&context->mutex);
@@ -572,8 +570,6 @@ long celix_bundleContext_trackBundlesWithOptions(
         trackerId = entry->trackerId;
 
         //loop through all already installed bundles.
-        // FIXME there is a race condition between installing the listener and looping through the started bundles.
-        // NOTE move this to the framework, so that the framework can ensure locking to ensure not bundles is missed.
         if (entry->opts.onStarted != NULL) {
             celix_framework_useBundles(ctx->framework, entry->opts.includeFrameworkBundle, entry->opts.callbackHandle, entry->opts.onStarted);
         }
@@ -758,7 +754,7 @@ bool celix_bundleContext_stopBundle(celix_bundle_context_t *ctx, long bundleId) 
 
 static void bundleContext_uninstallBundleCallback(void *handle, const bundle_t *c_bnd) {
     bool *uninstalled = handle;
-    bundle_t *bnd = (bundle_t*)c_bnd; //TODO use mute-able variant ??
+    bundle_t *bnd = (bundle_t*)c_bnd;
     if (celix_bundle_getState(bnd) == OSGI_FRAMEWORK_BUNDLE_ACTIVE) {
         bundle_stop(bnd);
     }

--- a/libs/framework/src/bundle_context_private.h
+++ b/libs/framework/src/bundle_context_private.h
@@ -16,13 +16,6 @@
  *specific language governing permissions and limitations
  *under the License.
  */
-/*
- * bundle_context_private.h
- *
- *  \date       Feb 12, 2013
- *  \author     <a href="mailto:dev@celix.apache.org">Apache Celix Project Team</a>
- *  \copyright  Apache License, Version 2.0
- */
 
 
 #ifndef BUNDLE_CONTEXT_PRIVATE_H_

--- a/libs/framework/src/bundle_revision.c
+++ b/libs/framework/src/bundle_revision.c
@@ -42,7 +42,6 @@ celix_status_t bundleRevision_create(const char *root, const char *location, lon
     if (!revision) {
     	status = CELIX_ENOMEM;
     } else {
-    	// TODO: This overwrites an existing revision, is this supposed to happen?
         int state = mkdir(root, S_IRWXU);
         if ((state != 0) && (errno != EEXIST)) {
             free(revision);
@@ -51,7 +50,6 @@ celix_status_t bundleRevision_create(const char *root, const char *location, lon
             if (inputFile != NULL) {
                 status = extractBundle(inputFile, root);
             } else if (strcmp(location, "inputstream:") != 0) {
-            	// TODO how to handle this correctly?
             	// If location != inputstream, extract it, else ignore it and assume this is a cache entry.
                 status = extractBundle(location, root);
             }

--- a/libs/framework/src/dm_event.c
+++ b/libs/framework/src/dm_event.c
@@ -43,7 +43,6 @@ celix_status_t event_create(dm_event_type_e event_type, bundle_pt bundle, bundle
 	serviceReference_getProperty(reference, OSGI_FRAMEWORK_SERVICE_ID, &serviceIdStr);
 	unsigned long servId = strtoul(serviceIdStr,NULL,10);
 
-	//FIXME service ranking can dynamically change, but service reference can be removed at any time.
 	const char* rankingStr = NULL;
 	serviceReference_getProperty(reference, OSGI_FRAMEWORK_SERVICE_RANKING, &rankingStr);
 	long ranking = rankingStr == NULL ? 0 : atol(rankingStr);

--- a/libs/framework/src/framework.c
+++ b/libs/framework/src/framework.c
@@ -231,7 +231,6 @@ struct request {
 
 typedef struct request *request_pt;
 
-//TODO move to service registry
 typedef struct celix_fw_service_listener_entry {
     //only set during creating
     celix_bundle_t *bundle;
@@ -301,7 +300,6 @@ static inline void listener_waitAndDestroy(celix_framework_t *framework, celix_f
 
 framework_logger_pt logger;
 
-//TODO introduce a counter + mutex to control the freeing of the logger when mutiple threads are running a framework.
 static celix_thread_once_t loggerInit = CELIX_THREAD_ONCE_INIT;
 static void framework_loggerInit(void) {
     logger = malloc(sizeof(*logger));
@@ -324,11 +322,11 @@ celix_status_t framework_create(framework_pt *framework, properties_pt config) {
 
         status = CELIX_DO_IF(status, celixThreadCondition_init(&(*framework)->shutdown.cond, NULL));
         status = CELIX_DO_IF(status, celixThreadMutex_create(&(*framework)->shutdown.mutex, NULL));
-        status = CELIX_DO_IF(status, celixThreadMutex_create(&(*framework)->dispatcher.mutex, NULL));  //TODO refactor to use use count with condition (see serviceListeners)
+        status = CELIX_DO_IF(status, celixThreadMutex_create(&(*framework)->dispatcher.mutex, NULL));
         status = CELIX_DO_IF(status, celixThreadMutex_create(&(*framework)->serviceListenersLock, &attr));
-        status = CELIX_DO_IF(status, celixThreadMutex_create(&(*framework)->frameworkListenersLock, &attr));  //TODO refactor to use use count with condition (see serviceListeners)
-        status = CELIX_DO_IF(status, celixThreadMutex_create(&(*framework)->bundleListenerLock, NULL));  //TODO refactor to use use count with condition (see serviceListeners)
-        status = CELIX_DO_IF(status, celixThreadMutex_create(&(*framework)->installedBundles.mutex, NULL));  //TODO refactor to use use count with condition (see serviceListeners)
+        status = CELIX_DO_IF(status, celixThreadMutex_create(&(*framework)->frameworkListenersLock, &attr));
+        status = CELIX_DO_IF(status, celixThreadMutex_create(&(*framework)->bundleListenerLock, NULL));
+        status = CELIX_DO_IF(status, celixThreadMutex_create(&(*framework)->installedBundles.mutex, NULL));
         status = CELIX_DO_IF(status, celixThreadCondition_init(&(*framework)->dispatcher.cond, NULL));
         if (status == CELIX_SUCCESS) {
             (*framework)->bundle = NULL;
@@ -352,8 +350,7 @@ celix_status_t framework_create(framework_pt *framework, properties_pt config) {
             status = CELIX_DO_IF(status, bundle_getBundleId((*framework)->bundle, &(*framework)->bundleId));
             status = CELIX_DO_IF(status, bundle_setFramework((*framework)->bundle, (*framework)));
             if (status == CELIX_SUCCESS) {
-                //
-                //TODO set group (*framework)->bundle
+                //nop
             } else {
                 status = CELIX_FRAMEWORK_EXCEPTION;
                 fw_logCode((*framework)->logger, OSGI_FRAMEWORK_LOG_ERROR, status, "Could not create framework");
@@ -656,7 +653,6 @@ static void framework_autoStartConfiguredBundles(bundle_context_t *fwCtx) {
     for (int i = 0; i < len; ++i) {
         bundleContext_getProperty(fwCtx, celixKeys[i], &autoStart);
         if (autoStart == NULL) {
-            //trying cosgi.auto.start.<level> variants. TODO make this prop deprecated -> warning
             bundleContext_getProperty(fwCtx, cosgiKeys[i], &autoStart);
         }
         if (autoStart != NULL) {
@@ -780,7 +776,7 @@ celix_status_t fw_installBundle2(framework_pt framework, bundle_pt * bundle, lon
         return CELIX_FILE_IO_EXCEPTION;
     }
 
-    //increase use count of framework bundle to prevent a stop. TODO is concurrent installing of bundles supported? -> else need another lock
+    //increase use count of framework bundle to prevent a stop.
     fw_bundleEntry_increaseUseCount(framework, framework->bundleId);
 
   	status = CELIX_DO_IF(status, bundle_getState(framework->bundle, &state));
@@ -1158,7 +1154,6 @@ celix_status_t fw_stopBundle(framework_pt framework, bundle_pt bundle, bool reco
 
                     serviceRegistry_clearReferencesFor(framework->registry, bundle);
                 }
-                // #TODO remove listeners for bundle
 
                 if (context != NULL) {
                     status = CELIX_DO_IF(status, bundleContext_destroy(context));
@@ -1230,7 +1225,6 @@ celix_status_t fw_uninstallBundle(framework_pt framework, bundle_pt bundle) {
 
     status = CELIX_DO_IF(status, fw_stopBundle(framework, bundle, true));
 
-    // TODO Unload all libraries for transition to unresolved
     bundle_archive_t *archive = NULL;
     bundle_revision_t *revision = NULL;
 	array_list_pt handles = NULL;
@@ -1623,50 +1617,13 @@ celix_status_t framework_ungetService(framework_pt framework, bundle_pt bundle, 
 }
 
 void fw_addServiceListener(framework_pt framework, bundle_pt bundle, celix_service_listener_t *listener, const char* sfilter) {
-	array_list_pt listenerHooks = NULL;
-	unsigned int i;
-
     celix_fw_service_listener_entry_t *fwListener = listener_create(bundle, sfilter, listener);
-
-	bundle_context_t *context = NULL;
 
     celixThreadMutex_lock(&framework->serviceListenersLock);
 	arrayList_add(framework->serviceListeners, fwListener);
     celixThreadMutex_unlock(&framework->serviceListenersLock);
 
-    //TODO lock listeners hooks?
-	celix_status_t  status = serviceRegistry_getListenerHooks(framework->registry, framework->bundle, &listenerHooks);
-
-	if (status == CELIX_SUCCESS) {
-        struct listener_hook_info info;
-
-        bundle_getContext(bundle, &context);
-        info.context = context;
-        info.removed = false;
-        info.filter = sfilter;
-
-        for (i = 0; i < arrayList_size(listenerHooks); i++) {
-            service_reference_pt ref = (service_reference_pt) arrayList_get(listenerHooks, i);
-            listener_hook_service_pt hook = NULL;
-            array_list_pt infos = NULL;
-            bool ungetResult = false;
-
-            status = fw_getService(framework, framework->bundle, ref, (const void **) &hook);
-
-            if (status == CELIX_SUCCESS && hook != NULL) {
-                arrayList_create(&infos);
-                arrayList_add(infos, &info);
-                hook->added(hook->handle, infos);
-                serviceRegistry_ungetService(framework->registry, framework->bundle, ref, &ungetResult);
-                serviceRegistry_ungetServiceReference(framework->registry, framework->bundle, ref);
-                arrayList_destroy(infos);
-            } else {
-                fw_logCode(framework->logger, OSGI_FRAMEWORK_LOG_ERROR, status, "Could not retrieve hook service.");
-            }
-        }
-
-        arrayList_destroy(listenerHooks);
-    }
+    serviceRegistry_callHooksForListenerFilter(framework->registry, bundle, sfilter, false);
 }
 
 void fw_removeServiceListener(framework_pt framework, bundle_pt bundle, celix_service_listener_t *listener) {
@@ -1690,35 +1647,9 @@ void fw_removeServiceListener(framework_pt framework, bundle_pt bundle, celix_se
 
     if (match != NULL) {
         //invoke listener hooks
-
-        bundle_context_pt lContext = NULL;
-
-        struct listener_hook_info info;
-        bundle_getContext(match->bundle, &lContext);
-        info.context = lContext;
-        filter_getString(match->filter, &info.filter);
-        info.removed = true;
-
-        array_list_pt listenerHooks = NULL;
-        serviceRegistry_getListenerHooks(framework->registry, framework->bundle, &listenerHooks);
-        for (i = 0; i < arrayList_size(listenerHooks); i++) {
-            service_reference_pt ref = (service_reference_pt) arrayList_get(listenerHooks, i);
-            listener_hook_service_pt hook = NULL;
-            array_list_pt infos = NULL;
-            bool ungetResult;
-
-            fw_getService(framework, framework->bundle, ref, (const void **) &hook);
-
-            if (hook != NULL) {
-                arrayList_create(&infos);
-                arrayList_add(infos, &info);
-                hook->removed(hook->handle, infos);
-                serviceRegistry_ungetService(framework->registry, framework->bundle, ref, &ungetResult);
-                serviceRegistry_ungetServiceReference(framework->registry, framework->bundle, ref);
-                arrayList_destroy(infos);
-            }
-        }
-        arrayList_destroy(listenerHooks);
+        const char *filter;
+        filter_getString(match->filter, &filter);
+        serviceRegistry_callHooksForListenerFilter(framework->registry, bundle, filter, true);
     }
 
     if (match != NULL) {

--- a/libs/framework/src/service_registry.c
+++ b/libs/framework/src/service_registry.c
@@ -16,13 +16,7 @@
  *specific language governing permissions and limitations
  *under the License.
  */
-/*
- * service_registry.c
- *
- *  \date       Aug 6, 2010
- *  \author    	<a href="mailto:dev@celix.apache.org">Apache Celix Project Team</a>
- *  \copyright	Apache License, Version 2.0
- */
+
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
@@ -54,6 +48,11 @@ static celix_status_t serviceRegistry_setReferenceStatus(service_registry_pt reg
                                                   bool deleted);
 static celix_status_t serviceRegistry_getUsingBundles(service_registry_pt registry, service_registration_pt reg, array_list_pt *bundles);
 static celix_status_t serviceRegistry_getServiceReference_internal(service_registry_pt registry, bundle_pt owner, service_registration_pt registration, service_reference_pt *out);
+
+static celix_service_registry_listener_hook_entry_t* celix_createHookEntry(long svcId, celix_listener_hook_service_t*);
+static void celix_waitAndDestroyHookEntry(celix_service_registry_listener_hook_entry_t *entry);
+static void celix_increaseCountHook(celix_service_registry_listener_hook_entry_t *entry);
+static void celix_decreaseCountHook(celix_service_registry_listener_hook_entry_t *entry);
 
 celix_status_t serviceRegistry_create(framework_pt framework, serviceChanged_function_pt serviceChanged, service_registry_pt *out) {
 	celix_status_t status;
@@ -127,9 +126,12 @@ celix_status_t serviceRegistry_destroy(service_registry_pt registry) {
     hashMap_destroy(registry->serviceReferences, false, false);
 
     //destroy listener hooks
-    size = arrayList_size(registry->listenerHooks);
-    if (size == 0)
-    	arrayList_destroy(registry->listenerHooks);
+    size = celix_arrayList_size(registry->listenerHooks);
+    for (int i = 0; i < celix_arrayList_size(registry->listenerHooks); ++i) {
+        celix_service_registry_listener_hook_entry_t *entry = celix_arrayList_get(registry->listenerHooks, i);
+        celix_waitAndDestroyHookEntry(entry);
+    }
+    celix_arrayList_destroy(registry->listenerHooks);
 
     hashMap_destroy(registry->deletedServiceReferences, false, false);
 
@@ -737,7 +739,9 @@ static celix_status_t serviceRegistry_addHooks(service_registry_pt registry, con
 
 	if (strcmp(OSGI_FRAMEWORK_LISTENER_HOOK_SERVICE_NAME, serviceName) == 0) {
         celixThreadRwlock_writeLock(&registry->lock);
-		arrayList_add(registry->listenerHooks, registration);
+        long svcId = serviceRegistration_getServiceId(registration);
+        celix_service_registry_listener_hook_entry_t *entry = celix_createHookEntry(svcId, (celix_listener_hook_service_t*)serviceObject);
+		arrayList_add(registry->listenerHooks, entry);
         celixThreadRwlock_unlock(&registry->lock);
 	}
 
@@ -748,13 +752,27 @@ static celix_status_t serviceRegistry_removeHook(service_registry_pt registry, s
 	celix_status_t status = CELIX_SUCCESS;
 	const char* serviceName = NULL;
 
+	celix_service_registry_listener_hook_entry_t *removedEntry = NULL;
+
 	properties_pt props = NULL;
 	serviceRegistration_getProperties(registration, &props);
 	serviceName = properties_get(props, (char *) OSGI_FRAMEWORK_OBJECTCLASS);
+	long svcId = serviceRegistration_getServiceId(registration);
 	if (strcmp(OSGI_FRAMEWORK_LISTENER_HOOK_SERVICE_NAME, serviceName) == 0) {
         celixThreadRwlock_writeLock(&registry->lock);
-		arrayList_removeElement(registry->listenerHooks, registration);
+        for (int i = 0; i < celix_arrayList_size(registry->listenerHooks); ++i) {
+            celix_service_registry_listener_hook_entry_t *visit = celix_arrayList_get(registry->listenerHooks, i);
+            if (visit->svcId == svcId) {
+                removedEntry = visit;
+                celix_arrayList_removeAt(registry->listenerHooks, i);
+                break;
+            }
+        }
         celixThreadRwlock_unlock(&registry->lock);
+	}
+
+	if (removedEntry != NULL) {
+        celix_waitAndDestroyHookEntry(removedEntry);
 	}
 
 	return status;
@@ -776,37 +794,22 @@ void serviceRegistry_callHooksForListenerFilter(service_registry_pt registry, ce
     celixThreadRwlock_readLock(&registry->lock);
     unsigned size = arrayList_size(registry->listenerHooks);
     for (int i = 0; i < size; ++i) {
-        service_registration_pt registration = arrayList_get(registry->listenerHooks, i);
-        if (registration != NULL) {
-            serviceRegistration_retain(registration);
-            celix_arrayList_add(hookRegistrations, registration);
+        celix_service_registry_listener_hook_entry_t* entry = arrayList_get(registry->listenerHooks, i);
+        if (entry != NULL) {
+            celix_increaseCountHook(entry); //increate use count to ensure the hook cannot be removed, untill used
+            celix_arrayList_add(hookRegistrations, entry);
         }
     }
     celixThreadRwlock_unlock(&registry->lock);
 
     for (int i = 0; i < arrayList_size(hookRegistrations); ++i) {
-        service_registration_pt reg = celix_arrayList_get(hookRegistrations, i);
-        service_reference_pt ref;
-        serviceRegistry_getServiceReference(registry, owner, reg, &ref);
-
-        listener_hook_service_pt hook = NULL;
-        celix_status_t status = serviceRegistry_getService(registry, owner, ref, (const void **) &hook);
-
-        if (status == CELIX_SUCCESS && hook != NULL) {
-            if (removed) {
-                hook->removed(hook->handle, infos);
-            } else {
-                hook->added(hook->handle, infos);
-            }
-
-            bool ungetResult = false;
-            serviceRegistry_ungetService(registry, owner, ref, &ungetResult);
-            serviceRegistry_ungetServiceReference(registry, owner, ref);
+        celix_service_registry_listener_hook_entry_t* entry = celix_arrayList_get(hookRegistrations, i);
+        if (removed) {
+            entry->hook->removed(entry->hook->handle, infos);
         } else {
-            fw_logCode(logger, OSGI_FRAMEWORK_LOG_ERROR, status, "Could not retrieve hook service.");
+            entry->hook->added(entry->hook->handle, infos);
         }
-
-        serviceRegistration_release(reg);
+        celix_decreaseCountHook(entry); //done using hook. decrease count
     }
     celix_arrayList_destroy(hookRegistrations);
     celix_arrayList_destroy(infos);
@@ -867,4 +870,50 @@ celix_serviceRegistry_registerServiceFactory(
         celix_properties_t* props,
         service_registration_t **registration) {
     return serviceRegistry_registerServiceInternal(reg, (celix_bundle_t*)bnd, serviceName, (const void *) factory, props, CELIX_FACTORY_SERVICE, registration);
+}
+
+static celix_service_registry_listener_hook_entry_t* celix_createHookEntry(long svcId, celix_listener_hook_service_t *hook) {
+    celix_service_registry_listener_hook_entry_t* entry = calloc(1, sizeof(*entry));
+    entry->svcId = svcId;
+    entry->hook = hook;
+    celixThreadMutex_create(&entry->mutex, NULL);
+    celixThreadCondition_init(&entry->cond, NULL);
+    return entry;
+}
+
+static void celix_waitAndDestroyHookEntry(celix_service_registry_listener_hook_entry_t *entry) {
+    if (entry != NULL) {
+        celixThreadMutex_lock(&entry->mutex);
+        int waitCount = 0;
+        while (entry->count > 0) {
+            celixThreadCondition_timedwaitRelative(&entry->cond, &entry->mutex, 1, 0); //wait for 1 second
+            waitCount += 1;
+            if (waitCount >= 5) {
+                fw_log(logger, OSGI_FRAMEWORK_LOG_WARNING,
+                        "Still waiting for service listener hook use count to become zero. Waiting for %i seconds. Use Count is %i, svc id is %li", waitCount, (int)entry->count, entry->svcId);
+            }
+        }
+        celixThreadMutex_unlock(&entry->mutex);
+
+        //done waiting, use count is on 0
+        celixThreadCondition_destroy(&entry->cond);
+        celixThreadMutex_destroy(&entry->mutex);
+        free(entry);
+    }
+}
+static void celix_increaseCountHook(celix_service_registry_listener_hook_entry_t *entry) {
+    if (entry != NULL) {
+        celixThreadMutex_lock(&entry->mutex);
+        entry->count += 1;
+        celixThreadCondition_broadcast(&entry->cond);
+        celixThreadMutex_unlock(&entry->mutex);
+    }
+}
+static void celix_decreaseCountHook(celix_service_registry_listener_hook_entry_t *entry) {
+    if (entry != NULL) {
+        celixThreadMutex_lock(&entry->mutex);
+        entry->count -= 1;
+        celixThreadCondition_broadcast(&entry->cond);
+        celixThreadMutex_unlock(&entry->mutex);
+    }
 }

--- a/libs/framework/src/service_registry_private.h
+++ b/libs/framework/src/service_registry_private.h
@@ -30,6 +30,8 @@
 
 #include "registry_callback_private.h"
 #include "service_registry.h"
+#include "listener_hook_service.h"
+#include "service_reference.h"
 
 struct celix_serviceRegistry {
 	framework_pt framework;
@@ -44,10 +46,18 @@ struct celix_serviceRegistry {
 	serviceChanged_function_pt serviceChanged;
 	unsigned long currentServiceId;
 
-	array_list_pt listenerHooks;
+	array_list_pt listenerHooks; //celix_service_registry_listener_hook_entry_t*
 
 	celix_thread_rwlock_t lock;
 };
+
+typedef struct celix_service_registry_listener_hook_entry {
+    long svcId;
+    celix_listener_hook_service_t *hook;
+    celix_thread_mutex_t mutex; //protects below
+    celix_thread_cond_t cond;
+    unsigned int count;
+} celix_service_registry_listener_hook_entry_t;
 
 typedef enum reference_status_enum {
 	REF_ACTIVE,


### PR DESCRIPTION
Fixes a race condition issue with adding/removing service listener hooks (service trackers). 

Also fixes an mem issue in the json serialiser and refactors the pubsub tests to use service instead of a global pointer.