### PR TITLE
Only disable optimizations for specific test, rather than entire celix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,16 +100,6 @@ set(CMAKE_C_FLAGS_DEBUG "-g -DDEBUG ${CMAKE_C_FLAGS}")
 set(CMAKE_CXX_FLAGS_DEBUG "-g -DDEBUG ${CMAKE_CXX_FLAGS}")
 set(CMAKE_DEBUG_POSTFIX "d")
 
-# Release with debug info
-# Optimization is disabled, enabled it will result in segfaults due to the ffi_call function
-set(CMAKE_C_FLAGS_RELWITHDEBINFO "-O0 -g -DNDEBUG ${CMAKE_C_FLAGS}")
-set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O0 -g -DNDEBUG ${CMAKE_CXX_FLAGS}")
-
-# Release
-# Optimization is disabled, enabled it will result in segfaults due to the ffi_call function
-set(CMAKE_C_FLAGS_RELEASE "-O0 -DNDEBUG ${CMAKE_C_FLAGS}")
-set(CMAKE_CXX_FLAGS_RELEASE "-O0 -DNDEBUG ${CMAKE_CXX_FLAGS}")
-
 # Set version for the framework package/release
 set(CELIX_MAJOR "2")
 set(CELIX_MINOR "2")

--- a/libs/dfi/gtest/src/dyn_function_tests.cpp
+++ b/libs/dfi/gtest/src/dyn_function_tests.cpp
@@ -156,6 +156,7 @@ TEST_F(DynFunctionTests, DynFuncAccTest) {
 }
 
 extern "C" {
+__attribute__((optimize("0")))
 static bool func_test3() {
     dyn_function_type *dynFunc = nullptr;
     void (*fp)(void) = (void(*)(void)) testExample3;

--- a/libs/dfi/gtest/src/dyn_function_tests.cpp
+++ b/libs/dfi/gtest/src/dyn_function_tests.cpp
@@ -156,7 +156,11 @@ TEST_F(DynFunctionTests, DynFuncAccTest) {
 }
 
 extern "C" {
+#ifdef __clang__
+[[clang::optnone]]
+#else
 __attribute__((optimize("0")))
+#endif
 static bool func_test3() {
     dyn_function_type *dynFunc = nullptr;
     void (*fp)(void) = (void(*)(void)) testExample3;


### PR DESCRIPTION
This fixes the dfi test problem for me, whilst re-enabling optimizations for the library. 

Waiting on CI build to see if this also works for clang.