### PR TITLE
Add page titles to documentation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+---
+title: Changes
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one or more
 contributor license agreements.  See the NOTICE file distributed with

--- a/bundles/deployment_admin/README.md
+++ b/bundles/deployment_admin/README.md
@@ -1,3 +1,7 @@
+---
+title: Deployment Admin
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one or more
 contributor license agreements.  See the NOTICE file distributed with

--- a/bundles/device_access/README.md
+++ b/bundles/device_access/README.md
@@ -1,3 +1,7 @@
+---
+title: Device Access
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one or more
 contributor license agreements.  See the NOTICE file distributed with

--- a/bundles/device_access/example/base_driver/README.md
+++ b/bundles/device_access/example/base_driver/README.md
@@ -1,3 +1,7 @@
+---
+title: Base driver
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one or more
 contributor license agreements.  See the NOTICE file distributed with

--- a/bundles/device_access/example/consuming_driver/README.md
+++ b/bundles/device_access/example/consuming_driver/README.md
@@ -1,3 +1,7 @@
+---
+title: Consuming driver
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one or more
 contributor license agreements.  See the NOTICE file distributed with

--- a/bundles/device_access/example/refining_driver/README.md
+++ b/bundles/device_access/example/refining_driver/README.md
@@ -1,3 +1,7 @@
+---
+title: Refining driver
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one or more
 contributor license agreements.  See the NOTICE file distributed with

--- a/bundles/http_admin/README.md
+++ b/bundles/http_admin/README.md
@@ -1,3 +1,7 @@
+---
+title: HTTP Admin
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one or more
 contributor license agreements.  See the NOTICE file distributed with

--- a/bundles/logging/README.md
+++ b/bundles/logging/README.md
@@ -1,3 +1,7 @@
+---
+title: Logging Facilities
+---
+
 # Celix Logging Facilities
 
 The Celix Logging facility is service oriented and logging technology agnostic logging solution.

--- a/bundles/logging/log_writers/README.md
+++ b/bundles/logging/log_writers/README.md
@@ -1,3 +1,7 @@
+---
+title: Log Writers
+---
+
 # Log Writer
 
 The Celix Log Writers are components that sinks log from the Celix log service to different backends.

--- a/bundles/pubsub/README.md
+++ b/bundles/pubsub/README.md
@@ -1,3 +1,7 @@
+---
+title: Publisher / subscriber implementation
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one or more
 contributor license agreements.  See the NOTICE file distributed with

--- a/bundles/pubsub/examples/keys/README.md
+++ b/bundles/pubsub/examples/keys/README.md
@@ -1,3 +1,7 @@
+---
+title: Pubsub Keys
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one or more
 contributor license agreements.  See the NOTICE file distributed with

--- a/bundles/pubsub/pubsub_admin_udp_mc/README.md
+++ b/bundles/pubsub/pubsub_admin_udp_mc/README.md
@@ -1,3 +1,7 @@
+---
+title: PSA UDP Multicast
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one or more
 contributor license agreements.  See the NOTICE file distributed with

--- a/bundles/remote_services/README.md
+++ b/bundles/remote_services/README.md
@@ -1,3 +1,7 @@
+---
+title: Remote Service Admin Service
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one or more
 contributor license agreements.  See the NOTICE file distributed with
@@ -14,8 +18,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-
-Title: Apache Celix Remote Service Admin Service
 
 ## Introduction
 

--- a/bundles/remote_services/discovery_etcd/README.md
+++ b/bundles/remote_services/discovery_etcd/README.md
@@ -1,3 +1,7 @@
+---
+title: Discovery ETCD
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one or more
 contributor license agreements.  See the NOTICE file distributed with

--- a/bundles/remote_services/remote_service_admin_dfi/README.md
+++ b/bundles/remote_services/remote_service_admin_dfi/README.md
@@ -1,3 +1,7 @@
+---
+title: Remote Service Admin DFI
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one or more
 contributor license agreements.  See the NOTICE file distributed with

--- a/bundles/remote_services/remote_services_api/README.md
+++ b/bundles/remote_services/remote_services_api/README.md
@@ -1,3 +1,7 @@
+---
+title: Remote Services API
+---
+
 # Remote Service Admin
 
 The Remote Service Admin (RSA) provides the mechanisms to import and export services when instructed to do so by the Topology Manager. 

