### PR TITLE
Constify parameters to functions, assorted minor fixes

### DIFF
--- a/bundles/pubsub/pubsub_serializer_avrobin/src/pubsub_avrobin_serializer_impl.c
+++ b/bundles/pubsub/pubsub_serializer_avrobin/src/pubsub_avrobin_serializer_impl.c
@@ -64,9 +64,9 @@ typedef struct pubsub_avrobin_msg_serializer_impl {
     version_pt msgVersion;
 } pubsub_avrobin_msg_serializer_impl_t;
 
-static char *pubsubAvrobinSerializer_getMsgDescriptionDir(celix_bundle_t *bundle);
-static void pubsubAvrobinSerializer_addMsgSerializerFromBundle(const char *root, celix_bundle_t *bundle, hash_map_pt msgTypesMap);
-static void pubsubAvrobinSerializer_fillMsgSerializerMap(hash_map_pt msgTypesMap, celix_bundle_t *bundle);
+static char *pubsubAvrobinSerializer_getMsgDescriptionDir(const celix_bundle_t *bundle);
+static void pubsubAvrobinSerializer_addMsgSerializerFromBundle(const char *root, const celix_bundle_t *bundle, hash_map_pt msgTypesMap);
+static void pubsubAvrobinSerializer_fillMsgSerializerMap(hash_map_pt msgTypesMap, const celix_bundle_t *bundle);
 
 static int pubsubMsgAvrobinSerializer_convertDescriptor(FILE* file_ptr, pubsub_msg_serializer_t* serializer);
 static int pubsubMsgAvrobinSerializer_convertAvpr(FILE* file_ptr, pubsub_msg_serializer_t* serializer, const char* fqn);
@@ -116,7 +116,7 @@ celix_status_t pubsubAvrobinSerializer_destroy(pubsub_avrobin_serializer_t *seri
     return status;
 }
 
