### PR TITLE
CELIX-468

### DIFF
--- a/bundles/config_admin/config_admin_tst/config_admin_test.cpp
+++ b/bundles/config_admin/config_admin_tst/config_admin_test.cpp
@@ -37,7 +37,7 @@ extern "C" {
 #include "array_list.h"
 
 #include "celix_launcher.h"
-#include "constants.h"
+#include "celix_constants.h"
 #include "framework.h"
 #include "configuration_admin.h"
 #include "example_managed_service_impl.h"

--- a/bundles/config_admin/config_admin_tst/example_test/private/src/activator.c
+++ b/bundles/config_admin/config_admin_tst/example_test/private/src/activator.c
@@ -32,7 +32,7 @@
 /* celix.framework */
 #include "bundle_activator.h"
 #include "bundle_context.h"
-#include "constants.h"
+#include "celix_constants.h"
 #include "properties.h"
 #include "utils.h"
 /* celix.utils */

--- a/bundles/config_admin/config_admin_tst/example_test2/private/src/activator.c
+++ b/bundles/config_admin/config_admin_tst/example_test2/private/src/activator.c
@@ -33,7 +33,7 @@
 /* celix.framework */
 #include "bundle_activator.h"
 #include "bundle_context.h"
-#include "constants.h"
+#include "celix_constants.h"
 #include "properties.h"
 #include "utils.h"
 /* celix.utils */

--- a/bundles/config_admin/example/private/src/bundle_activator.c
+++ b/bundles/config_admin/example/private/src/bundle_activator.c
@@ -1,7 +1,7 @@
 #include <stdlib.h>
 #include <pthread.h>
 
-#include <constants.h>
+#include "celix_constants.h"
 #include <bundle_context.h>
 #include <service_tracker.h>
 

--- a/bundles/config_admin/service/private/src/configuration_impl.c
+++ b/bundles/config_admin/service/private/src/configuration_impl.c
@@ -37,7 +37,7 @@
 
 /* celix.framework */
 #include "bundle.h"
-#include "constants.h"
+#include "celix_constants.h"
 #include "utils.h"
 /* celix.framework_patch*/
 #include "framework_patch.h"

--- a/bundles/config_admin/service/private/src/managed_service_tracker.c
+++ b/bundles/config_admin/service/private/src/managed_service_tracker.c
@@ -36,7 +36,7 @@
 /* celix.utils */
 #include "hash_map.h"
 /* celix.framework */
-#include "constants.h"
+#include "celix_constants.h"
 #include "properties.h"
 #include "utils.h"
 #include "service_reference.h"

--- a/bundles/deployment_admin/src/deployment_admin.c
+++ b/bundles/deployment_admin/src/deployment_admin.c
@@ -44,7 +44,7 @@
 #include "deployment_admin.h"
 #include "celix_errno.h"
 #include "bundle_context.h"
-#include "constants.h"
+#include "celix_constants.h"
 #include "deployment_package.h"
 #include "bundle.h"
 #include "utils.h"

--- a/bundles/deployment_admin/src/deployment_package.c
+++ b/bundles/deployment_admin/src/deployment_package.c
@@ -29,7 +29,7 @@
 #include "celix_errno.h"
 
 #include "deployment_package.h"
-#include "constants.h"
+#include "celix_constants.h"
 #include "utils.h"
 #include "bundle_context.h"
 #include "module.h"

--- a/bundles/device_access/device_access/src/device_manager.c
+++ b/bundles/device_access/device_access/src/device_manager.c
@@ -24,7 +24,7 @@
  *  \copyright	Apache License, Version 2.0
  */
 #include <stdlib.h>
-#include <constants.h>
+#include "celix_constants.h"
 #include <string.h>
 
 #include "device_manager.h"

--- a/bundles/device_access/device_access/src/driver_attributes.c
+++ b/bundles/device_access/device_access/src/driver_attributes.c
@@ -31,7 +31,7 @@
 #include "celixbool.h"
 #include "driver_loader.h"
 #include "device.h"
-#include "constants.h"
+#include "celix_constants.h"
 
 struct driver_attributes {
 	bundle_pt bundle;

--- a/bundles/device_access/device_access/src/driver_matcher.c
+++ b/bundles/device_access/device_access/src/driver_matcher.c
@@ -26,7 +26,7 @@
 #include <stdlib.h>
 
 #include "hash_map.h"
-#include "constants.h"
+#include "celix_constants.h"
 
 #include "driver_matcher.h"
 #include "log_helper.h"

--- a/bundles/event_admin/event_admin/private/include/event_admin_impl.h
+++ b/bundles/event_admin/event_admin/private/include/event_admin_impl.h
@@ -30,7 +30,7 @@
 #include <string.h>
 #include "celix_errno.h"
 #include "bundle_context.h"
-#include "constants.h"
+#include "celix_constants.h"
 #include "event_constants.h"
 #include "event_admin.h"
 #include "event_handler.h"

--- a/bundles/http_admin/test/test/http_admin_info_tests.cc
+++ b/bundles/http_admin/test/test/http_admin_info_tests.cc
@@ -27,7 +27,7 @@
 
 #include <CppUTest/TestHarness.h>
 #include <CppUTestExt/MockSupport.h>
-#include <constants.h>
+#include "celix_constants.h"
 
 extern celix_framework_t *fw;
 

--- a/bundles/http_admin/test/test/http_websocket_tests.cc
+++ b/bundles/http_admin/test/test/http_websocket_tests.cc
@@ -35,7 +35,7 @@
 
 #include <CppUTest/TestHarness.h>
 #include <CppUTestExt/MockSupport.h>
-#include <constants.h>
+#include "celix_constants.h"
 
 #define HTTP_PORT 8000
 

--- a/bundles/logging/log_service/src/log_service_activator.c
+++ b/bundles/logging/log_service/src/log_service_activator.c
@@ -26,7 +26,7 @@
 
 #include <stdlib.h>
 #include <string.h>
-#include <constants.h>
+#include "celix_constants.h"
 
 #include "bundle_activator.h"
 #include "log_service_impl.h"

--- a/bundles/pubsub/pubsub_admin_tcp/src/pubsub_tcp_topic_sender.c
+++ b/bundles/pubsub/pubsub_admin_tcp/src/pubsub_tcp_topic_sender.c
@@ -32,7 +32,7 @@
 #include "pubsub_tcp_common.h"
 #include "pubsub_endpoint.h"
 #include <uuid/uuid.h>
-#include <constants.h>
+#include "celix_constants.h"
 #include <signal.h>
 
 #define FIRST_SEND_DELAY_IN_SECONDS             2

--- a/bundles/pubsub/pubsub_admin_websocket/src/pubsub_websocket_topic_sender.c
+++ b/bundles/pubsub/pubsub_admin_websocket/src/pubsub_websocket_topic_sender.c
@@ -29,7 +29,7 @@
 #include "pubsub_psa_websocket_constants.h"
 #include "pubsub_websocket_common.h"
 #include <uuid/uuid.h>
-#include <constants.h>
+#include "celix_constants.h"
 #include "http_admin/api.h"
 #include "civetweb.h"
 

--- a/bundles/pubsub/pubsub_admin_zmq/src/pubsub_zmq_topic_sender.c
+++ b/bundles/pubsub/pubsub_admin_zmq/src/pubsub_zmq_topic_sender.c
@@ -31,7 +31,7 @@
 #include "pubsub_psa_zmq_constants.h"
 #include "pubsub_zmq_common.h"
 #include <uuid/uuid.h>
-#include <constants.h>
+#include "celix_constants.h"
 
 #define FIRST_SEND_DELAY_IN_SECONDS             2
 #define ZMQ_BIND_MAX_RETRY                      10

--- a/bundles/pubsub/pubsub_discovery/src/psd_activator.c
+++ b/bundles/pubsub/pubsub_discovery/src/psd_activator.c
@@ -26,7 +26,7 @@
 
 #include "celix_bundle_context.h"
 #include "celix_bundle_activator.h"
-#include "constants.h"
+#include "celix_constants.h"
 #include "celix_log.h"
 
 #include "pubsub_listeners.h"

--- a/bundles/pubsub/pubsub_discovery/src/pubsub_discovery_impl.c
+++ b/bundles/pubsub/pubsub_discovery/src/pubsub_discovery_impl.c
@@ -30,7 +30,7 @@
 
 #include "celix_bundle_context.h"
 #include "celix_properties.h"
-#include "constants.h"
+#include "celix_constants.h"
 #include "celix_threads.h"
 #include "array_list.h"
 #include "utils.h"

--- a/bundles/pubsub/pubsub_spi/src/pubsub_endpoint.c
+++ b/bundles/pubsub/pubsub_spi/src/pubsub_endpoint.c
@@ -34,7 +34,7 @@
 #include "celix_log.h"
 
 #include "pubsub_endpoint.h"
-#include "constants.h"
+#include "celix_constants.h"
 
 #include "pubsub_utils.h"
 

--- a/bundles/pubsub/pubsub_spi/src/pubsub_utils.c
+++ b/bundles/pubsub/pubsub_spi/src/pubsub_utils.c
@@ -20,7 +20,7 @@
 #include <string.h>
 #include <stdlib.h>
 
-#include "constants.h"
+#include "celix_constants.h"
 #include "celix_filter.h"
 #include "filter.h"
 

--- a/bundles/pubsub/pubsub_spi/src/pubsub_utils_match.c
+++ b/bundles/pubsub/pubsub_spi/src/pubsub_utils_match.c
@@ -28,7 +28,7 @@
 #include "pubsub_admin.h"
 
 #include "pubsub_utils.h"
-#include "constants.h"
+#include "celix_constants.h"
 
 static double getPSAScore(const char *requested_admin, const char *request_qos, const char *adminType, double sampleScore, double controlScore, double defaultScore) {
     double score;

--- a/bundles/pubsub/pubsub_topology_manager/src/pubsub_topology_manager.c
+++ b/bundles/pubsub/pubsub_topology_manager/src/pubsub_topology_manager.c
@@ -30,7 +30,7 @@
 #include "hash_map.h"
 #include "celix_array_list.h"
 #include "celix_bundle_context.h"
-#include "constants.h"
+#include "celix_constants.h"
 #include "utils.h"
 #include "log_service.h"
 #include "log_helper.h"

--- a/bundles/pubsub/test/test/loopback_activator.c
+++ b/bundles/pubsub/test/test/loopback_activator.c
@@ -19,7 +19,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <constants.h>
+#include "celix_constants.h"
 #include <unistd.h>
 
 #include "celix_api.h"

--- a/bundles/pubsub/test/test/sut_activator.c
+++ b/bundles/pubsub/test/test/sut_activator.c
@@ -19,7 +19,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <constants.h>
+#include "celix_constants.h"
 #include <unistd.h>
 
 #include "celix_api.h"

--- a/bundles/pubsub/test/test/sut_endpoint_activator.c
+++ b/bundles/pubsub/test/test/sut_endpoint_activator.c
@@ -19,7 +19,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <constants.h>
+#include "celix_constants.h"
 #include <unistd.h>
 
 #include "celix_api.h"

--- a/bundles/remote_services/discovery_common/src/discovery_activator.c
+++ b/bundles/remote_services/discovery_common/src/discovery_activator.c
@@ -31,7 +31,7 @@
 
 #include "bundle_activator.h"
 #include "service_tracker.h"
-#include "constants.h"
+#include "celix_constants.h"
 
 #include "log_helper.h"
 #include "discovery.h"

--- a/bundles/remote_services/discovery_common/src/endpoint_descriptor_writer.c
+++ b/bundles/remote_services/discovery_common/src/endpoint_descriptor_writer.c
@@ -28,7 +28,7 @@
 #include <string.h>
 #include <libxml/xmlwriter.h>
 
-#include "constants.h"
+#include "celix_constants.h"
 #include "remote_constants.h"
 
 #include "endpoint_description.h"

--- a/bundles/remote_services/discovery_etcd/src/discovery_impl.c
+++ b/bundles/remote_services/discovery_etcd/src/discovery_impl.c
@@ -30,7 +30,7 @@
 #include <netdb.h>
 #include <netinet/in.h>
 
-#include "constants.h"
+#include "celix_constants.h"
 #include "celix_threads.h"
 #include "bundle_context.h"
 #include "array_list.h"

--- a/bundles/remote_services/discovery_etcd/src/etcd_watcher.c
+++ b/bundles/remote_services/discovery_etcd/src/etcd_watcher.c
@@ -31,7 +31,7 @@
 
 #include "log_helper.h"
 #include "log_service.h"
-#include "constants.h"
+#include "celix_constants.h"
 #include "utils.h"
 #include "discovery.h"
 #include "discovery_impl.h"

--- a/bundles/remote_services/discovery_shm/src/discovery_impl.c
+++ b/bundles/remote_services/discovery_shm/src/discovery_impl.c
@@ -30,7 +30,7 @@
 #include <netdb.h>
 #include <netinet/in.h>
 
-#include "constants.h"
+#include "celix_constants.h"
 #include "celix_threads.h"
 #include "bundle_context.h"
 #include "array_list.h"

--- a/bundles/remote_services/discovery_shm/src/discovery_shmWatcher.c
+++ b/bundles/remote_services/discovery_shm/src/discovery_shmWatcher.c
@@ -32,7 +32,7 @@
 
 
 #include "celix_log.h"
-#include "constants.h"
+#include "celix_constants.h"
 #include "discovery_impl.h"
 
 #include "discovery_shm.h"

--- a/bundles/remote_services/remote_service_admin_dfi/src/export_registration_dfi.c
+++ b/bundles/remote_services/remote_service_admin_dfi/src/export_registration_dfi.c
@@ -25,7 +25,7 @@
 #include <service_tracker_customizer.h>
 #include <service_tracker.h>
 #include <json_rpc.h>
-#include "constants.h"
+#include "celix_constants.h"
 #include "export_registration_dfi.h"
 #include "dfi_utils.h"
 

--- a/bundles/remote_services/remote_service_admin_dfi/src/remote_service_admin_dfi.c
+++ b/bundles/remote_services/remote_service_admin_dfi/src/remote_service_admin_dfi.c
@@ -37,7 +37,7 @@
 #include "json_rpc.h"
 
 #include "remote_constants.h"
-#include "constants.h"
+#include "celix_constants.h"
 #include "civetweb.h"
 
 #include "remote_service_admin_dfi_constants.h"

--- a/bundles/remote_services/remote_service_admin_shm/private/src/remote_service_admin_impl.c
+++ b/bundles/remote_services/remote_service_admin_shm/private/src/remote_service_admin_impl.c
@@ -41,7 +41,7 @@
 #include "export_registration_impl.h"
 #include "import_registration_impl.h"
 #include "remote_constants.h"
-#include "constants.h"
+#include "celix_constants.h"
 #include "utils.h"
 #include "bundle_context.h"
 #include "bundle.h"

--- a/bundles/remote_services/rsa_common/src/endpoint_description.c
+++ b/bundles/remote_services/rsa_common/src/endpoint_description.c
@@ -31,7 +31,7 @@
 
 #include "endpoint_description.h"
 #include "remote_constants.h"
-#include "constants.h"
+#include "celix_constants.h"
 
 static celix_status_t endpointDescription_verifyLongProperty(celix_properties_t *properties, char *propertyName, unsigned long *longProperty);
 

--- a/bundles/remote_services/rsa_common/src/export_registration_impl.c
+++ b/bundles/remote_services/rsa_common/src/export_registration_impl.c
@@ -25,7 +25,7 @@
  */
 #include <stdlib.h>
 
-#include "constants.h"
+#include "celix_constants.h"
 
 #include "celix_errno.h"
 

--- a/bundles/remote_services/rsa_common/src/import_registration_impl.c
+++ b/bundles/remote_services/rsa_common/src/import_registration_impl.c
@@ -27,7 +27,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include <constants.h>
+#include "celix_constants.h"
 
 #include "celix_errno.h"
 

--- a/bundles/remote_services/topology_manager/src/activator.c
+++ b/bundles/remote_services/topology_manager/src/activator.c
@@ -28,7 +28,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "constants.h"
+#include "celix_constants.h"
 #include "bundle_activator.h"
 #include "service_tracker.h"
 #include "service_registration.h"

--- a/bundles/remote_services/topology_manager/src/topology_manager.c
+++ b/bundles/remote_services/topology_manager/src/topology_manager.c
@@ -30,7 +30,7 @@
 #include "celixbool.h"
 #include "topology_manager.h"
 #include "bundle_context.h"
-#include "constants.h"
+#include "celix_constants.h"
 #include "bundle.h"
 #include "remote_service_admin.h"
 #include "remote_constants.h"

--- a/bundles/remote_services/topology_manager/tms_tst/disc_mock/disc_mock_activator.c
+++ b/bundles/remote_services/topology_manager/tms_tst/disc_mock/disc_mock_activator.c
@@ -29,7 +29,7 @@
 #include "celix_errno.h"
 
 #include "disc_mock_service.h"
-#include "constants.h"
+#include "celix_constants.h"
 #include "remote_constants.h"
 
 celix_status_t discovery_endpointAdded(void *handle, endpoint_description_t *endpoint, char *matchedFilter);

--- a/bundles/remote_services/topology_manager/tms_tst/tms_tests.cpp
+++ b/bundles/remote_services/topology_manager/tms_tst/tms_tests.cpp
@@ -42,7 +42,7 @@ extern "C" {
 #include <jansson.h>
 
 #include "celix_launcher.h"
-#include "constants.h"
+#include "celix_constants.h"
 #include "endpoint_description.h"
 #include "framework.h"
 #include "topology_manager.h"

--- a/bundles/shell/shell/src/activator.c
+++ b/bundles/shell/shell/src/activator.c
@@ -30,7 +30,7 @@
 #include "bundle_activator.h"
 #include "std_commands.h"
 #include "service_tracker.h"
-#include "constants.h"
+#include "celix_constants.h"
 
 #define NUMBER_OF_COMMANDS 11
 

--- a/bundles/shell/shell_bonjour/private/src/activator.c
+++ b/bundles/shell/shell_bonjour/private/src/activator.c
@@ -30,7 +30,7 @@
 
 #include "bundle_activator.h"
 #include "bundle_context.h"
-#include "constants.h"
+#include "celix_constants.h"
 
 #include "bonjour_shell.h"
 

--- a/examples/celix-examples/services_example_c/src/dynamic_consumer_example.c
+++ b/examples/celix-examples/services_example_c/src/dynamic_consumer_example.c
@@ -21,7 +21,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <constants.h>
+#include "celix_constants.h"
 
 #include "example_calc.h"
 #include <celix_api.h>

--- a/libs/dfi/src/dyn_avpr_function.c
+++ b/libs/dfi/src/dyn_avpr_function.c
@@ -47,10 +47,9 @@ inline static bool dynAvprFunction_initCif(dyn_function_type * func, size_t nofA
 
 // Section: extern function definitions
 ffi_type * dynType_ffiType(dyn_type *type);
-dyn_type * dynAvprType_parseFromJson(json_t * const root, const char * fqn);
 dyn_type * dynAvprType_createNestedForFunction(dyn_type * store_type, const char* fqn);
 dyn_type * dynAvprType_parseFromTypedJson(json_t * const root, json_t const * const type_entry, const char * namespace);
-void dynAvprType_constructFqn(char* destination, int size, const char * possibleFqn, const char * ns);
+void dynAvprType_constructFqn(char *destination, size_t size, const char *possibleFqn, const char *ns);
 
 // Section: function definitions
 dyn_function_type * dynFunction_parseAvpr(FILE * avprStream, const char * fqn) {
@@ -227,7 +226,7 @@ inline static bool dynAvprFunction_parseArgument(dyn_function_type * func, size_
         return false;
     }
 
-    arg->index = index;
+    arg->index = (int) index;
     arg->type = entry_dyn_type;
     arg->argumentMeta = DYN_FUNCTION_ARGUMENT_META__STD;
 
@@ -256,7 +255,7 @@ inline static bool dynAvprFunction_parseReturn(dyn_function_type * func, size_t 
         return false;
     }
 
-    arg->index = index;
+    arg->index = (int) index;
 
     // Check descriptor type, if it is a struct ({), sequence ([) or a string (t) an extra level of indirection is needed
     int descriptor = dynType_descriptorType(return_dyn_type);
@@ -345,7 +344,7 @@ inline static bool dynAvprFunction_initCif(dyn_function_type * func, size_t nofA
     }
 
     ffi_type *returnType = dynType_ffiType(func->funcReturn);
-    int ffi_result = ffi_prep_cif(&func->cif, FFI_DEFAULT_ABI, nofArguments, returnType, func->ffiArguments);
+    int ffi_result = ffi_prep_cif(&func->cif, FFI_DEFAULT_ABI, (int) nofArguments, returnType, func->ffiArguments);
 
     return ffi_result == FFI_OK;
 }

--- a/libs/dfi/src/dyn_avpr_interface.c
+++ b/libs/dfi/src/dyn_avpr_interface.c
@@ -49,7 +49,7 @@ ffi_type * dynType_ffiType(dyn_type *type);
 dyn_type * dynAvprType_parseFromJson(json_t * const root, const char * fqn);
 dyn_function_type * dynAvprFunction_parseFromJson(json_t * const root, const char * fqn);
 int dynInterface_checkInterface(dyn_interface_type *intf);
-void dynAvprType_constructFqn(char * destination, int size, const char * possibleFqn, const char * ns);
+void dynAvprType_constructFqn(char *destination, size_t size, const char *possibleFqn, const char *ns);
 
 // Function definitions
 dyn_interface_type * dynInterface_parseAvprWithStr(const char * avpr) {

--- a/libs/dfi/test/dyn_avpr_function_tests.cpp
+++ b/libs/dfi/test/dyn_avpr_function_tests.cpp
@@ -176,7 +176,7 @@ const char* theAvprFile = "{ \
                     \"infoFunc\" : {\
                         \"request\" : [ {\
                                 \"name\" : \"arg1\", \
-                                \"type\" : \"Sint\" \
+                                \"type\" : \"int\" \
                             } ],\
                         \"response\" : \"Double\" \
                     }, \
@@ -202,7 +202,7 @@ const char* theAvprFile = "{ \
                     }, \
                     \"stringOutFunc\" : {\
                         \"request\" : [ ],\
-                        \"response\" : \"String\" \
+                        \"response\" : \"string\" \
                     }, \
                     \"structStringOutFunc\" : {\
                         \"request\" : [ ],\

--- a/libs/framework/CMakeLists.txt
+++ b/libs/framework/CMakeLists.txt
@@ -58,11 +58,13 @@ install(DIRECTORY include/ DESTINATION include/celix COMPONENT framework)
 add_library(Celix::framework ALIAS framework)
 
 
+#[[
 if (ENABLE_TESTING)
     find_package(CppUTest REQUIRED)
     include_directories(${CPPUTEST_INCLUDE_DIR})
     add_subdirectory(tst)
 endif()
+#]]
 
 
 celix_subproject(FRAMEWORK_TESTS "Option to build the framework tests" "OFF" DEPS)

--- a/libs/framework/CMakeLists.txt
+++ b/libs/framework/CMakeLists.txt
@@ -58,13 +58,11 @@ install(DIRECTORY include/ DESTINATION include/celix COMPONENT framework)
 add_library(Celix::framework ALIAS framework)
 
 
-#[[
 if (ENABLE_TESTING)
     find_package(CppUTest REQUIRED)
     include_directories(${CPPUTEST_INCLUDE_DIR})
     add_subdirectory(tst)
 endif()
-#]]
 
 
 celix_subproject(FRAMEWORK_TESTS "Option to build the framework tests" "OFF" DEPS)

--- a/libs/framework/include/celix/dm/ServiceDependency_Impl.h
+++ b/libs/framework/include/celix/dm/ServiceDependency_Impl.h
@@ -20,7 +20,7 @@
 #include <vector>
 #include <iostream>
 #include <cstring>
-#include "constants.h"
+#include "celix_constants.h"
 #include "celix_properties.h"
 
 using namespace celix::dm;

--- a/libs/framework/include/celix_api.h
+++ b/libs/framework/include/celix_api.h
@@ -22,7 +22,7 @@
 
 #include "properties.h"
 #include "array_list.h"
-#include "constants.h"
+#include "celix_constants.h"
 #include "bundle.h"
 #include "bundle_context.h"
 #include "framework.h"

--- a/libs/framework/include/celix_constants.h
+++ b/libs/framework/include/celix_constants.h
@@ -17,15 +17,15 @@
  *under the License.
  */
 /*
- * constants.h
+ * celix_constants.h
  *
  *  \date       Apr 29, 2010
  *  \author    	<a href="mailto:dev@celix.apache.org">Apache Celix Project Team</a>
  *  \copyright	Apache License, Version 2.0
  */
 
-#ifndef CONSTANTS_H_
-#define CONSTANTS_H_
+#ifndef CELIX_CONSTANTS_H_
+#define CELIX_CONSTANTS_H_
 
 #include <stdbool.h>
 
@@ -91,4 +91,4 @@ static const char *const CELIX_LOAD_BUNDLES_WITH_NODELETE = "CELIX_LOAD_BUNDLES_
 }
 #endif
 
-#endif /* CONSTANTS_H_ */
+#endif /* CELIX_CONSTANTS_H_ */

--- a/libs/framework/private/test/manifest_parser_test.cpp
+++ b/libs/framework/private/test/manifest_parser_test.cpp
@@ -35,7 +35,7 @@
 extern "C" {
 #include "capability_private.h"
 #include "requirement_private.h"
-#include "constants.h"
+#include "celix_constants.h"
 #include "manifest_parser.h"
 #include "attribute.h"
 #include "celix_log.h"

--- a/libs/framework/private/test/service_reference_test.cpp
+++ b/libs/framework/private/test/service_reference_test.cpp
@@ -35,7 +35,7 @@
 extern "C" {
 #include "service_reference_private.h"
 #include "service_reference.h"
-#include "constants.h"
+#include "celix_constants.h"
 #include "celix_log.h"
 #include "service_registry.h"
 #include "CppUTestExt/MockSupport_c.h"

--- a/libs/framework/private/test/service_registry_test.cpp
+++ b/libs/framework/private/test/service_registry_test.cpp
@@ -34,7 +34,7 @@
 #include "CppUTestExt/MockSupport_c.h"
 
 extern "C" {
-#include "constants.h"
+#include "celix_constants.h"
 #include "listener_hook_service.h"
 #include "service_registry.h"
 #include "service_registry_private.h"

--- a/libs/framework/src/bundle_cache.c
+++ b/libs/framework/src/bundle_cache.c
@@ -28,7 +28,7 @@
 
 #include "bundle_cache_private.h"
 #include "bundle_archive.h"
-#include "constants.h"
+#include "celix_constants.h"
 #include "celix_log.h"
 #include "celix_properties.h"
 #include "celix_utils_api.h"

--- a/libs/framework/src/bundle_context.c
+++ b/libs/framework/src/bundle_context.c
@@ -23,7 +23,7 @@
 #include <string.h>
 #include <utils.h>
 
-#include "constants.h"
+#include "celix_constants.h"
 #include "bundle_context_private.h"
 #include "framework_private.h"
 #include "bundle.h"

--- a/libs/framework/src/celix_library_loader.c
+++ b/libs/framework/src/celix_library_loader.c
@@ -17,7 +17,7 @@
  *under the License.
  */
 
-#include "constants.h"
+#include "celix_constants.h"
 #include "celix_library_loader.h"
 #include <dlfcn.h>
 

--- a/libs/framework/src/dm_component_impl.c
+++ b/libs/framework/src/dm_component_impl.c
@@ -28,7 +28,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "constants.h"
+#include "celix_constants.h"
 #include "filter.h"
 #include "dm_component_impl.h"
 

--- a/libs/framework/src/dm_event.c
+++ b/libs/framework/src/dm_event.c
@@ -26,7 +26,7 @@
  */
 
 #include <stdlib.h>
-#include <constants.h>
+#include "celix_constants.h"
 #include <utils.h>
 
 #include "dm_event.h"

--- a/libs/framework/src/dm_service_dependency.c
+++ b/libs/framework/src/dm_service_dependency.c
@@ -30,7 +30,7 @@
 #include <limits.h>
 #include <assert.h>
 
-#include "constants.h"
+#include "celix_constants.h"
 
 #include "dm_service_dependency_impl.h"
 #include "dm_component_impl.h"

--- a/libs/framework/src/framework.c
+++ b/libs/framework/src/framework.c
@@ -28,7 +28,7 @@
 
 #include "celix_dependency_manager.h"
 #include "framework_private.h"
-#include "constants.h"
+#include "celix_constants.h"
 #include "resolver.h"
 #include "utils.h"
 #include "linked_list_iterator.h"

--- a/libs/framework/src/manifest_parser.c
+++ b/libs/framework/src/manifest_parser.c
@@ -27,7 +27,7 @@
 #include <string.h>
 
 #include "utils.h"
-#include "constants.h"
+#include "celix_constants.h"
 #include "manifest_parser.h"
 #include "capability.h"
 #include "requirement.h"

--- a/libs/framework/src/service_reference.c
+++ b/libs/framework/src/service_reference.c
@@ -25,7 +25,7 @@
  */
 #include <stdio.h>
 #include <stdlib.h>
-#include <constants.h>
+#include "celix_constants.h"
 #include <stdint.h>
 #include <utils.h>
 #include <assert.h>

--- a/libs/framework/src/service_registration.c
+++ b/libs/framework/src/service_registration.c
@@ -29,7 +29,7 @@
 #include <assert.h>
 
 #include "service_registration_private.h"
-#include "constants.h"
+#include "celix_constants.h"
 
 static celix_status_t serviceRegistration_initializeProperties(service_registration_pt registration, properties_pt properties);
 static celix_status_t serviceRegistration_createInternal(registry_callback_t callback, bundle_pt bundle, const char* serviceName, unsigned long serviceId,

--- a/libs/framework/src/service_registry.c
+++ b/libs/framework/src/service_registry.c
@@ -25,7 +25,7 @@
 #include "service_registry_private.h"
 #include "service_registration_private.h"
 #include "listener_hook_service.h"
-#include "constants.h"
+#include "celix_constants.h"
 #include "service_reference_private.h"
 #include "framework_private.h"
 

--- a/libs/framework/src/service_tracker.c
+++ b/libs/framework/src/service_tracker.c
@@ -26,7 +26,7 @@
 
 #include "service_tracker_private.h"
 #include "bundle_context.h"
-#include "constants.h"
+#include "celix_constants.h"
 #include "service_reference.h"
 #include "celix_log.h"
 #include "bundle_context_private.h"


### PR DESCRIPTION
Renamed constants to celix_constants (including ifdef)
Changed all includes to use new file name
@pnoltes the issue mentions that some variables should be prefixed with CELIX, however all variables are already prefixed with either CELIX or OSGI, what would be the best way to proceed?