### PR TITLE
Try lock/unlock mutexes before destruction

### DIFF
--- a/libs/framework/src/framework.c
+++ b/libs/framework/src/framework.c
@@ -335,6 +335,8 @@ celix_status_t framework_destroy(framework_pt framework) {
 
     }
     celix_arrayList_destroy(framework->installedBundles.entries);
+    celixThreadMutex_trylock(&framework->installedBundles.mutex);
+    celixThreadMutex_unlock(&framework->installedBundles.mutex);
     celixThreadMutex_destroy(&framework->installedBundles.mutex);
 
 	hashMap_destroy(framework->installRequestMap, false, false);
@@ -359,9 +361,17 @@ celix_status_t framework_destroy(framework_pt framework) {
 	bundleCache_destroy(&framework->cache);
 
 	celixThreadCondition_destroy(&framework->dispatcher.cond);
+    celixThreadMutex_trylock(&framework->frameworkListenersLock);
+    celixThreadMutex_unlock(&framework->frameworkListenersLock);
     celixThreadMutex_destroy(&framework->frameworkListenersLock);
+    celixThreadMutex_trylock(&framework->bundleListenerLock);
+    celixThreadMutex_unlock(&framework->bundleListenerLock);
 	celixThreadMutex_destroy(&framework->bundleListenerLock);
+    celixThreadMutex_trylock(&framework->dispatcher.mutex);
+    celixThreadMutex_unlock(&framework->dispatcher.mutex);
 	celixThreadMutex_destroy(&framework->dispatcher.mutex);
+    celixThreadMutex_trylock(&framework->shutdown.mutex);
+    celixThreadMutex_unlock(&framework->shutdown.mutex);
 	celixThreadMutex_destroy(&framework->shutdown.mutex);
 	celixThreadCondition_destroy(&framework->shutdown.cond);
 

--- a/libs/framework/src/service_registry.c
+++ b/libs/framework/src/service_registry.c
@@ -159,6 +159,8 @@ celix_status_t serviceRegistry_destroy(service_registry_pt registry) {
 
     size = hashMap_size(registry->pendingRegisterEvents.map);
     assert(size == 0);
+    celixThreadMutex_trylock(&registry->pendingRegisterEvents.mutex);
+    celixThreadMutex_unlock(&registry->pendingRegisterEvents.mutex);
     celixThreadMutex_destroy(&registry->pendingRegisterEvents.mutex);
     celixThreadCondition_destroy(&registry->pendingRegisterEvents.cond);
     hashMap_destroy(registry->pendingRegisterEvents.map, false, false);

--- a/libs/framework/src/service_tracker.c
+++ b/libs/framework/src/service_tracker.c
@@ -272,6 +272,8 @@ celix_status_t serviceTracker_close(service_tracker_pt tracker) {
 
         celixThreadMutex_destroy(&instance->closingLock);
         celixThreadCondition_destroy(&instance->activeServiceChangeCallsCond);
+        celixThreadMutex_trylock(&instance->mutex);
+        celixThreadMutex_unlock(&instance->mutex);
         celixThreadMutex_destroy(&instance->mutex);
         celixThreadRwlock_destroy(&instance->lock);
         celix_arrayList_destroy(instance->trackedServices);

--- a/libs/utils/include/celix_threads.h
+++ b/libs/utils/include/celix_threads.h
@@ -90,6 +90,7 @@ celix_status_t celixThreadMutex_create(celix_thread_mutex_t *mutex, celix_thread
 
 celix_status_t celixThreadMutex_destroy(celix_thread_mutex_t *mutex);
 
+celix_status_t celixThreadMutex_trylock(celix_thread_mutex_t *mutex);
 celix_status_t celixThreadMutex_lock(celix_thread_mutex_t *mutex);
 
 celix_status_t celixThreadMutex_unlock(celix_thread_mutex_t *mutex);

--- a/libs/utils/src/celix_threads.c
+++ b/libs/utils/src/celix_threads.c
@@ -106,6 +106,10 @@ celix_status_t celixThreadMutex_destroy(celix_thread_mutex_t *mutex) {
     return pthread_mutex_destroy(mutex);
 }
 
+celix_status_t celixThreadMutex_trylock(celix_thread_mutex_t *mutex) {
+    return pthread_mutex_trylock(mutex);
+}
+
 celix_status_t celixThreadMutex_lock(celix_thread_mutex_t *mutex) {
     return pthread_mutex_lock(mutex);
 }


### PR DESCRIPTION
This PR is mostly for discussion about how to solve the warning "destroy of a locked mutex" by thread sanitizer. Destroying locked mutexes is UB according to the spec: 
`Attempting to destroy a locked mutex results in undefined behavior.`
https://pubs.opengroup.org/onlinepubs/009695399/functions/pthread_mutex_destroy.html