### PR TITLE
First version for coverity workflow.

### DIFF
--- a/.github/workflows/coverity-scan.yml
+++ b/.github/workflows/coverity-scan.yml
@@ -1,0 +1,56 @@
+name: coverity-scan
+on:
+  schedule:
+    - cron: '0 0 * * 0' # Weekly at 00:00 UTC
+
+jobs:
+  latest:
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@master
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -yq --no-install-recommends \
+            build-essential \
+            curl \
+            uuid-dev \
+            libjansson-dev \
+            libcurl4-openssl-dev \
+            default-jdk \
+            cmake \
+            libffi-dev \
+            libxml2-dev \
+            libczmq-dev \
+            libcpputest-dev
+      - name: Download Coverity Build Tool
+        run: |
+          mkdir -p build/cov-analysis-linux64
+          cd build
+          wget -q https://scan.coverity.com/download/cxx/linux64 --post-data "token=$TOKEN&project=Apache+Celix" -O cov-analysis-linux64.tar.gz
+          tar xzf cov-analysis-linux64.tar.gz --strip 1 -C cov-analysis-linux64
+        env:
+          TOKEN: ${{ secrets.COVERITY_SCAN_TOKEN }}
+      - name: Build
+        env:
+          BUILD_OPTIONS: |
+            -DENABLE_TESTING=ON
+            -DCMAKE_BUILD_TYPE=Debug
+        run: |
+          cd build
+          cmake ${BUILD_OPTIONS} ..
+          export PATH=`pwd`/cov-analysis-linux64/bin:$PATH
+          cov-build --dir cov-int make
+      - name: Submit the result to Coverity Scan
+        run: |
+          tar czvf celix.tgz cov-int
+#          curl \
+#            --form project=Apache+Celix \
+#            --form token=$TOKEN \
+#            --form email=a.broekhuis@gmail.com \
+#            --form file=@celix.tgz \
+#            --form version=master \
+#            https://scan.coverity.com/builds?project=Apache+Celix
+        env:
+          TOKEN: ${{ secrets.COVERITY_SCAN_TOKEN }}


### PR DESCRIPTION
@pnoltes please review, but do not yet merge.

Todo:
- Waiting for Apache infra to setup token
- Enable upload if other steps are ok (to prevent reaching the limit of allowed coverity scans)

Uses a simplified workflow for building. No options wrt compiler etc. Defaults are assumed (gcc I guess). Builds and uploads to coverity for analysis.