--- a/bundles/remote_services/rsa_spi/README.md
+++ b/bundles/remote_services/rsa_spi/README.md
@@ -1,3 +1,7 @@
+---
+title: Remote Services SPI
+---
+
 # Remote Service Admin
 
 The Remote Service Admin (RSA) provides the mechanisms to import and export services when instructed to do so by the Topology Manager. 

--- a/bundles/remote_services/topology_manager/README.md
+++ b/bundles/remote_services/topology_manager/README.md
@@ -1,3 +1,7 @@
+---
+title: RSA Topology Manager
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one or more
 contributor license agreements.  See the NOTICE file distributed with

--- a/bundles/shell/remote_shell/README.md
+++ b/bundles/shell/remote_shell/README.md
@@ -1,3 +1,7 @@
+---
+title: Remote Shell
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one or more
 contributor license agreements.  See the NOTICE file distributed with

--- a/bundles/shell/shell/README.md
+++ b/bundles/shell/shell/README.md
@@ -1,3 +1,7 @@
+---
+title: Shell
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one or more
 contributor license agreements.  See the NOTICE file distributed with

--- a/bundles/shell/shell_tui/README.md
+++ b/bundles/shell/shell_tui/README.md
@@ -1,3 +1,7 @@
+---
+title: Shell TUI
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one or more
 contributor license agreements.  See the NOTICE file distributed with

--- a/bundles/shell/shell_wui/README.md
+++ b/bundles/shell/shell_wui/README.md
@@ -1,3 +1,7 @@
+---
+title: Shell WUI
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one or more
 contributor license agreements.  See the NOTICE file distributed with

--- a/documents/building/README.md
+++ b/documents/building/README.md
@@ -1,3 +1,7 @@
+---
+title: Building and Installing
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one or more
 contributor license agreements.  See the NOTICE file distributed with

--- a/documents/cmake_commands/README.md
+++ b/documents/cmake_commands/README.md
@@ -1,3 +1,7 @@
+---
+title: CMake Commands
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one or more
 contributor license agreements.  See the NOTICE file distributed with

--- a/documents/getting_started/README.md
+++ b/documents/getting_started/README.md
@@ -1,3 +1,7 @@
+---
+title: Getting Started Guide
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one or more
 contributor license agreements.  See the NOTICE file distributed with

--- a/documents/getting_started/creating_a_simple_bundle.md
+++ b/documents/getting_started/creating_a_simple_bundle.md
@@ -1,3 +1,7 @@
+---
+title: Creating a Simple Bundle
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one or more
 contributor license agreements.  See the NOTICE file distributed with

--- a/documents/getting_started/using_services_with_c.md
+++ b/documents/getting_started/using_services_with_c.md
@@ -1,3 +1,7 @@
+---
+title: Using Services with C
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one or more
 contributor license agreements.  See the NOTICE file distributed with

--- a/documents/getting_started/using_services_with_cxx.md
+++ b/documents/getting_started/using_services_with_cxx.md
@@ -1,3 +1,7 @@
+---
+title: Using Services with C++
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one or more
 contributor license agreements.  See the NOTICE file distributed with

--- a/documents/intro/README.md
+++ b/documents/intro/README.md
@@ -1,3 +1,7 @@
+---
+title: Introduction
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one or more
 contributor license agreements.  See the NOTICE file distributed with

--- a/documents/subprojects/README.md
+++ b/documents/subprojects/README.md
@@ -1,3 +1,7 @@
+---
+title: Subprojects
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one or more
 contributor license agreements.  See the NOTICE file distributed with

--- a/examples/celix-examples/README.md
+++ b/examples/celix-examples/README.md
@@ -1,3 +1,7 @@
+---
+title: Celix Examples
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one or more
 contributor license agreements.  See the NOTICE file distributed with

--- a/examples/celix-examples/http_example/README.md
+++ b/examples/celix-examples/http_example/README.md
@@ -1,3 +1,7 @@
+---
+title: HTTP Example
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one or more
 contributor license agreements.  See the NOTICE file distributed with
