### PR TITLE
Changed freeSerializeMsg behaviour for pubsub serialization.

### DIFF
--- a/bundles/pubsub/pubsub_admin_tcp/src/pubsub_tcp_topic_sender.c
+++ b/bundles/pubsub/pubsub_admin_tcp/src/pubsub_tcp_topic_sender.c
@@ -558,7 +558,6 @@ psa_tcp_topicPublicationSend(void *handle, unsigned int msgTypeId, const void *i
                     entry->msgSer->freeSerializeMsg(entry->msgSer->handle,
                                                     serializedIoVecOutput,
                                                     serializedIoVecOutputLen);
-                    free(serializedIoVecOutput);
                     serializedIoVecOutput = NULL;
                 }
             }

--- a/bundles/pubsub/pubsub_admin_udp_mc/src/pubsub_udpmc_topic_sender.c
+++ b/bundles/pubsub/pubsub_admin_udp_mc/src/pubsub_udpmc_topic_sender.c
@@ -306,7 +306,6 @@ static int psa_udpmc_topicPublicationSend(void* handle, unsigned int msgTypeId, 
             free(msg);
             free(msg_hdr);
             msgSer->freeSerializeMsg(msgSer->handle, serializedOutput, serializedOutputLen);
-            free(serializedOutput);
         } else {
             printf("[PSA_UDPMC/TopicSender] Serialization of msg type id %d failed\n", msgTypeId);
             status = -1;

--- a/bundles/pubsub/pubsub_admin_websocket/src/pubsub_websocket_topic_sender.c
+++ b/bundles/pubsub/pubsub_admin_websocket/src/pubsub_websocket_topic_sender.c
@@ -344,7 +344,6 @@ static int psa_websocket_topicPublicationSend(void* handle, unsigned int msgType
             json_decref(jsMsg); //Decrease ref count means freeing the object
             free(hdrEncoded);
             entry->msgSer->freeSerializeMsg(entry->msgSer->handle, serializedOutput, serializedOutputLen);
-            free(serializedOutput);
         } else {
             L_WARN("[PSA_WEBSOCKET_TS] Error serialize message of type %s for scope/topic %s/%s",
                    entry->msgSer->msgName, sender->scope == NULL ? "(null)" : sender->scope, sender->topic);

--- a/bundles/pubsub/pubsub_admin_zmq/src/pubsub_zmq_topic_sender.c
+++ b/bundles/pubsub/pubsub_admin_zmq/src/pubsub_zmq_topic_sender.c
@@ -511,7 +511,6 @@ static void psa_zmq_freeMsg(void *msg, void *hint) {
     if(hint) {
         psa_zmq_zerocopy_free_entry *entry = hint;
         entry->msgSer->freeSerializeMsg(entry->msgSer->handle, entry->serializedOutput, entry->serializedOutputLen);
-        free(entry->serializedOutput);
         free(entry);
     } else {
         free(msg);
@@ -677,7 +676,6 @@ static int psa_zmq_topicPublicationSend(void* handle, unsigned int msgTypeId, co
                 }
                 if (!bound->parent->zeroCopyEnabled && serializedOutput) {
                     entry->msgSer->freeSerializeMsg(entry->msgSer->handle, serializedOutput, serializedOutputLen);
-                    free(serializedOutput);
                 }
 
                 celixThreadMutex_unlock(&entry->sendLock);

--- a/bundles/pubsub/pubsub_serializer_avrobin/src/pubsub_avrobin_serializer_impl.c
+++ b/bundles/pubsub/pubsub_serializer_avrobin/src/pubsub_avrobin_serializer_impl.c
@@ -195,13 +195,16 @@ static celix_status_t pubsubMsgAvrobinSerializer_serialize(void *handle, const v
 
 void pubsubMsgAvrobinSerializer_freeSerializeMsg(void* handle, struct iovec* input, size_t inputIovLen) {
   pubsub_avrobin_msg_serializer_impl_t *impl = handle;
-  if (input == NULL) return;
+  if (input == NULL) {
+      return;
+  }
   if (impl->msgType != NULL) {
     for (int i = 0; i < inputIovLen; i++) {
       if (input[i].iov_base) free(input[i].iov_base);
       input[i].iov_base = NULL;
       input[i].iov_len  = 0;
     }
+    free(input);
   }
 }
 

--- a/bundles/pubsub/pubsub_serializer_json/src/pubsub_serializer_impl.c
+++ b/bundles/pubsub/pubsub_serializer_json/src/pubsub_serializer_impl.c
@@ -210,13 +210,16 @@ celix_status_t pubsubMsgSerializer_deserialize(void* handle, const struct iovec*
 
 void pubsubMsgSerializer_freeSerializeMsg(void* handle, struct iovec* input, size_t inputIovLen) {
     pubsub_json_msg_serializer_impl_t *impl = handle;
-    if (input == NULL) return;
+    if (input == NULL) {
+        return;
+    }
     if (impl->msgType != NULL) {
         for (int i = 0; i < inputIovLen; i++) {
             if (input[i].iov_base) free(input[i].iov_base);
             input[i].iov_base = NULL;
             input[i].iov_len  = 0;
         }
+        free(input);
     }
 }
 


### PR DESCRIPTION
Because the serialize message allocates the memory for the io vec output, the freeSerializeMsg should also free it.