### PR TITLE
Fix thread safety in dependency manager

### DIFF
--- a/libs/framework/src/dm_dependency_manager_impl.c
+++ b/libs/framework/src/dm_dependency_manager_impl.c
@@ -41,7 +41,10 @@ celix_dependency_manager_t* celix_private_dependencyManager_create(celix_bundle_
 
 void celix_private_dependencyManager_destroy(celix_dependency_manager_t *manager) {
 	if (manager != NULL) {
+        celixThreadMutex_lock(&manager->mutex);
 		celix_arrayList_destroy(manager->components);
+        celixThreadMutex_unlock(&manager->mutex);
+
 		pthread_mutex_destroy(&manager->mutex);
 		free(manager);
 	}
@@ -50,7 +53,11 @@ void celix_private_dependencyManager_destroy(celix_dependency_manager_t *manager
 
 celix_status_t celix_dependencyManager_add(celix_dependency_manager_t *manager, celix_dm_component_t *component) {
 	celix_status_t status;
+
+    celixThreadMutex_lock(&manager->mutex);
 	celix_arrayList_add(manager->components, component);
+    celixThreadMutex_unlock(&manager->mutex);
+
 	status = celix_private_dmComponent_start(component);
 	return status;
 }
@@ -62,13 +69,18 @@ celix_status_t celix_dependencyManager_remove(celix_dependency_manager_t *manage
 	celix_array_list_entry_t entry;
 	memset(&entry, 0, sizeof(entry));
 	entry.voidPtrVal = component;
+
+    celixThreadMutex_lock(&manager->mutex);
 	int index = celix_arrayList_indexOf(manager->components, entry);
 
 	if (index >= 0) {
         celix_arrayList_removeAt(manager->components, index);
+        celixThreadMutex_unlock(&manager->mutex);
+
         status = celix_private_dmComponent_stop(component);
         component_destroy(component);
 	} else {
+        celixThreadMutex_unlock(&manager->mutex);
 	    fprintf(stderr, "Cannot find component with pointer %p\n", component);
 	    status = CELIX_BUNDLE_EXCEPTION;
 	}
@@ -80,22 +92,24 @@ celix_status_t celix_dependencyManager_remove(celix_dependency_manager_t *manage
 
 celix_status_t celix_dependencyManager_removeAllComponents(celix_dependency_manager_t *manager) {
 	celix_status_t status = CELIX_SUCCESS;
+    celix_array_list_t *toRemoveComponents = celix_arrayList_create();
 
-	int i=0;
-	int size = celix_arrayList_size(manager->components);
+    celixThreadMutex_lock(&manager->mutex);
+    while (!arrayList_isEmpty(manager->components)) {
+        celix_dm_component_t *cmp = celix_arrayList_get(manager->components, 0);
+        celix_arrayList_removeAt(manager->components, 0);
+        celix_arrayList_add(toRemoveComponents, cmp);
+    }
+    celixThreadMutex_unlock(&manager->mutex);
 
-	for(;i<size;i++){
-		celix_dm_component_t *cmp = celix_arrayList_get(manager->components, i);
-//		printf("Stopping comp %s\n", component_getName(cmp));
-		celix_private_dmComponent_stop(cmp);
-	}
+    while (!arrayList_isEmpty(toRemoveComponents)) {
+        celix_dm_component_t *cmp = celix_arrayList_get(toRemoveComponents, 0);
+        celix_arrayList_removeAt(toRemoveComponents, 0);
+        celix_private_dmComponent_stop(cmp);
+        component_destroy(cmp);
+    }
 
-	while (!arrayList_isEmpty(manager->components)) {
-		celix_dm_component_t *cmp = celix_arrayList_get(manager->components, 0);
-		celix_arrayList_removeAt(manager->components, 0);
-//        printf("Removing comp %s\n", component_getName(cmp));
-		component_destroy(cmp);
-	}
+    celix_arrayList_destroy(toRemoveComponents);
 
 	return status;
 }


### PR DESCRIPTION
Critical bug in dependency manager, add/remove were not done inside mutex.