### PR TITLE
Get proper backtraces when using asan

### DIFF
--- a/cmake/celix_project/CelixProject.cmake
+++ b/cmake/celix_project/CelixProject.cmake
@@ -20,11 +20,11 @@ option(ENABLE_UNDEFINED_SANITIZER "Enabled building with undefined behavior sani
 
 if (ENABLE_ADDRESS_SANITIZER)
     if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
-        set(CMAKE_C_FLAGS "-fsanitize=address ${CMAKE_C_FLAGS}")
-        set(CMAKE_CXX_FLAGS "-fsanitize=address ${CMAKE_CXX_FLAGS}")
+        set(CMAKE_C_FLAGS "-fsanitize=address -fno-omit-frame-pointer ${CMAKE_C_FLAGS}")
+        set(CMAKE_CXX_FLAGS "-fsanitize=address -fno-omit-frame-pointer ${CMAKE_CXX_FLAGS}")
     else ()
-        set(CMAKE_C_FLAGS "-lasan -fsanitize=address ${CMAKE_C_FLAGS}")
-        set(CMAKE_CXX_FLAGS "-lasan -fsanitize=address ${CMAKE_CXX_FLAGS}")
+        set(CMAKE_C_FLAGS "-lasan -fsanitize=address -fno-omit-frame-pointer ${CMAKE_C_FLAGS}")
+        set(CMAKE_CXX_FLAGS "-lasan -fsanitize=address -fno-omit-frame-pointer ${CMAKE_CXX_FLAGS}")
     endif ()
 endif()
 


### PR DESCRIPTION
asan by default uses the frame pointers to detect backtraces for mallocs. Another option is to use `ASAN_OPTIONS=fast_unwind_on_malloc=0`, which severely slows down the application.