### PR TITLE
Cleanup dm interface

### DIFF
--- a/libs/framework/include/celix/dm/Component.h
+++ b/libs/framework/include/celix/dm/Component.h
@@ -243,18 +243,6 @@ namespace celix { namespace dm {
          * @return the DM Component reference for chaining (fluent API)
          */
         Component<T>& removeCallbacks();
-
-        /**
-         * Safely copies a std::string into a char* buffer
-         * @param input string to copy
-         * @param dst buffer to allocate into, owner is responsible for freeing memory
-         */
-        void copyString(const std::string& input, char **dst)
-        {
-            *dst = (char*)malloc(input.length() + 1);
-            strncpy(*dst, input.c_str(), input.length());
-            *dst[input.length()] = '\0';
-        }
     };
 }}
 

--- a/libs/framework/include/celix/dm/Component.h
+++ b/libs/framework/include/celix/dm/Component.h
@@ -34,11 +34,11 @@ namespace celix { namespace dm {
         celix_bundle_context_t *context {nullptr};
         celix_dm_component_t *cCmp {nullptr};
     public:
-        BaseComponent(celix_bundle_context_t *con, std::string name) : context{con}, cCmp{nullptr} {
+        BaseComponent(celix_bundle_context_t *con, const std::string &name) : context{con}, cCmp{nullptr} {
             this->cCmp = celix_dmComponent_create(this->context, name.c_str());
             celix_dmComponent_setImplementation(this->cCmp, this);
         }
-        virtual ~BaseComponent() {}
+        virtual ~BaseComponent() = default;
 
         BaseComponent(const BaseComponent&) = delete;
         BaseComponent& operator=(const BaseComponent&) = delete;
@@ -53,7 +53,7 @@ namespace celix { namespace dm {
          */
         celix_bundle_context_t* bundleContext() const { return this->context; }
     };
-        
+
 
     template<class T>
     class Component : public BaseComponent {
@@ -74,8 +74,8 @@ namespace celix { namespace dm {
         int (T::*stopFpNoExc)() = {};
         int (T::*deinitFpNoExc)() = {};
     public:
-        Component(celix_bundle_context_t *context, std::string name);
-        virtual ~Component();
+        Component(celix_bundle_context_t *context, const std::string &name);
+        ~Component() override;
 
         /**
          * Creates a Component using the provided bundle context
@@ -83,7 +83,7 @@ namespace celix { namespace dm {
          * Will use new(nothrow) if exceptions are disabled.
          * @return newly created DM Component or nullptr
          */
-        static Component<T>* create(celix_bundle_context_t*, std::string name);
+        static Component<T>* create(celix_bundle_context_t*, const std::string &name);
 
         /**
          * Creates a Component using the provided bundle context.
@@ -137,7 +137,7 @@ namespace celix { namespace dm {
          * @param properties To (meta) properties to provide with the service
          * @return the DM Component reference for chaining (fluent API)
          */
-        template<class I> Component<T>& addInterfaceWithName(const std::string serviceName, const std::string version = std::string{}, const Properties properties = Properties{});
+        template<class I> Component<T>& addInterfaceWithName(const std::string &serviceName, const std::string &version = std::string{}, const Properties &properties = Properties{});
 
         /**
          * Adds a C++ interface to provide as service to the Celix framework.
@@ -147,7 +147,7 @@ namespace celix { namespace dm {
          * @param properties To (meta) properties to provide with the service
          * @return the DM Component reference for chaining (fluent API)
          */
-        template<class I> Component<T>& addInterface(const std::string version = std::string{}, const Properties properties = Properties{});
+        template<class I> Component<T>& addInterface(const std::string &version = std::string{}, const Properties &properties = Properties{});
 
         /**
          * Adds a C interface to provide as service to the Celix framework.
@@ -157,7 +157,7 @@ namespace celix { namespace dm {
          * @param version The version of the interface (e.g. "1.0.0"), can be an empty string
          * @param properties To (meta) properties to provide with the service
          */
-        template<class I> Component<T>& addCInterface(const I* svc, const std::string serviceName, const std::string version = std::string{}, const Properties properties = Properties{});
+        template<class I> Component<T>& addCInterface(const I* svc, const std::string &serviceName, const std::string &version = std::string{}, const Properties &properties = Properties{});
 
 
         /**
@@ -177,7 +177,7 @@ namespace celix { namespace dm {
          * @return the Service Dependency reference for chaining (fluent API)
          */
         template<class I>
-        ServiceDependency<T,I>& createServiceDependency(const std::string name = std::string{});
+        ServiceDependency<T,I>& createServiceDependency(const std::string &name = std::string{});
 
         /**
          Removes a C++ service dependency from the component
@@ -193,7 +193,7 @@ namespace celix { namespace dm {
          * @return the DM Component reference for chaining (fluent API)
          */
         template<typename I>
-        CServiceDependency<T,I>& createCServiceDependency(const std::string name);
+        CServiceDependency<T,I>& createCServiceDependency(const std::string &name);
 
         /**
          * Removes a C service dependency to the component
@@ -214,10 +214,10 @@ namespace celix { namespace dm {
          * @return the DM Component reference for chaining (fluent API)
          */
         Component<T>& setCallbacks(
-            void (T::*init)(),
-            void (T::*start)(),
-            void (T::*stop)(),
-            void (T::*deinit)()
+                void (T::*init)(),
+                void (T::*start)(),
+                void (T::*stop)(),
+                void (T::*deinit)()
         );
 
         /**
@@ -232,10 +232,10 @@ namespace celix { namespace dm {
          * @return the DM Component reference for chaining (fluent API)
          */
         Component<T>& setCallbacks(
-            int (T::*init)(),
-            int (T::*start)(),
-            int (T::*stop)(),
-            int (T::*deinit)()
+                int (T::*init)(),
+                int (T::*start)(),
+                int (T::*stop)(),
+                int (T::*deinit)()
         );
         /**
          * Remove the previously registered callbacks for the component life cycle control
@@ -243,6 +243,18 @@ namespace celix { namespace dm {
          * @return the DM Component reference for chaining (fluent API)
          */
         Component<T>& removeCallbacks();
+
+        /**
+         * Safely copies a std::string into a char* buffer
+         * @param input string to copy
+         * @param dst buffer to allocate into, owner is responsible for freeing memory
+         */
+        void copyString(const std::string& input, char **dst)
+        {
+            *dst = (char*)malloc(input.length() + 1);
+            strncpy(*dst, input.c_str(), input.length());
+            *dst[input.length()] = '\0';
+        }
     };
 }}
 

--- a/libs/framework/include/celix/dm/Component_Impl.h
+++ b/libs/framework/include/celix/dm/Component_Impl.h
@@ -30,7 +30,7 @@
 using namespace celix::dm;
 
 template<class T>
-Component<T>::Component(celix_bundle_context_t *context, std::string name) : BaseComponent(context, name) {}
+Component<T>::Component(celix_bundle_context_t *context, const std::string &name) : BaseComponent(context, name) {}
 
 template<class T>
 Component<T>::~Component() {
@@ -39,21 +39,25 @@ Component<T>::~Component() {
 
 template<class T>
 template<class I>
-Component<T>& Component<T>::addInterfaceWithName(const std::string serviceName, const std::string version, const Properties properties) {
+Component<T>& Component<T>::addInterfaceWithName(const std::string &serviceName, const std::string &version, const Properties &properties) {
     if (!serviceName.empty()) {
         //setup c properties
         celix_properties_t *cProperties = properties_create();
         properties_set(cProperties, CELIX_FRAMEWORK_SERVICE_LANGUAGE, CELIX_FRAMEWORK_SERVICE_CXX_LANGUAGE);
         for (const auto& pair : properties) {
-            properties_set(cProperties, (char *) pair.first.c_str(), (char *) pair.second.c_str());
+            char *key = nullptr;
+            char *value = nullptr;
+            copyString(pair.first, &key);
+            copyString(pair.second, &value);
+            properties_set(cProperties, key, value);
         }
 
         T* cmpPtr = &this->getInstance();
         I* intfPtr = static_cast<I*>(cmpPtr); //NOTE T should implement I
 
         const char *cVersion = version.empty() ? nullptr : version.c_str();
-        celix_dmComponent_addInterface(this->cComponent(), (char *) serviceName.c_str(), (char *) cVersion,
-                               intfPtr, cProperties);
+        celix_dmComponent_addInterface(this->cComponent(), serviceName.c_str(), cVersion,
+                                       intfPtr, cProperties);
     } else {
         std::cerr << "Cannot add interface with a empty name\n";
     }
@@ -63,7 +67,7 @@ Component<T>& Component<T>::addInterfaceWithName(const std::string serviceName, 
 
 template<class T>
 template<class I>
-Component<T>& Component<T>::addInterface(const std::string version, const Properties properties) {
+Component<T>& Component<T>::addInterface(const std::string &version, const Properties &properties) {
     //get name if not provided
     static_assert(std::is_base_of<I,T>::value, "Component T must implement Interface I");
     std::string serviceName = typeName<I>();
@@ -72,23 +76,27 @@ Component<T>& Component<T>::addInterface(const std::string version, const Proper
     }
 
     return this->addInterfaceWithName<I>(serviceName, version, properties);
-};
+}
 
 template<class T>
 template<class I>
-Component<T>& Component<T>::addCInterface(const I* svc, const std::string serviceName, const std::string version, const Properties properties) {
+Component<T>& Component<T>::addCInterface(const I* svc, const std::string &serviceName, const std::string &version, const Properties &properties) {
     static_assert(std::is_standard_layout<I>::value, "Service I must be an object with a standard layout");
     celix_properties_t *cProperties = properties_create();
     properties_set(cProperties, CELIX_FRAMEWORK_SERVICE_LANGUAGE, CELIX_FRAMEWORK_SERVICE_C_LANGUAGE);
     for (const auto& pair : properties) {
-        properties_set(cProperties, (char*)pair.first.c_str(), (char*)pair.second.c_str());
+        char *key = nullptr;
+        char *value = nullptr;
+        copyString(pair.first, &key);
+        copyString(pair.second, &value);
+        properties_set(cProperties, key, value);
     }
 
     const char *cVersion = version.empty() ? nullptr : version.c_str();
-    celix_dmComponent_addInterface(this->cComponent(), (char*)serviceName.c_str(), (char*)cVersion, svc, cProperties);
+    celix_dmComponent_addInterface(this->cComponent(), serviceName.c_str(), cVersion, svc, cProperties);
 
     return *this;
-};
+}
 
 template<class T>
 template<class I>
@@ -96,11 +104,11 @@ Component<T>& Component<T>::removeCInterface(const I* svc){
     static_assert(std::is_standard_layout<I>::value, "Service I must be an object with a standard layout");
     celix_dmComponent_removeInterface(this->cComponent(), svc);
     return *this;
-};
+}
 
 template<class T>
 template<class I>
-ServiceDependency<T,I>& Component<T>::createServiceDependency(const std::string name) {
+ServiceDependency<T,I>& Component<T>::createServiceDependency(const std::string &name) {
     static ServiceDependency<T,I> invalidDep{std::string{}, false};
     auto dep = std::shared_ptr<ServiceDependency<T,I>> {new ServiceDependency<T,I>(name)};
     if (dep == nullptr) {
@@ -122,7 +130,7 @@ Component<T>& Component<T>::remove(ServiceDependency<T,I>& dep) {
 
 template<class T>
 template<typename I>
-CServiceDependency<T,I>& Component<T>::createCServiceDependency(const std::string name) {
+CServiceDependency<T,I>& Component<T>::createCServiceDependency(const std::string &name) {
     static CServiceDependency<T,I> invalidDep{std::string{}, false};
     auto dep = std::shared_ptr<CServiceDependency<T,I>> {new CServiceDependency<T,I>(name)};
     if (dep == nullptr) {
@@ -138,7 +146,7 @@ template<class T>
 template<typename I>
 Component<T>& Component<T>::remove(CServiceDependency<T,I>& dep) {
     celix_component_removeServiceDependency(cComponent(), dep.cServiceDependency());
-     this->dependencies.erase(std::remove(this->dependencies.begin(), this->dependencies.end(), dep));
+    this->dependencies.erase(std::remove(this->dependencies.begin(), this->dependencies.end(), dep));
     return *this;
 }
 
@@ -149,9 +157,9 @@ Component<T>* Component<T>::create(celix_bundle_context_t *context) {
 }
 
 template<class T>
-Component<T>* Component<T>::create(celix_bundle_context_t *context, std::string name) {
+Component<T>* Component<T>::create(celix_bundle_context_t *context, const std::string &name) {
     static Component<T> invalid{nullptr, std::string{}};
-    Component<T>* cmp = new Component<T>(context, name);
+    Component<T>* cmp = new (std::nothrow) Component<T>(context, name);
     if (cmp == nullptr) {
         cmp = &invalid;
     }
@@ -181,7 +189,7 @@ template<class T>
 Component<T>& Component<T>::setInstance(std::shared_ptr<T> inst) {
     this->valInstance.clear();
     this->instance = std::unique_ptr<T> {nullptr};
-    this->sharedInstance = inst;
+    this->sharedInstance = std::move(inst);
     return *this;
 }
 
@@ -204,10 +212,10 @@ Component<T>& Component<T>::setInstance(T&& inst) {
 
 template<class T>
 Component<T>& Component<T>::setCallbacks(
-            void (T::*init)(),
-            void (T::*start)(),
-            void (T::*stop)(),
-            void (T::*deinit)() ) {
+        void (T::*init)(),
+        void (T::*start)(),
+        void (T::*stop)(),
+        void (T::*deinit)() ) {
 
     this->initFp = init;
     this->startFp = start;
@@ -258,10 +266,10 @@ Component<T>& Component<T>::setCallbacks(
 
 template<class T>
 Component<T>& Component<T>::setCallbacks(
-            int (T::*init)(),
-            int (T::*start)(),
-            int (T::*stop)(),
-            int (T::*deinit)() ) {
+        int (T::*init)(),
+        int (T::*start)(),
+        int (T::*stop)(),
+        int (T::*deinit)() ) {
 
     this->initFpNoExc = init;
     this->startFpNoExc = start;

--- a/libs/framework/include/celix/dm/Component_Impl.h
+++ b/libs/framework/include/celix/dm/Component_Impl.h
@@ -49,7 +49,7 @@ Component<T>& Component<T>::addInterfaceWithName(const std::string &serviceName,
             char *value = nullptr;
             copyString(pair.first, &key);
             copyString(pair.second, &value);
-            properties_set(cProperties, key, value);
+            celix_properties_setWithoutCopy(cProperties, key, value);
         }
 
         T* cmpPtr = &this->getInstance();
@@ -89,7 +89,7 @@ Component<T>& Component<T>::addCInterface(const I* svc, const std::string &servi
         char *value = nullptr;
         copyString(pair.first, &key);
         copyString(pair.second, &value);
-        properties_set(cProperties, key, value);
+        celix_properties_setWithoutCopy(cProperties, key, value);
     }
 
     const char *cVersion = version.empty() ? nullptr : version.c_str();

--- a/libs/framework/include/celix/dm/Component_Impl.h
+++ b/libs/framework/include/celix/dm/Component_Impl.h
@@ -45,11 +45,7 @@ Component<T>& Component<T>::addInterfaceWithName(const std::string &serviceName,
         celix_properties_t *cProperties = properties_create();
         properties_set(cProperties, CELIX_FRAMEWORK_SERVICE_LANGUAGE, CELIX_FRAMEWORK_SERVICE_CXX_LANGUAGE);
         for (const auto& pair : properties) {
-            char *key = nullptr;
-            char *value = nullptr;
-            copyString(pair.first, &key);
-            copyString(pair.second, &value);
-            celix_properties_setWithoutCopy(cProperties, key, value);
+            properties_set(cProperties, pair.first.c_str(), pair.second.c_str());
         }
 
         T* cmpPtr = &this->getInstance();
@@ -85,11 +81,7 @@ Component<T>& Component<T>::addCInterface(const I* svc, const std::string &servi
     celix_properties_t *cProperties = properties_create();
     properties_set(cProperties, CELIX_FRAMEWORK_SERVICE_LANGUAGE, CELIX_FRAMEWORK_SERVICE_C_LANGUAGE);
     for (const auto& pair : properties) {
-        char *key = nullptr;
-        char *value = nullptr;
-        copyString(pair.first, &key);
-        copyString(pair.second, &value);
-        celix_properties_setWithoutCopy(cProperties, key, value);
+        properties_set(cProperties, pair.first.c_str(), pair.second.c_str());
     }
 
     const char *cVersion = version.empty() ? nullptr : version.c_str();

--- a/libs/framework/include/celix/dm/ServiceDependency.h
+++ b/libs/framework/include/celix/dm/ServiceDependency.h
@@ -41,8 +41,9 @@ namespace celix { namespace dm {
     };
 
     class BaseServiceDependency {
+    private:
+        bool valid;
     protected:
-        const bool valid;
         celix_dm_service_dependency_t *cServiceDep {nullptr};
 
         void setDepStrategy(DependencyUpdateStrategy strategy) {
@@ -70,6 +71,8 @@ namespace celix { namespace dm {
 
         BaseServiceDependency(const BaseServiceDependency&) = delete;
         BaseServiceDependency& operator=(const BaseServiceDependency&) = delete;
+        BaseServiceDependency(BaseServiceDependency&&) noexcept = default;
+        BaseServiceDependency& operator=(BaseServiceDependency&&) noexcept = default;
 
         /**
          * Whether the service dependency is valid.
@@ -89,12 +92,12 @@ namespace celix { namespace dm {
         T* componentInstance {nullptr};
     public:
         TypedServiceDependency(bool valid) : BaseServiceDependency(valid) {}
-        virtual ~TypedServiceDependency() = default;
+        ~TypedServiceDependency() override = default;
 
         TypedServiceDependency(const TypedServiceDependency&) = delete;
         TypedServiceDependency& operator=(const TypedServiceDependency&) = delete;
-        TypedServiceDependency(TypedServiceDependency&&) = default;
-        TypedServiceDependency& operator=(TypedServiceDependency&&) = default;
+        TypedServiceDependency(TypedServiceDependency&&) noexcept = default;
+        TypedServiceDependency& operator=(TypedServiceDependency&&) noexcept = default;
 
         /**
          * Set the component instance with a pointer
@@ -106,8 +109,13 @@ namespace celix { namespace dm {
     class CServiceDependency : public TypedServiceDependency<T> {
         using type = I;
     public:
-        CServiceDependency(const std::string name, bool valid = true);
-        virtual ~CServiceDependency() = default;
+        CServiceDependency(const std::string &name, bool valid = true);
+        ~CServiceDependency() override = default;
+
+        CServiceDependency(const CServiceDependency&) = delete;
+        CServiceDependency& operator=(const CServiceDependency&) = delete;
+        CServiceDependency(CServiceDependency&&) noexcept = default;
+        CServiceDependency& operator=(CServiceDependency&&) noexcept = default;
 
         /**
          * Sets the service version range for the C service dependency.
@@ -115,7 +123,7 @@ namespace celix { namespace dm {
          * @param serviceVersionRange The service version range, can be an empty string
          * @return the C service dependency reference for chaining (fluent API)
          */
-        CServiceDependency<T,I>& setVersionRange(const std::string serviceVersionRange);
+        CServiceDependency<T,I>& setVersionRange(const std::string &serviceVersionRange);
 
         /**
          * Sets the service filter for the C service dependency.
@@ -123,7 +131,7 @@ namespace celix { namespace dm {
          * @param filter The (additional) filter to use (e.g. "(location=front)")
          * @return the C service dependency reference for chaining (fluent API)
          */
-        CServiceDependency<T,I>& setFilter(const std::string filter);
+        CServiceDependency<T,I>& setFilter(const std::string &filter);
 
         /**
          * Specify if the service dependency is required. Default is false
@@ -183,8 +191,8 @@ namespace celix { namespace dm {
          * @return the C service dependency reference for chaining (fluent API)
          */
         CServiceDependency<T,I>& setCallbacks(
-		std::function<void(const I* service, Properties&& properties)> add,
-		std::function<void(const I* service, Properties&& properties)> remove
+                std::function<void(const I* service, Properties&& properties)> add,
+                std::function<void(const I* service, Properties&& properties)> remove
         );
 
         /**
@@ -211,29 +219,34 @@ namespace celix { namespace dm {
     class ServiceDependency : public TypedServiceDependency<T> {
         using type = I;
     public:
-        ServiceDependency(const std::string name = std::string{}, bool valid = true);
-        virtual ~ServiceDependency() = default;
+        ServiceDependency(const std::string &name = std::string{}, bool valid = true);
+        ~ServiceDependency() override = default;
+
+        ServiceDependency(const ServiceDependency&) = delete;
+        ServiceDependency& operator=(const ServiceDependency&) = delete;
+        ServiceDependency(ServiceDependency&&) noexcept = default;
+        ServiceDependency& operator=(ServiceDependency&&) noexcept = default;
 
         /**
          * Set the service name of the service dependency.
          *
          * @return the C++ service dependency reference for chaining (fluent API)
          */
-        ServiceDependency<T,I>& setName(const std::string name);
+        ServiceDependency<T,I>& setName(const std::string &_name);
 
         /**
          * Set the service filter of the service dependency.
          *
          * @return the C++ service dependency reference for chaining (fluent API)
          */
-        ServiceDependency<T,I>& setFilter(const std::string filter);
+        ServiceDependency<T,I>& setFilter(const std::string &filter);
 
         /**
          * Set the service version range of the service dependency.
          *
          * @return the C++ service dependency reference for chaining (fluent API)
          */
-        ServiceDependency<T,I>& setVersionRange(const std::string versionRange);
+        ServiceDependency<T,I>& setVersionRange(const std::string &versionRange);
 
         /**
          * Set the set callback for when the service dependency becomes available
@@ -279,8 +292,8 @@ namespace celix { namespace dm {
          * @return the C service dependency reference for chaining (fluent API)
          */
         ServiceDependency<T,I>& setCallbacks(
-		std::function<void(I* service, Properties&& properties)> add,
-		std::function<void(I* service, Properties&& properties)> remove
+                std::function<void(I* service, Properties&& properties)> add,
+                std::function<void(I* service, Properties&& properties)> remove
         );
 
         /**

--- a/libs/framework/include/celix/dm/ServiceDependency_Impl.h
+++ b/libs/framework/include/celix/dm/ServiceDependency_Impl.h
@@ -26,48 +26,48 @@
 using namespace celix::dm;
 
 template<class T, typename I>
-CServiceDependency<T,I>::CServiceDependency(const std::string name, bool valid) : TypedServiceDependency<T>(valid) {
+CServiceDependency<T,I>::CServiceDependency(const std::string &name, bool valid) : TypedServiceDependency<T>(valid) {
     this->name = name;
     this->setupService();
 }
 
 template<class T, typename I>
-CServiceDependency<T,I>& CServiceDependency<T,I>::setVersionRange(const std::string serviceVersionRange) {
+CServiceDependency<T,I>& CServiceDependency<T,I>::setVersionRange(const std::string &serviceVersionRange) {
     this->versionRange = serviceVersionRange;
     this->setupService();
     return *this;
 }
 
 template<class T, typename I>
-CServiceDependency<T,I>& CServiceDependency<T,I>::setFilter(const std::string filter) {
-    this->filter = filter;
+CServiceDependency<T,I>& CServiceDependency<T,I>::setFilter(const std::string &_filter) {
+    filter = _filter;
     this->setupService();
     return *this;
 }
 
 template<class T, typename I>
 void CServiceDependency<T,I>::setupService() {
-    if (!this->valid) {
+    if (!this->isValid()) {
         return;
     }
     const char* cversion = this->versionRange.empty() ? nullptr : versionRange.c_str();
     const char* cfilter = filter.empty() ? nullptr : filter.c_str();
     celix_dmServiceDependency_setService(this->cServiceDependency(), this->name.c_str(), cversion, cfilter);
-};
+}
 
 template<class T, typename I>
 CServiceDependency<T,I>& CServiceDependency<T,I>::setAddLanguageFilter(bool addLang) {
-//    if (!this->valid) {
+//    if (!this->isValid()) {
 //        *this;
 //    }
     celix_serviceDependency_setAddCLanguageFilter(this->cServiceDependency(), addLang);
     this->setupService();
     return *this;
-};
+}
 
 template<class T, typename I>
 CServiceDependency<T,I>& CServiceDependency<T,I>::setRequired(bool req) {
-    if (!this->valid) {
+    if (!this->isValid()) {
         return *this;
     }
     celix_dmServiceDependency_setRequired(this->cServiceDependency(), req);
@@ -76,7 +76,7 @@ CServiceDependency<T,I>& CServiceDependency<T,I>::setRequired(bool req) {
 
 template<class T, typename I>
 CServiceDependency<T,I>& CServiceDependency<T,I>::setStrategy(DependencyUpdateStrategy strategy) {
-    if (!this->valid) {
+    if (!this->isValid()) {
         return *this;
     }
     this->setDepStrategy(strategy);
@@ -115,14 +115,14 @@ CServiceDependency<T,I>& CServiceDependency<T,I>::setCallbacks(
         void (T::*add)(const I* service),
         void (T::*remove)(const I* service)) {
     this->setCallbacks(
-		    [this, add](const I* service, [[gnu::unused]] Properties&& properties) {
-			    T *cmp = this->componentInstance;
-			    (cmp->*add)(service);
-		    },
-		    [this, remove](const I* service, [[gnu::unused]] Properties&& properties) {
-			    T *cmp = this->componentInstance;
-			    (cmp->*remove)(service);
-		    }
+            [this, add](const I* service, [[gnu::unused]] Properties&& properties) {
+                T *cmp = this->componentInstance;
+                (cmp->*add)(service);
+            },
+            [this, remove](const I* service, [[gnu::unused]] Properties&& properties) {
+                T *cmp = this->componentInstance;
+                (cmp->*remove)(service);
+            }
     );
     return *this;
 }
@@ -133,21 +133,21 @@ CServiceDependency<T,I>& CServiceDependency<T,I>::setCallbacks(
         void (T::*remove)(const I* service, Properties&& properties)
 ) {
     this->setCallbacks(
-		    [this, add](const I* service, Properties&& properties) {
-			    T *cmp = this->componentInstance;
-			    (cmp->*add)(service, std::move(properties));
-		    },
-		    [this, remove](const I* service, Properties&& properties) {
-			    T *cmp = this->componentInstance;
-			    (cmp->*remove)(service, std::move(properties));
-		    }
+            [this, add](const I* service, Properties&& properties) {
+                T *cmp = this->componentInstance;
+                (cmp->*add)(service, std::move(properties));
+            },
+            [this, remove](const I* service, Properties&& properties) {
+                T *cmp = this->componentInstance;
+                (cmp->*remove)(service, std::move(properties));
+            }
     );
     return *this;
 }
 
 template<class T, typename I>
 CServiceDependency<T,I>& CServiceDependency<T,I>::setCallbacks(std::function<void(const I* service, Properties&& properties)> add, std::function<void(const I* service, Properties&& properties)> remove) {
-    this->addFp = add;;
+    this->addFp = add;
     this->removeFp = remove;
     this->setupCallbacks();
     return *this;
@@ -156,7 +156,7 @@ CServiceDependency<T,I>& CServiceDependency<T,I>::setCallbacks(std::function<voi
 
 template<class T, typename I>
 void CServiceDependency<T,I>::setupCallbacks() {
-    if (!this->valid) {
+    if (!this->isValid()) {
         return;
     }
 
@@ -214,17 +214,17 @@ int CServiceDependency<T,I>::invokeCallback(std::function<void(const I*, Propert
 }
 
 template<class T, class I>
-ServiceDependency<T,I>::ServiceDependency(std::string name, bool valid) : TypedServiceDependency<T>(valid) {
+ServiceDependency<T,I>::ServiceDependency(const std::string &name, bool valid) : TypedServiceDependency<T>(valid) {
     if (!name.empty()) {
         this->setName(name);
     } else {
         this->setupService();
     }
-};
+}
 
 template<class T, class I>
 void ServiceDependency<T,I>::setupService() {
-    if (!this->valid) {
+    if (!this->isValid()) {
         return;
     }
 
@@ -276,25 +276,25 @@ void ServiceDependency<T,I>::setupService() {
 }
 
 template<class T, class I>
-ServiceDependency<T,I>& ServiceDependency<T,I>::setName(std::string name) {
-    this->name = name;
+ServiceDependency<T,I>& ServiceDependency<T,I>::setName(const std::string &_name) {
+    name = _name;
     setupService();
     return *this;
-};
+}
 
 template<class T, class I>
-ServiceDependency<T,I>& ServiceDependency<T,I>::setFilter(std::string filter) {
-    this->filter = filter;
+ServiceDependency<T,I>& ServiceDependency<T,I>::setFilter(const std::string &_filter) {
+    filter = _filter;
     setupService();
     return *this;
-};
+}
 
 template<class T, class I>
-ServiceDependency<T,I>& ServiceDependency<T,I>::setVersionRange(std::string versionRange) {
-    this->versionRange = versionRange;
+ServiceDependency<T,I>& ServiceDependency<T,I>::setVersionRange(const std::string &_versionRange) {
+    versionRange = _versionRange;
     setupService();
     return *this;
-};
+}
 
 
 template<class T, class I>
@@ -302,7 +302,7 @@ ServiceDependency<T,I>& ServiceDependency<T,I>::setAddLanguageFilter(bool addLan
     this->addCxxLanguageFilter = addLang;
     setupService();
     return *this;
-};
+}
 
 //set callbacks
 template<class T, class I>
@@ -336,14 +336,14 @@ ServiceDependency<T,I>& ServiceDependency<T,I>::setCallbacks(
         void (T::*add)(I* service),
         void (T::*remove)(I* service)) {
     this->setCallbacks(
-	    [this, add](I* srv, [[gnu::unused]] Properties&& props) {
-        	T *cmp = this->componentInstance;
-        	(cmp->*add)(srv);
-    	    },
-	    [this, remove](I* srv, [[gnu::unused]] Properties&& props) {
-        	T *cmp = this->componentInstance;
-        	(cmp->*remove)(srv);
-    	    }
+            [this, add](I* srv, [[gnu::unused]] Properties&& props) {
+                T *cmp = this->componentInstance;
+                (cmp->*add)(srv);
+            },
+            [this, remove](I* srv, [[gnu::unused]] Properties&& props) {
+                T *cmp = this->componentInstance;
+                (cmp->*remove)(srv);
+            }
     );
     return *this;
 }
@@ -352,24 +352,24 @@ template<class T, class I>
 ServiceDependency<T,I>& ServiceDependency<T,I>::setCallbacks(
         void (T::*add)(I* service, Properties&& properties),
         void (T::*remove)(I* service, Properties&& properties)
-        ) {
+) {
     this->setCallbacks(
-	    [this, add](I* srv, Properties&& props) {
-        	T *cmp = this->componentInstance;
-        	(cmp->*add)(srv, std::move(props));
-    	    },
-	    [this, remove](I* srv, Properties&& props) {
-        	T *cmp = this->componentInstance;
-        	(cmp->*remove)(srv, std::move(props));
-    	    }
+            [this, add](I* srv, Properties&& props) {
+                T *cmp = this->componentInstance;
+                (cmp->*add)(srv, std::move(props));
+            },
+            [this, remove](I* srv, Properties&& props) {
+                T *cmp = this->componentInstance;
+                (cmp->*remove)(srv, std::move(props));
+            }
     );
     return *this;
 }
 
 template<class T, class I>
 ServiceDependency<T,I>& ServiceDependency<T,I>::setCallbacks(
-		std::function<void(I* service, Properties&& properties)> add,
-		std::function<void(I* service, Properties&& properties)> remove) {
+        std::function<void(I* service, Properties&& properties)> add,
+        std::function<void(I* service, Properties&& properties)> remove) {
     this->addFp = add;
     this->removeFp = remove;
     this->setupCallbacks();
@@ -386,7 +386,7 @@ template<class T, class I>
 ServiceDependency<T,I>& ServiceDependency<T,I>::setStrategy(DependencyUpdateStrategy strategy) {
     this->setDepStrategy(strategy);
     return *this;
-};
+}
 
 template<class T, class I>
 int ServiceDependency<T,I>::invokeCallback(std::function<void(I*, Properties&&)> fp, const celix_properties_t *props, const void* service) {
@@ -396,15 +396,15 @@ int ServiceDependency<T,I>::invokeCallback(std::function<void(I*, Properties&&)>
     const char* key {nullptr};
     const char* value {nullptr};
 
-	if (props != nullptr) {
-            hash_map_iterator_t iter = hashMapIterator_construct((hash_map_pt)props);
-            while(hashMapIterator_hasNext(&iter)) {
-                key = (const char*) hashMapIterator_nextKey(&iter);
-                value = celix_properties_get(props, key, "");
-                //std::cout << "got property " << key << "=" << value << "\n";
-                properties[key] = value;
-            }
-	}
+    if (props != nullptr) {
+        hash_map_iterator_t iter = hashMapIterator_construct((hash_map_pt)props);
+        while(hashMapIterator_hasNext(&iter)) {
+            key = (const char*) hashMapIterator_nextKey(&iter);
+            value = celix_properties_get(props, key, "");
+            //std::cout << "got property " << key << "=" << value << "\n";
+            properties[key] = value;
+        }
+    }
 
     fp(svc, std::move(properties)); //explicit move of lvalue properties.
     return 0;
@@ -412,7 +412,7 @@ int ServiceDependency<T,I>::invokeCallback(std::function<void(I*, Properties&&)>
 
 template<class T, class I>
 void ServiceDependency<T,I>::setupCallbacks() {
-    if (!this->valid) {
+    if (!this->isValid()) {
         return;
     }
 
@@ -446,4 +446,4 @@ void ServiceDependency<T,I>::setupCallbacks() {
     opts.addWithProps = cadd;
     opts.removeWithProps = crem;
     celix_dmServiceDependency_setCallbacksWithOptions(this->cServiceDependency(), &opts);
-};
+}

--- a/libs/framework/include/celix/dm/types.h
+++ b/libs/framework/include/celix/dm/types.h
@@ -49,7 +49,7 @@ namespace celix { namespace dm {
      * Returns the deferred type name for the template I
      */
     template<typename INTERFACE_TYPENAME>
-    const std::string typeName() {
+    std::string typeName() {
         std::string result;
 
 #ifdef __GXX_RTTI


### PR DESCRIPTION
Cleanup dm interface, prevent lots of string copies and re-enable proper move assign for ServiceDependency