### PR TITLE
Prevent ld from optimizing away linked library

### DIFF
--- a/libs/framework/test/CMakeLists.txt
+++ b/libs/framework/test/CMakeLists.txt
@@ -23,7 +23,9 @@ add_subdirectory(subdir) #simple_test_bundle4, simple_test_bundle5 and sublib
 
 add_celix_bundle(unresolveable_bundle SOURCES nop_activator.c VERSION 1.0.0)
 target_link_libraries(unresolveable_bundle PRIVATE "-L${CMAKE_CURRENT_BINARY_DIR}/subdir -lsublib")
-set_target_properties(unresolveable_bundle PROPERTIES LINK_FLAGS -Wl,--no-as-needed)
+if(NOT APPLE)
+    set_target_properties(unresolveable_bundle PROPERTIES LINK_FLAGS -Wl,--no-as-needed)
+endif()
 add_dependencies(unresolveable_bundle sublib)
 
 add_executable(test_framework

--- a/libs/framework/test/CMakeLists.txt
+++ b/libs/framework/test/CMakeLists.txt
@@ -23,6 +23,7 @@ add_subdirectory(subdir) #simple_test_bundle4, simple_test_bundle5 and sublib
 
 add_celix_bundle(unresolveable_bundle SOURCES nop_activator.c VERSION 1.0.0)
 target_link_libraries(unresolveable_bundle PRIVATE "-L${CMAKE_CURRENT_BINARY_DIR}/subdir -lsublib")
+set_target_properties(unresolveable_bundle PROPERTIES LINK_FLAGS -Wl,--no-as-needed)
 add_dependencies(unresolveable_bundle sublib)
 
 add_executable(test_framework

--- a/libs/framework/test/bundle_context_bundles_tests.cpp
+++ b/libs/framework/test/bundle_context_bundles_tests.cpp
@@ -147,7 +147,6 @@ TEST(CelixBundleContextBundlesTests, startBundleWithException) {
     CHECK_TRUE(called);
 }
 
-/* TODO research why this lead to resolved instead of installed bundle for Ubuntu 18
 TEST(CelixBundleContextBundlesTests, startUnresolveableBundle) {
     long bndId = celix_bundleContext_installBundle(ctx, TEST_BND_UNRESOLVEABLE_LOC, true);
     CHECK(bndId > 0); //bundle is installed, but not resolved
@@ -166,7 +165,6 @@ TEST(CelixBundleContextBundlesTests, startUnresolveableBundle) {
     });
     CHECK_TRUE(called);
 }
- */
 
 
 TEST(CelixBundleContextBundlesTests, useBundleTest) {


### PR DESCRIPTION
ld by default uses --as-needed, which means that programs that do not use any symbol from a library, do not get linked to that library.