-celix_status_t pubsubAvrobinSerializer_createSerializerMap(void *handle, celix_bundle_t *bundle, hash_map_pt *serializerMap) {
+celix_status_t pubsubAvrobinSerializer_createSerializerMap(void *handle, const celix_bundle_t *bundle, hash_map_pt *serializerMap) {
     celix_status_t status = CELIX_SUCCESS;
     pubsub_avrobin_serializer_t *serializer = handle;
 
@@ -214,7 +214,7 @@ static void pubsubMsgAvrobinSerializer_freeMsg(void *handle, void *msg) {
     }
 }
 
-static char *pubsubAvrobinSerializer_getMsgDescriptionDir(celix_bundle_t *bundle) {
+static char *pubsubAvrobinSerializer_getMsgDescriptionDir(const celix_bundle_t *bundle) {
     char *root = NULL;
 
     bool isSystemBundle = false;
@@ -240,7 +240,7 @@ static char *pubsubAvrobinSerializer_getMsgDescriptionDir(celix_bundle_t *bundle
     return root;
 }
 
-static void pubsubAvrobinSerializer_addMsgSerializerFromBundle(const char *root, celix_bundle_t *bundle, hash_map_pt msgTypesMap) {
+static void pubsubAvrobinSerializer_addMsgSerializerFromBundle(const char *root, const celix_bundle_t *bundle, hash_map_pt msgTypesMap) {
     char fqn[MAX_PATH_LEN];
     char path[MAX_PATH_LEN];
     const char* entry_name = NULL;
@@ -305,7 +305,7 @@ static void pubsubAvrobinSerializer_addMsgSerializerFromBundle(const char *root,
     }
 }
 
-static void pubsubAvrobinSerializer_fillMsgSerializerMap(hash_map_pt msgTypesMap, celix_bundle_t *bundle) {
+static void pubsubAvrobinSerializer_fillMsgSerializerMap(hash_map_pt msgTypesMap, const celix_bundle_t *bundle) {
     char *root = NULL;
     char *metaInfPath = NULL;
 

--- a/bundles/pubsub/pubsub_serializer_avrobin/src/pubsub_avrobin_serializer_impl.h
+++ b/bundles/pubsub/pubsub_serializer_avrobin/src/pubsub_avrobin_serializer_impl.h
@@ -34,7 +34,7 @@ typedef struct pubsub_avrobin_serializer pubsub_avrobin_serializer_t;
 celix_status_t pubsubAvrobinSerializer_create(celix_bundle_context_t *context, pubsub_avrobin_serializer_t **serializer);
 celix_status_t pubsubAvrobinSerializer_destroy(pubsub_avrobin_serializer_t *serializer);
 
-celix_status_t pubsubAvrobinSerializer_createSerializerMap(void *handle, celix_bundle_t *bundle, hash_map_pt *serializerMap);
+celix_status_t pubsubAvrobinSerializer_createSerializerMap(void *handle, const celix_bundle_t *bundle, hash_map_pt *serializerMap);
 celix_status_t pubsubAvrobinSerializer_destroySerializerMap(void *handle, hash_map_pt serializerMap);
 
 #endif /* PUBSUB_SERIALIZER_AVROBIN_H_ */

--- a/bundles/pubsub/pubsub_serializer_json/src/pubsub_serializer_impl.c
+++ b/bundles/pubsub/pubsub_serializer_json/src/pubsub_serializer_impl.c
@@ -77,9 +77,9 @@ typedef struct pubsub_json_msg_serializer_impl {
     version_pt msgVersion;
 } pubsub_json_msg_serializer_impl_t;
 
-static char* pubsubSerializer_getMsgDescriptionDir(celix_bundle_t *bundle);
-static void pubsubSerializer_addMsgSerializerFromBundle(pubsub_json_serializer_t* serializer, const char *root, celix_bundle_t *bundle, hash_map_pt msgSerializers);
-static void pubsubSerializer_fillMsgSerializerMap(pubsub_json_serializer_t* serializer, hash_map_pt msgSerializers,celix_bundle_t *bundle);
+static char* pubsubSerializer_getMsgDescriptionDir(const celix_bundle_t *bundle);
+static void pubsubSerializer_addMsgSerializerFromBundle(pubsub_json_serializer_t* serializer, const char *root, const celix_bundle_t *bundle, hash_map_pt msgSerializers);
+static void pubsubSerializer_fillMsgSerializerMap(pubsub_json_serializer_t* serializer, hash_map_pt msgSerializers, const celix_bundle_t *bundle);
 
 static int pubsubMsgSerializer_convertDescriptor(pubsub_json_serializer_t* serializer, FILE* file_ptr, pubsub_msg_serializer_t* msgSerializer);
 static int pubsubMsgSerializer_convertAvpr(pubsub_json_serializer_t *serializer, FILE* file_ptr, pubsub_msg_serializer_t* msgSerializer, const char* fqn);
@@ -131,7 +131,7 @@ celix_status_t pubsubSerializer_destroy(pubsub_json_serializer_t* serializer) {
     return status;
 }
 
-celix_status_t pubsubSerializer_createSerializerMap(void *handle, celix_bundle_t *bundle, hash_map_pt* serializerMap) {
+celix_status_t pubsubSerializer_createSerializerMap(void *handle, const celix_bundle_t *bundle, hash_map_pt* serializerMap) {
     pubsub_json_serializer_t *serializer = handle;
 
     hash_map_pt map = hashMap_create(NULL, NULL, NULL, NULL);
@@ -210,7 +210,7 @@ void pubsubMsgSerializer_freeMsg(void* handle, void *msg) {
 }
 
 
-static void pubsubSerializer_fillMsgSerializerMap(pubsub_json_serializer_t* serializer, hash_map_pt msgSerializers, celix_bundle_t *bundle) {
+static void pubsubSerializer_fillMsgSerializerMap(pubsub_json_serializer_t* serializer, hash_map_pt msgSerializers, const celix_bundle_t *bundle) {
     char* root = NULL;
     char* metaInfPath = NULL;
 
@@ -227,7 +227,7 @@ static void pubsubSerializer_fillMsgSerializerMap(pubsub_json_serializer_t* seri
     }
 }
 
-static char* pubsubSerializer_getMsgDescriptionDir(celix_bundle_t *bundle) {
+static char* pubsubSerializer_getMsgDescriptionDir(const celix_bundle_t *bundle) {
     char *root = NULL;
 
     bool isSystemBundle = false;
@@ -253,7 +253,7 @@ static char* pubsubSerializer_getMsgDescriptionDir(celix_bundle_t *bundle) {
     return root;
 }
 
-static void pubsubSerializer_addMsgSerializerFromBundle(pubsub_json_serializer_t* serializer, const char *root, celix_bundle_t *bundle, hash_map_pt msgSerializers) {
+static void pubsubSerializer_addMsgSerializerFromBundle(pubsub_json_serializer_t* serializer, const char *root, const celix_bundle_t *bundle, hash_map_pt msgSerializers) {
     char fqn[MAX_PATH_LEN];
     char pathOrError[MAX_PATH_LEN];
     const char* entry_name = NULL;

--- a/bundles/pubsub/pubsub_serializer_json/src/pubsub_serializer_impl.h
+++ b/bundles/pubsub/pubsub_serializer_json/src/pubsub_serializer_impl.h
@@ -34,7 +34,7 @@ typedef struct pubsub_json_serializer pubsub_json_serializer_t;
 celix_status_t pubsubSerializer_create(celix_bundle_context_t *context, pubsub_json_serializer_t **serializer);
 celix_status_t pubsubSerializer_destroy(pubsub_json_serializer_t* serializer);
 
-celix_status_t pubsubSerializer_createSerializerMap(void *handle, celix_bundle_t *bundle, hash_map_pt* serializerMap);
+celix_status_t pubsubSerializer_createSerializerMap(void *handle, const celix_bundle_t *bundle, hash_map_pt* serializerMap);
 celix_status_t pubsubSerializer_destroySerializerMap(void *handle, hash_map_pt serializerMap);
 
 #endif /* PUBSUB_SERIALIZER_JSON_H_ */

--- a/bundles/pubsub/pubsub_spi/include/pubsub_serializer.h
+++ b/bundles/pubsub/pubsub_spi/include/pubsub_serializer.h
@@ -53,7 +53,7 @@ typedef struct pubsub_msg_serializer {
 typedef struct pubsub_serializer_service {
     void* handle;
 
-    celix_status_t (*createSerializerMap)(void* handle, celix_bundle_t *bundle, hash_map_pt* serializerMap);
+    celix_status_t (*createSerializerMap)(void* handle, const celix_bundle_t *bundle, hash_map_pt* serializerMap);
     celix_status_t (*destroySerializerMap)(void* handle, hash_map_pt serializerMap);
 
 } pubsub_serializer_service_t;

--- a/libs/framework/include/bundle.h
+++ b/libs/framework/include/bundle.h
@@ -47,27 +47,27 @@ bundle_createFromArchive(celix_bundle_t **bundle, celix_framework_t *framework, 
 
 FRAMEWORK_EXPORT celix_status_t bundle_destroy(celix_bundle_t *bundle);
 
-FRAMEWORK_EXPORT celix_status_t bundle_isSystemBundle(celix_bundle_t *bundle, bool *systemBundle);
+FRAMEWORK_EXPORT celix_status_t bundle_isSystemBundle(const celix_bundle_t *bundle, bool *systemBundle);
 
-FRAMEWORK_EXPORT celix_status_t bundle_getArchive(celix_bundle_t *bundle, bundle_archive_pt *archive);
+FRAMEWORK_EXPORT celix_status_t bundle_getArchive(const celix_bundle_t *bundle, bundle_archive_pt *archive);
 
-FRAMEWORK_EXPORT celix_status_t bundle_getCurrentModule(celix_bundle_t *bundle, module_pt *module);
+FRAMEWORK_EXPORT celix_status_t bundle_getCurrentModule(const celix_bundle_t *bundle, module_pt *module);
 
-FRAMEWORK_EXPORT celix_array_list_t *bundle_getModules(celix_bundle_t *bundle);
+FRAMEWORK_EXPORT celix_array_list_t *bundle_getModules(const celix_bundle_t *bundle);
 
 FRAMEWORK_EXPORT void *bundle_getHandle(celix_bundle_t *bundle);
 
 FRAMEWORK_EXPORT void bundle_setHandle(celix_bundle_t *bundle, void *handle);
 
-FRAMEWORK_EXPORT celix_bundle_activator_t *bundle_getActivator(celix_bundle_t *bundle);
+FRAMEWORK_EXPORT celix_bundle_activator_t *bundle_getActivator(const celix_bundle_t *bundle);
 
 FRAMEWORK_EXPORT celix_status_t bundle_setActivator(celix_bundle_t *bundle, celix_bundle_activator_t *activator);
 
-FRAMEWORK_EXPORT celix_status_t bundle_getContext(celix_bundle_t *bundle, celix_bundle_context_t **context);
+FRAMEWORK_EXPORT celix_status_t bundle_getContext(const celix_bundle_t *bundle, celix_bundle_context_t **context);
 
 FRAMEWORK_EXPORT celix_status_t bundle_setContext(celix_bundle_t *bundle, celix_bundle_context_t *context);
 
-FRAMEWORK_EXPORT celix_status_t bundle_getEntry(celix_bundle_t *bundle, const char *name, char **entry);
+FRAMEWORK_EXPORT celix_status_t bundle_getEntry(const celix_bundle_t *bundle, const char *name, char **entry);
 
 FRAMEWORK_EXPORT celix_status_t bundle_start(celix_bundle_t *bundle);
 
@@ -93,22 +93,22 @@ FRAMEWORK_EXPORT celix_status_t bundle_revise(celix_bundle_t *bundle, const char
 
 FRAMEWORK_EXPORT celix_status_t bundle_addModule(celix_bundle_t *bundle, module_pt module);
 
-FRAMEWORK_EXPORT celix_status_t bundle_closeModules(celix_bundle_t *bundle);
+FRAMEWORK_EXPORT celix_status_t bundle_closeModules(const celix_bundle_t *bundle);
 
 // Service Reference Functions
 FRAMEWORK_EXPORT celix_array_list_t *getUsingBundles(service_reference_pt reference);
 
 FRAMEWORK_EXPORT int compareTo(service_reference_pt a, service_reference_pt b);
 
-FRAMEWORK_EXPORT celix_status_t bundle_getState(celix_bundle_t *bundle, bundle_state_e *state);
+FRAMEWORK_EXPORT celix_status_t bundle_getState(const celix_bundle_t *bundle, bundle_state_e *state);
 
-FRAMEWORK_EXPORT celix_status_t bundle_closeAndDelete(celix_bundle_t *bundle);
+FRAMEWORK_EXPORT celix_status_t bundle_closeAndDelete(const celix_bundle_t *bundle);
 
-FRAMEWORK_EXPORT celix_status_t bundle_close(celix_bundle_t *bundle);
+FRAMEWORK_EXPORT celix_status_t bundle_close(const celix_bundle_t *bundle);
 
 FRAMEWORK_EXPORT celix_status_t bundle_refresh(celix_bundle_t *bundle);
 
-FRAMEWORK_EXPORT celix_status_t bundle_getBundleId(celix_bundle_t *bundle, long *id);
+FRAMEWORK_EXPORT celix_status_t bundle_getBundleId(const celix_bundle_t *bundle, long *id);
 
 FRAMEWORK_EXPORT celix_status_t bundle_getRegisteredServices(celix_bundle_t *bundle, celix_array_list_t **list);
 
@@ -116,9 +116,9 @@ FRAMEWORK_EXPORT celix_status_t bundle_getServicesInUse(celix_bundle_t *bundle, 
 
 FRAMEWORK_EXPORT celix_status_t bundle_setFramework(celix_bundle_t *bundle, celix_framework_t *framework);
 
-FRAMEWORK_EXPORT celix_status_t bundle_getFramework(celix_bundle_t *bundle, celix_framework_t **framework);
+FRAMEWORK_EXPORT celix_status_t bundle_getFramework(const celix_bundle_t *bundle, celix_framework_t **framework);
 
-FRAMEWORK_EXPORT celix_status_t bundle_getBundleLocation(celix_bundle_t *bundle, const char **location);
+FRAMEWORK_EXPORT celix_status_t bundle_getBundleLocation(const celix_bundle_t *bundle, const char **location);
 
 
 #ifdef __cplusplus

--- a/libs/framework/include/celix_types.h
+++ b/libs/framework/include/celix_types.h
@@ -53,8 +53,10 @@ typedef struct celix_dm_service_dependency dm_service_dependency_t CELIX_DEPRECA
 typedef struct celix_bundle_context *bundle_context_pt CELIX_DEPRECATED_ATTR;
 typedef struct celix_bundle_context bundle_context_t CELIX_DEPRECATED_ATTR;
 typedef struct celix_framework *framework_pt CELIX_DEPRECATED_ATTR;
+typedef const struct celix_framework *const_framework_pt CELIX_DEPRECATED_ATTR;
 typedef struct celix_framework framework_t CELIX_DEPRECATED_ATTR;
 typedef struct celix_bundle * bundle_pt CELIX_DEPRECATED_ATTR;
+typedef const struct celix_bundle * const_bundle_pt CELIX_DEPRECATED_ATTR;
 typedef struct celix_bundle bundle_t CELIX_DEPRECATED_ATTR;
 
 // will be deprecated in the future

--- a/libs/framework/include/framework.h
+++ b/libs/framework/include/framework.h
@@ -48,9 +48,9 @@ FRAMEWORK_EXPORT celix_status_t framework_destroy(celix_framework_t *framework);
 
 FRAMEWORK_EXPORT celix_status_t framework_waitForStop(celix_framework_t *framework);
 
-FRAMEWORK_EXPORT celix_status_t framework_getFrameworkBundle(celix_framework_t *framework, celix_bundle_t **bundle);
+FRAMEWORK_EXPORT celix_status_t framework_getFrameworkBundle(const celix_framework_t *framework, celix_bundle_t **bundle);
 
-celix_bundle_context_t* framework_getContext(celix_framework_t *framework);
+celix_bundle_context_t* framework_getContext(const celix_framework_t *framework);
 
 #ifdef __cplusplus
 }

--- a/libs/framework/private/mock/bundle_mock.c
+++ b/libs/framework/private/mock/bundle_mock.c
@@ -92,7 +92,7 @@ celix_status_t bundle_setActivator(bundle_pt bundle, celix_bundle_activator_t *a
 	return mock_c()->returnValue().value.intValue;
 }
 
-celix_status_t bundle_getContext(bundle_pt bundle, bundle_context_pt *context) {
+celix_status_t bundle_getContext(const_bundle_pt bundle, bundle_context_pt *context) {
 	mock_c()->actualCall("bundle_getContext")
 			->withPointerParameters("bundle", bundle)
 			->withOutputParameter("context", context);

--- a/libs/framework/private/mock/bundle_mock.c
+++ b/libs/framework/private/mock/bundle_mock.c
@@ -49,26 +49,26 @@ celix_status_t bundle_destroy(bundle_pt bundle) {
 }
 
 
-celix_status_t bundle_isSystemBundle(bundle_pt bundle, bool *systemBundle) {
+celix_status_t bundle_isSystemBundle(const_bundle_pt bundle, bool *systemBundle) {
 	mock_c()->actualCall("bundle_isSystembundle")
-			->withPointerParameters("bundle", bundle)
+			->withPointerParameters("bundle", (bundle_pt)bundle)
 			->withOutputParameter("systemBundle", systemBundle);
 	return mock_c()->returnValue().value.intValue;
 }
 
-celix_status_t bundle_getArchive(bundle_pt bundle, bundle_archive_pt *archive) {
+celix_status_t bundle_getArchive(const_bundle_pt bundle, bundle_archive_pt *archive) {
 	mock_c()->actualCall("bundle_getArchive");
 	return mock_c()->returnValue().value.intValue;
 }
 
-celix_status_t bundle_getCurrentModule(bundle_pt bundle, module_pt *module) {
+celix_status_t bundle_getCurrentModule(const_bundle_pt bundle, module_pt *module) {
 	mock_c()->actualCall("bundle_getCurrentModule")
-		->withPointerParameters("bundle", bundle)
+		->withPointerParameters("bundle", (bundle_pt)bundle)
 		->withOutputParameter("module", (void **) module);
 	return mock_c()->returnValue().value.intValue;
 }
 
-array_list_pt bundle_getModules(bundle_pt bundle) {
+array_list_pt bundle_getModules(const_bundle_pt bundle) {
 	mock_c()->actualCall("bundle_getModules");
 	return mock_c()->returnValue().value.pointerValue;
 }
@@ -82,7 +82,7 @@ void bundle_setHandle(bundle_pt bundle, void * handle) {
 	mock_c()->actualCall("bundle_setHandle");
 }
 
-celix_bundle_activator_t *bundle_getActivator(bundle_pt bundle) {
+celix_bundle_activator_t *bundle_getActivator(const_bundle_pt bundle) {
 	mock_c()->actualCall("bundle_getActivator");
 	return mock_c()->returnValue().value.pointerValue;
 }
@@ -94,7 +94,7 @@ celix_status_t bundle_setActivator(bundle_pt bundle, celix_bundle_activator_t *a
 
 celix_status_t bundle_getContext(const_bundle_pt bundle, bundle_context_pt *context) {
 	mock_c()->actualCall("bundle_getContext")
-			->withPointerParameters("bundle", bundle)
+			->withPointerParameters("bundle", (bundle_pt)bundle)
 			->withOutputParameter("context", context);
 	return mock_c()->returnValue().value.intValue;
 }
@@ -104,9 +104,9 @@ celix_status_t bundle_setContext(bundle_pt bundle, bundle_context_pt context) {
 	return mock_c()->returnValue().value.intValue;
 }
 
-celix_status_t bundle_getEntry(bundle_pt bundle, const char * name, char **entry) {
+celix_status_t bundle_getEntry(const_bundle_pt bundle, const char * name, char **entry) {
 	mock_c()->actualCall("bundle_getEntry")
-			->withPointerParameters("bundle", bundle)
+			->withPointerParameters("bundle", (bundle_pt)bundle)
 			->withStringParameters("name", name)
 			->withOutputParameter("entry", entry);
 	return mock_c()->returnValue().value.intValue;
@@ -158,9 +158,9 @@ celix_status_t bundle_setPersistentStateUninstalled(bundle_pt bundle) {
 	return mock_c()->returnValue().value.intValue;
 }
 
-celix_status_t bundle_getBundleLocation(bundle_pt bundle, const char **location) {
+celix_status_t bundle_getBundleLocation(const_bundle_pt bundle, const char **location) {
 	mock_c()->actualCall("bundle_getBundleLocation")
-	    ->withPointerParameters("bundle", bundle)
+	    ->withPointerParameters("bundle", (bundle_pt)bundle)
 	    ->withOutputParameter("location", location);
 	return mock_c()->returnValue().value.intValue;
 }
@@ -180,7 +180,7 @@ celix_status_t bundle_addModule(bundle_pt bundle, module_pt module) {
 	return mock_c()->returnValue().value.intValue;
 }
 
-celix_status_t bundle_closeModules(bundle_pt bundle) {
+celix_status_t bundle_closeModules(const_bundle_pt bundle) {
 	mock_c()->actualCall("bundle_closeModules");
 	return mock_c()->returnValue().value.intValue;
 }
@@ -199,9 +199,9 @@ int compareTo(service_reference_pt a, service_reference_pt b) {
 }
 
 
-celix_status_t bundle_getState(bundle_pt bundle, bundle_state_e *state) {
+celix_status_t bundle_getState(const_bundle_pt bundle, bundle_state_e *state) {
 	mock_c()->actualCall("bundle_getState")
-			->withPointerParameters("bundle", bundle)
+			->withPointerParameters("bundle", (bundle_pt)bundle)
 			->withOutputParameter("state", state);
 	return mock_c()->returnValue().value.intValue;
 }
@@ -235,12 +235,12 @@ celix_status_t bundle_unlock(bundle_pt bundle, bool *unlocked) {
 }
 
 
-celix_status_t bundle_closeAndDelete(bundle_pt bundle) {
+celix_status_t bundle_closeAndDelete(const_bundle_pt bundle) {
 	mock_c()->actualCall("bundle_closeAndDelete");
 	return mock_c()->returnValue().value.intValue;
 }
 
-celix_status_t bundle_close(bundle_pt bundle) {
+celix_status_t bundle_close(const_bundle_pt bundle) {
 	mock_c()->actualCall("bundle_close");
 	return mock_c()->returnValue().value.intValue;
 }
@@ -251,9 +251,9 @@ celix_status_t bundle_refresh(bundle_pt bundle) {
 	return mock_c()->returnValue().value.intValue;
 }
 
-celix_status_t bundle_getBundleId(bundle_pt bundle, long *id) {
+celix_status_t bundle_getBundleId(const_bundle_pt bundle, long *id) {
 	mock_c()->actualCall("bundle_getBundleId")
-			->withPointerParameters("bundle", bundle)
+			->withPointerParameters("bundle", (bundle_pt)bundle)
 			->withOutputParameter("id", id);
 	return mock_c()->returnValue().value.intValue;
 }
@@ -278,9 +278,9 @@ celix_status_t bundle_setFramework(bundle_pt bundle, framework_pt framework) {
 	return mock_c()->returnValue().value.intValue;
 }
 
-celix_status_t bundle_getFramework(bundle_pt bundle, framework_pt *framework) {
+celix_status_t bundle_getFramework(const_bundle_pt bundle, framework_pt *framework) {
 	mock_c()->actualCall("bundle_getFramework")
-			->withPointerParameters("bundle", bundle)
+			->withPointerParameters("bundle", (bundle_pt)bundle)
 			->withOutputParameter("framework", framework);
 	return mock_c()->returnValue().value.intValue;
 }

--- a/libs/framework/private/mock/framework_mock.c
+++ b/libs/framework/private/mock/framework_mock.c
@@ -79,10 +79,10 @@ celix_status_t fw_uninstallBundle(framework_pt framework, bundle_pt bundle) {
 		return mock_c()->returnValue().value.intValue;
 }
 
-celix_status_t framework_getBundleEntry(framework_pt framework, bundle_pt bundle, const char *name, char **entry) {
+celix_status_t framework_getBundleEntry(framework_pt framework, const_bundle_pt bundle, const char *name, char **entry) {
 	mock_c()->actualCall("framework_getBundleEntry")
 			->withPointerParameters("framework", framework)
-			->withPointerParameters("bundle", bundle)
+			->withPointerParameters("bundle", (bundle_pt)bundle)
 			->withStringParameters("name", name)
 			->withOutputParameter("entry", (const char **) entry);
 		return mock_c()->returnValue().value.intValue;
@@ -314,9 +314,9 @@ bundle_pt framework_getBundleById(framework_pt framework, long id) {
 	return mock_c()->returnValue().value.pointerValue;
 }
 
-celix_status_t framework_getFrameworkBundle(framework_pt framework, bundle_pt *bundle) {
+celix_status_t framework_getFrameworkBundle(const_framework_pt framework, bundle_pt *bundle) {
 	mock_c()->actualCall("framework_getFrameworkBundle")
-			->withPointerParameters("framework", framework)
+			->withPointerParameters("framework", (framework_pt)framework)
 			->withOutputParameter("bundle", bundle);
 	return mock_c()->returnValue().value.intValue;
 }

--- a/libs/framework/src/bundle.c
+++ b/libs/framework/src/bundle.c
@@ -26,7 +26,7 @@
 #include "utils.h"
 
 celix_status_t bundle_createModule(bundle_pt bundle, module_pt *module);
-celix_status_t bundle_closeRevisions(bundle_pt bundle);
+celix_status_t bundle_closeRevisions(const_bundle_pt bundle);
 
 celix_status_t bundle_create(bundle_pt * bundle) {
     celix_status_t status;
@@ -105,7 +105,7 @@ celix_status_t bundle_destroy(bundle_pt bundle) {
 	return CELIX_SUCCESS;
 }
 
-celix_status_t bundle_getArchive(bundle_pt bundle, bundle_archive_pt *archive) {
+celix_status_t bundle_getArchive(const_bundle_pt bundle, bundle_archive_pt *archive) {
 	celix_status_t status = CELIX_SUCCESS;
 
 	if (bundle != NULL && *archive == NULL) {
@@ -119,7 +119,7 @@ celix_status_t bundle_getArchive(bundle_pt bundle, bundle_archive_pt *archive) {
 	return status;
 }
 
-celix_status_t bundle_getCurrentModule(bundle_pt bundle, module_pt *module) {
+celix_status_t bundle_getCurrentModule(const_bundle_pt bundle, module_pt *module) {
 	celix_status_t status = CELIX_SUCCESS;
 
 	if (bundle == NULL || arrayList_size(bundle->modules)==0 ) {
@@ -131,7 +131,7 @@ celix_status_t bundle_getCurrentModule(bundle_pt bundle, module_pt *module) {
 	return status;
 }
 
-array_list_pt bundle_getModules(bundle_pt bundle) {
+array_list_pt bundle_getModules(const_bundle_pt bundle) {
     return bundle->modules;
 }
 
@@ -143,7 +143,7 @@ void bundle_setHandle(bundle_pt bundle, void * handle) {
 	bundle->handle = handle;
 }
 
-celix_bundle_activator_t* bundle_getActivator(bundle_pt bundle) {
+celix_bundle_activator_t* bundle_getActivator(const_bundle_pt bundle) {
 	return bundle->activator;
 }
 
@@ -152,7 +152,7 @@ celix_status_t bundle_setActivator(bundle_pt bundle, celix_bundle_activator_t *a
 	return CELIX_SUCCESS;
 }
 
-celix_status_t bundle_getContext(bundle_pt bundle, bundle_context_pt *context) {
+celix_status_t bundle_getContext(const_bundle_pt bundle, bundle_context_pt *context) {
 	*context = bundle->context;
 	return CELIX_SUCCESS;
 }
@@ -162,11 +162,11 @@ celix_status_t bundle_setContext(bundle_pt bundle, bundle_context_pt context) {
 	return CELIX_SUCCESS;
 }
 
-celix_status_t bundle_getEntry(bundle_pt bundle, const char* name, char** entry) {
+celix_status_t bundle_getEntry(const_bundle_pt bundle, const char* name, char** entry) {
 	return framework_getBundleEntry(bundle->framework, bundle, name, entry);
 }
 
-celix_status_t bundle_getState(bundle_pt bundle, bundle_state_e *state) {
+celix_status_t bundle_getState(const_bundle_pt bundle, bundle_state_e *state) {
 	if(bundle==NULL){
 		*state = OSGI_FRAMEWORK_BUNDLE_UNKNOWN;
 		return CELIX_BUNDLE_EXCEPTION;
@@ -193,10 +193,10 @@ celix_status_t bundle_createModule(bundle_pt bundle, module_pt *module) {
 		long bundleId = 0;
         status = bundleArchive_getId(bundle->archive, &bundleId);
         if (status == CELIX_SUCCESS) {
-			int revision = 0;
+			int revision_no = 0;
 			char moduleId[512];
 
-			snprintf(moduleId, sizeof(moduleId), "%ld.%d", bundleId, revision);
+			snprintf(moduleId, sizeof(moduleId), "%ld.%d", bundleId, revision_no);
 			*module = module_create(headerMap, moduleId, bundle);
 
 			if (*module != NULL) {
@@ -406,7 +406,7 @@ celix_status_t bundle_addModule(bundle_pt bundle, module_pt module) {
 	return CELIX_SUCCESS;
 }
 
-celix_status_t bundle_isSystemBundle(bundle_pt bundle, bool *systemBundle) {
+celix_status_t bundle_isSystemBundle(const_bundle_pt bundle, bool *systemBundle) {
 	celix_status_t status;
 	long bundleId;
 	bundle_archive_pt archive = NULL;
@@ -424,7 +424,7 @@ celix_status_t bundle_isSystemBundle(bundle_pt bundle, bool *systemBundle) {
 	return status;
 }
 
-celix_status_t bundle_close(bundle_pt bundle) {
+celix_status_t bundle_close(const_bundle_pt bundle) {
 	bundle_archive_pt archive = NULL;
 	
 	celix_status_t status;
@@ -441,7 +441,7 @@ celix_status_t bundle_close(bundle_pt bundle) {
     return status;
 }
 
-celix_status_t bundle_closeAndDelete(bundle_pt bundle) {
+celix_status_t bundle_closeAndDelete(const_bundle_pt bundle) {
 	celix_status_t status;
 
 	bundle_archive_pt archive = NULL;
@@ -458,12 +458,12 @@ celix_status_t bundle_closeAndDelete(bundle_pt bundle) {
     return status;
 }
 
-celix_status_t bundle_closeRevisions(bundle_pt bundle) {
+celix_status_t bundle_closeRevisions(const_bundle_pt bundle) {
     celix_status_t status = CELIX_SUCCESS;
     return status;
 }
 
-celix_status_t bundle_closeModules(bundle_pt bundle) {
+celix_status_t bundle_closeModules(const_bundle_pt bundle) {
     celix_status_t status = CELIX_SUCCESS;
 
     unsigned int i = 0;
@@ -497,7 +497,7 @@ celix_status_t bundle_refresh(bundle_pt bundle) {
     return status;
 }
 
-celix_status_t bundle_getBundleId(bundle_t *bundle, long *bndId) {
+celix_status_t bundle_getBundleId(const bundle_t *bundle, long *bndId) {
 	celix_status_t status = CELIX_SUCCESS;
 	long id = celix_bundle_getId(bundle);
 	if (id >= 0) {
@@ -543,7 +543,7 @@ celix_status_t bundle_setFramework(bundle_pt bundle, framework_pt framework) {
 	return status;
 }
 
-celix_status_t bundle_getFramework(bundle_pt bundle, framework_pt *framework) {
+celix_status_t bundle_getFramework(const_bundle_pt bundle, framework_pt *framework) {
 	celix_status_t status = CELIX_SUCCESS;
 
 	if (bundle != NULL && *framework == NULL) {
@@ -557,7 +557,7 @@ celix_status_t bundle_getFramework(bundle_pt bundle, framework_pt *framework) {
 	return status;
 }
 
-celix_status_t bundle_getBundleLocation(bundle_pt bundle, const char **location){
+celix_status_t bundle_getBundleLocation(const_bundle_pt bundle, const char **location){
 
 	celix_status_t status;
 

--- a/libs/framework/src/framework_private.h
+++ b/libs/framework/src/framework_private.h
@@ -96,7 +96,7 @@ FRAMEWORK_EXPORT celix_status_t fw_getProperty(framework_pt framework, const cha
 FRAMEWORK_EXPORT celix_status_t fw_installBundle(framework_pt framework, bundle_pt * bundle, const char * location, const char *inputFile);
 FRAMEWORK_EXPORT celix_status_t fw_uninstallBundle(framework_pt framework, bundle_pt bundle);
 
-FRAMEWORK_EXPORT celix_status_t framework_getBundleEntry(framework_pt framework, bundle_pt bundle, const char* name, char** entry);
+FRAMEWORK_EXPORT celix_status_t framework_getBundleEntry(framework_pt framework, const_bundle_pt bundle, const char* name, char** entry);
 
 FRAMEWORK_EXPORT celix_status_t fw_startBundle(framework_pt framework, bundle_pt bundle, int options);
 FRAMEWORK_EXPORT celix_status_t framework_updateBundle(framework_pt framework, bundle_pt bundle, const char* inputFile);

--- a/libs/framework/src/resolver.c
+++ b/libs/framework/src/resolver.c
@@ -73,7 +73,7 @@ linked_list_pt resolver_resolve(module_pt root) {
     candidatesMap = hashMap_create(NULL, NULL, NULL, NULL);
 
     if (resolver_populateCandidatesMap(candidatesMap, root) != 0) {
-        hash_map_iterator_pt iter = hashMapIterator_create(candidatesMap);
+        iter = hashMapIterator_create(candidatesMap);
         while (hashMapIterator_hasNext(iter)) {
             hash_map_entry_pt entry = hashMapIterator_nextEntry(iter);
             linked_list_pt value = hashMapEntry_getValue(entry);


### PR DESCRIPTION
* Calling `pubsubAvrobinSerializer_createSerializerMap` in the factory `getService` or `ungetService` required casting away constness. However, the function doesn't require non-const bundle.
* `framework_markBundleResolved` contained a bug where a shadowing variable made a call to `module_getSymbolicName` always return ILLEGAL_ACCESS.
* Assorted shadowing fixes for cases that didn't lead to bugs.
