### PR TITLE
Fixed conditional define to include memstream

### DIFF
--- a/libs/dfi/include/dyn_type.h
+++ b/libs/dfi/include/dyn_type.h
@@ -28,7 +28,7 @@
 
 #include "dfi_log_util.h"
 
-#if defined(BSD) || defined(__APPLE__) || defined(__ANDROID__)
+#if defined(NO_MEMSTREAM_AVAILABLE)
 #include "memstream/open_memstream.h"
 #include "memstream/fmemopen.h"
 #endif

--- a/libs/utils/include/celix_utils_api.h
+++ b/libs/utils/include/celix_utils_api.h
@@ -32,7 +32,7 @@
 #include "version_range.h"
 #include "thpool.h"
 
-#if defined(BSD) || defined(__APPLE__) || defined(__ANDROID__)
+#if defined(NO_MEMSTREAM_AVAILABLE)
 #include "memstream/open_memstream.h"
 #include "memstream/fmemopen.h"
 #endif


### PR DESCRIPTION
macOS actually (nowadays?) has the open_memstream symbol defined in stdio.h. This fix uses the target compile definition created by cmake which tests for this function