### PR TITLE
Fixes an incorrect loop that installed bundles multiple times

### DIFF
--- a/libs/framework/src/framework.c
+++ b/libs/framework/src/framework.c
@@ -599,9 +599,7 @@ static void framework_autoStartConfiguredBundles(bundle_context_t *fwCtx) {
             framework_autoInstallConfiguredBundlesForList(fwCtx, autoStart, installedBundles);
         }
     }
-    for (int i = 0; i < len; ++i) {
-        framework_autoStartConfiguredBundlesForList(fwCtx, installedBundles);
-    }
+    framework_autoStartConfiguredBundlesForList(fwCtx, installedBundles);
     celix_arrayList_destroy(installedBundles);
 }
 


### PR DESCRIPTION
Fixes an issues where the framework was starting all bundles multiple times for the nr of possible run levels. 
The list installedBundles is filled by the autoInstallBundlesForList call and only needs to be loop over once.