### PR TITLE
Feature/codecov ci

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Codecov
         uses: codecov/codecov-action@v1
         with:
-          file: ./coverage.info
+          file: build/coverage.info
           name: codecov-celix
 
 #      NOTE For now disabled, need to be able to configure coveralls thresholds

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -40,6 +40,12 @@ jobs:
           export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH:$(pwd)/utils:$(pwd)/framework:$(pwd)/dfi
           make coverage
           lcx="lcov --output-file=coverage.info " && for i in `find . -name "*.info.cleaned"`; do lcx+=" --add-tracefile=$i"; done && $lcx
+      - name: Codecov
+        uses: codecov/codecov-action@v1
+        with:
+          file: ./coverage.info
+          name: codecov-celix
+
 #      NOTE For now disabled, need to be able to configure coveralls thresholds
 #      See https://github.com/lemurheavy/coveralls-public/issues/1431
 #      - name: Coveralls

--- a/README.md
+++ b/README.md
@@ -15,17 +15,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-# Status
+# Apache Celix
 
 ![Celix Ubuntu](https://github.com/apache/celix/workflows/Celix%20Ubuntu/badge.svg)
-
 ![Celix MacOS](https://github.com/apache/celix/workflows/Celix%20MacOS/badge.svg)
-
 [![codecov](https://codecov.io/gh/apache/celix/branch/master/graph/badge.svg)](https://codecov.io/gh/apache/celix) 
- 
 [![Coverity Scan Build Status](https://scan.coverity.com/projects/6685/badge.svg)](https://scan.coverity.com/projects/6685)
-
-# Apache Celix  
 Apache Celix is an implementation of the OSGi specification adapted to C and C++ (C++11). It is a framework to develop (dynamic) modular software applications using component and/or service-oriented programming.
 
 
@@ -37,4 +32,3 @@ For an introduction into Apache Celix see [Apache Celix Intro](documents/intro/R
 
 ## Getting Started with Apache Celix
 For a guide how to start writing your own bundles and services see [Getting Started Guide](documents/getting_started/README.md)
-

--- a/README.md
+++ b/README.md
@@ -15,8 +15,19 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-# Apache Celix [![codecov](https://codecov.io/gh/apache/celix/branch/master/graph/badge.svg)](https://codecov.io/gh/apache/celix) [![Coverity Scan Build Status](https://scan.coverity.com/projects/6685/badge.svg)](https://scan.coverity.com/projects/6685) 
+# Status
+
+![Celix Ubuntu](https://github.com/apache/celix/workflows/Celix%20Ubuntu/badge.svg)
+
+![Celix MacOS](https://github.com/apache/celix/workflows/Celix%20MacOS/badge.svg)
+
+[![codecov](https://codecov.io/gh/apache/celix/branch/master/graph/badge.svg)](https://codecov.io/gh/apache/celix) 
+ 
+[![Coverity Scan Build Status](https://scan.coverity.com/projects/6685/badge.svg)](https://scan.coverity.com/projects/6685)
+
+# Apache Celix  
 Apache Celix is an implementation of the OSGi specification adapted to C and C++ (C++11). It is a framework to develop (dynamic) modular software applications using component and/or service-oriented programming.
+
 
 ## Building
 For information how to build Apache Celix see [Building Apache Celix](documents/building/README.md)

--- a/README.md
+++ b/README.md
@@ -16,11 +16,12 @@ limitations under the License.
 -->
 
 # Apache Celix
-
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 ![Celix Ubuntu](https://github.com/apache/celix/workflows/Celix%20Ubuntu/badge.svg)
 ![Celix MacOS](https://github.com/apache/celix/workflows/Celix%20MacOS/badge.svg)
 [![codecov](https://codecov.io/gh/apache/celix/branch/master/graph/badge.svg)](https://codecov.io/gh/apache/celix) 
 [![Coverity Scan Build Status](https://scan.coverity.com/projects/6685/badge.svg)](https://scan.coverity.com/projects/6685)
+
 Apache Celix is an implementation of the OSGi specification adapted to C and C++ (C++11). It is a framework to develop (dynamic) modular software applications using component and/or service-oriented programming.
 
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
-# Apache Celix [![Build Status](https://travis-ci.org/apache/celix.svg?branch=master)](https://travis-ci.org/apache/celix) [![Coverage Status](https://coveralls.io/repos/apache/celix/badge.svg?branch=master&service=github)](https://coveralls.io/github/apache/celix?branch=master) [![Coverity Scan Build Status](https://scan.coverity.com/projects/6685/badge.svg)](https://scan.coverity.com/projects/6685)
+# Apache Celix [![codecov](https://codecov.io/gh/apache/celix/branch/master/graph/badge.svg)](https://codecov.io/gh/apache/celix) [![Coverity Scan Build Status](https://scan.coverity.com/projects/6685/badge.svg)](https://scan.coverity.com/projects/6685) 
 Apache Celix is an implementation of the OSGi specification adapted to C and C++ (C++11). It is a framework to develop (dynamic) modular software applications using component and/or service-oriented programming.
 
 ## Building

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,4 @@
+coverage:
+  precision: 2
+  round: down
+  range: "68...100"

--- a/misc/experimental/promise/gtest/CMakeLists.txt
+++ b/misc/experimental/promise/gtest/CMakeLists.txt
@@ -21,5 +21,5 @@ add_executable(test_promise
 target_link_libraries(test_promise PRIVATE GTest::gtest GTest::gtest_main Celix::Promise)
 
 add_test(NAME test_promise COMMAND test_promise)
-SETUP_TARGET_FOR_COVERAGE(test_promise_cov test_promise ${CMAKE_BINARY_DIR}/coverage/promise ..)
+setup_target_for_coverage(test_promise SCAN_DIR ..)
 


### PR DESCRIPTION
Adds codecov configuration for coverage reports (instead of coveralls)

See https://codecov.io/github/apache/celix/commit/923e1e98460aafab9360cc468d9b9bdae03d7437
for coverage report we can expect if this is merged with master.