@@ -25,6 +29,3 @@ bundles to create a `http_example_cnt` Celix container.
 The `http_example_cnt` Celix container shows how you can create a use existing http/websocket services.
 After running the container browse to localhost:8080. 
 Under the /shell uri you find the `Celix::shell_wui` functionality and under /hello uri you find the `http_example` functionality
-
-
-

--- a/examples/celix-examples/services_example_c/README.md
+++ b/examples/celix-examples/services_example_c/README.md
@@ -1,3 +1,7 @@
+---
+title: Services example C
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one or more
 contributor license agreements.  See the NOTICE file distributed with

--- a/libs/dependency_manager/README.md
+++ b/libs/dependency_manager/README.md
@@ -1,3 +1,7 @@
+---
+title: Dependency Manager
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one or more
 contributor license agreements.  See the NOTICE file distributed with

--- a/libs/dependency_manager/TODO.md
+++ b/libs/dependency_manager/TODO.md
@@ -1,3 +1,7 @@
+---
+title: TODO Dependency Manager
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one or more
 contributor license agreements.  See the NOTICE file distributed with
@@ -17,5 +21,5 @@ limitations under the License.
 
 # TODO integrate dep man into framework
 
-- Update documentetion for CELIX_GEN_BUNDLE_ACTIVATOR usage and removal of dep manager libs  / shell_dm
+- Update documentation for CELIX_GEN_BUNDLE_ACTIVATOR usage and removal of dep manager libs  / shell_dm
 - Move documentation

--- a/libs/dependency_manager_cxx/README.md
+++ b/libs/dependency_manager_cxx/README.md
@@ -1,3 +1,7 @@
+---
+title: C++ Dependency Manager
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one or more
 contributor license agreements.  See the NOTICE file distributed with

--- a/libs/dependency_manager_cxx/TODO.md
+++ b/libs/dependency_manager_cxx/TODO.md
@@ -1,3 +1,7 @@
+---
+title: TODO C++ Dependency Manager
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one or more
 contributor license agreements.  See the NOTICE file distributed with
@@ -17,5 +21,5 @@ limitations under the License.
 
 # TODO integrate cxx dep man into framework
 
-- Update documentetion for CELIX_GEN_CXX_BUNDLE_ACTIVATOR usage and removal of dep manager libs  / shell_dm
+- Update documentation for CELIX_GEN_CXX_BUNDLE_ACTIVATOR usage and removal of dep manager libs  / shell_dm
 - Move documentation

--- a/libs/etcdlib/README.md
+++ b/libs/etcdlib/README.md
@@ -1,3 +1,7 @@
+---
+title: Etcdlib
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one or more
 contributor license agreements.  See the NOTICE file distributed with

--- a/libs/launcher/README.md
+++ b/libs/launcher/README.md
@@ -1,3 +1,7 @@
+---
+title: Launcher
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one or more
 contributor license agreements.  See the NOTICE file distributed with

--- a/libs/utils/README.md
+++ b/libs/utils/README.md
@@ -1,3 +1,7 @@
+---
+title: Utils
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one or more
 contributor license agreements.  See the NOTICE file distributed with

--- a/misc/experimental/README.md
+++ b/misc/experimental/README.md
@@ -1,3 +1,7 @@
+---
+title: Experimental
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one or more
 contributor license agreements.  See the NOTICE file distributed with

--- a/misc/experimental/bundles/config_admin/README.md
+++ b/misc/experimental/bundles/config_admin/README.md
@@ -1,3 +1,7 @@
+---
+title: Configuration Admin
+---
+
 <!--
 Licensed to the Apache Software Foundation (ASF) under one or more
 contributor license agreements.  See the NOTICE file distributed with

--- a/misc/experimental/promise/README.md
+++ b/misc/experimental/promise/README.md
@@ -1,3 +1,7 @@
+---
+title: Promises
+---
+
 # Celix Promises
 
 Celix Promises are based on the OSGI Promises (OSGi Compendium Release 7 Specification, Chapter 705).


### PR DESCRIPTION
When updating the documentation on the website it was a manual task to correct the page titles on releases (new documentation copied over from Celix repo to celix-site repo-> page titles were not present). To eliminate this I added the page titles to the individual markdown files. This means no manual editing should be required anymore when promoting releases to the website.

Xref: https://github.com/apache/celix-site/pull/10