### PR TITLE
Hotfix/rsa deadlock

### DIFF
--- a/bundles/remote_services/examples/remote_example_api/include/remote_example.h
+++ b/bundles/remote_services/examples/remote_example_api/include/remote_example.h
@@ -61,6 +61,8 @@ typedef struct remote_example {
 
     int (*setComplex)(void *handle, struct complex_input_example *exmpl, struct complex_output_example **out);
 
+    int (*createAdditionalRemoteService)(void *handle);
+
 } remote_example_t;
 
 #endif //CELIX_REMOTE_EXAMPLE_H

--- a/bundles/remote_services/examples/remote_example_api/org.apache.celix.RemoteExample.descriptor
+++ b/bundles/remote_services/examples/remote_example_api/org.apache.celix.RemoteExample.descriptor
@@ -16,3 +16,4 @@ setName2=setName2(#am=handle;P#const=true;t#am=out;*t)N
 setEnum=setEnum(#am=handle;Plenum_example;#am=pre;Lenum_example;)N
 action=action(#am=handle;P)N
 setComplex=setComplex(#am=handle;PLcomplex_input;#am=out;*Lcomplex_output;)N
+createAdditionalRemoteService=createAdditionalRemoteService(#am=handle;P)N

--- a/bundles/remote_services/examples/remote_example_service/src/remote_example_activator.c
+++ b/bundles/remote_services/examples/remote_example_service/src/remote_example_activator.c
@@ -33,7 +33,7 @@ struct activator {
 
 celix_status_t remoteExampleBndStart(struct activator *act, celix_bundle_context_t *ctx) {
     act->svcId = -1L;
-    act->impl = remoteExample_create();
+    act->impl = remoteExample_create(ctx);
     if (act->impl != NULL) {
         act->service.handle = act->impl;
         act->service.pow = (void*)remoteExample_pow;
@@ -43,6 +43,7 @@ celix_status_t remoteExampleBndStart(struct activator *act, celix_bundle_context
         act->service.setEnum = (void*)remoteExample_setEnum;
         act->service.action = (void*)remoteExample_action;
         act->service.setComplex = (void*)remoteExample_setComplex;
+        act->service.createAdditionalRemoteService = (void*)remoteExample_createAdditionalRemoteService;
 
         celix_properties_t *properties = celix_properties_create();
         celix_properties_set(properties, OSGI_RSA_SERVICE_EXPORTED_INTERFACES, REMOTE_EXAMPLE_NAME);

--- a/bundles/remote_services/examples/remote_example_service/src/remote_example_impl.h
+++ b/bundles/remote_services/examples/remote_example_service/src/remote_example_impl.h
@@ -21,11 +21,12 @@
 #define CELIX_REMOTE_EXAMPLE_IMPL_H
 
 #include <stdlib.h>
+#include <celix_api.h>
 
 typedef struct remote_example_impl remote_example_impl_t;
 
 
-remote_example_impl_t* remoteExample_create(void);
+remote_example_impl_t* remoteExample_create(celix_bundle_context_t *ctx);
 void remoteExample_destroy(remote_example_impl_t* impl);
 
 int remoteExample_pow(remote_example_impl_t* impl, double a, double b, double *out);
@@ -35,6 +36,7 @@ int remoteExample_setName1(remote_example_impl_t* impl, char *n, char **out);
 int remoteExample_setName2(remote_example_impl_t* impl, const char *n, char **out);
 int remoteExample_action(remote_example_impl_t* impl);
 int remoteExample_setComplex(remote_example_impl_t *impl, struct complex_input_example *exmpl, struct complex_output_example **out);
+int remoteExample_createAdditionalRemoteService(remote_example_impl_t* impl);
 
 //TODO complex
 #endif //CELIX_REMOTE_EXAMPLE_IMPL_H

--- a/bundles/remote_services/remote_service_admin_dfi/gtest/src/rsa_client_server_tests.cc
+++ b/bundles/remote_services/remote_service_admin_dfi/gtest/src/rsa_client_server_tests.cc
@@ -138,8 +138,13 @@ extern "C" {
 
     static void testCreateDestroyComponentWithRemoteService(void *handle __attribute__((unused)), void *svc) {
         auto *tst = static_cast<tst_service_t *>(svc);
-
         bool ok = tst->testCreateDestroyComponentWithRemoteService(tst->handle);
+        ASSERT_TRUE(ok);
+    };
+
+    static void testAddRemoteServiceInRemoteService(void *handle __attribute__((unused)), void *svc) {
+        auto *tst = static_cast<tst_service_t *>(svc);
+        bool ok = tst->testCreateRemoteServiceInRemoteCall(tst->handle);
         ASSERT_TRUE(ok);
     };
 
@@ -200,3 +205,6 @@ TEST_F(RsaDfiClientServerTests, CreateDestroyComponentWithRemoteService) {
     test(testCreateDestroyComponentWithRemoteService);
 }
 
+TEST_F(RsaDfiClientServerTests, AddRemoteServiceInRemoteService) {
+    test(testAddRemoteServiceInRemoteService);
+}

--- a/bundles/remote_services/remote_service_admin_dfi/gtest/src/rsa_client_server_tests.cc
+++ b/bundles/remote_services/remote_service_admin_dfi/gtest/src/rsa_client_server_tests.cc
@@ -136,6 +136,13 @@ extern "C" {
         ASSERT_TRUE(ok);
     };
 
+    static void testCreateDestroyComponentWithRemoteService(void *handle __attribute__((unused)), void *svc) {
+        auto *tst = static_cast<tst_service_t *>(svc);
+
+        bool ok = tst->testCreateDestroyComponentWithRemoteService(tst->handle);
+        ASSERT_TRUE(ok);
+    };
+
 }
 
 template<typename F>
@@ -188,3 +195,8 @@ TEST_F(RsaDfiClientServerTests, TestRemoteEnum) {
 TEST_F(RsaDfiClientServerTests, TestRemoteAction) {
     test(testAction);
 }
+
+TEST_F(RsaDfiClientServerTests, CreateDestroyComponentWithRemoteService) {
+    test(testCreateDestroyComponentWithRemoteService);
+}
+

--- a/bundles/remote_services/remote_service_admin_dfi/gtest/src/tst_activator.c
+++ b/bundles/remote_services/remote_service_admin_dfi/gtest/src/tst_activator.c
@@ -40,6 +40,7 @@
     } while(0)
 
 struct activator {
+    celix_bundle_context_t *ctx;
     long svcId;
     struct tst_service testSvc;
 
@@ -269,8 +270,30 @@ static bool bndTestRemoteComplex(void *handle) {
     return ok;
 }
 
+static bool bndTestCreateDestroyComponentWithRemoteService(void *handle) {
+    struct activator *act = handle;
+
+    celix_properties_t *properties = celix_properties_create();
+    celix_properties_set(properties, "service.exported.interfaces", CALCULATOR_SERVICE);
+
+    calculator_service_t calcSvc;
+    calcSvc.handle = NULL;
+    calcSvc.add = NULL; //note for this test case the actual services can be NULL
+    calcSvc.sub = NULL; //note for this test case the actual services can be NULL
+    calcSvc.sqrt = NULL; //note for this test case the actual services can be NULL
+
+    celix_dm_component_t *cmp = celix_dmComponent_create(act->ctx, "test");
+    celix_dmComponent_addInterface(cmp, CALCULATOR_SERVICE, NULL, &calcSvc, properties);
+
+    celix_dependency_manager_t *dm = celix_bundleContext_getDependencyManager(act->ctx);
+    dependencyManager_add(dm, cmp);
+    dependencyManager_removeAllComponents(dm); //note should not deadlock
+    return true;
+}
+
 static celix_status_t bndStart(struct activator *act, celix_bundle_context_t* ctx) {
     //initialize service struct
+    act->ctx = ctx;
     act->testSvc.handle = act;
     act->testSvc.isCalcDiscovered = bndIsCalculatorDiscovered;
     act->testSvc.isRemoteExampleDiscovered = bndIsRemoteExampleDiscovered;
@@ -281,6 +304,7 @@ static celix_status_t bndStart(struct activator *act, celix_bundle_context_t* ct
     act->testSvc.testRemoteEnum = bndTestRemoteEnum;
     act->testSvc.testRemoteAction = bndTestRemoteAction;
     act->testSvc.testRemoteComplex = bndTestRemoteComplex;
+    act->testSvc.testCreateDestroyComponentWithRemoteService = bndTestCreateDestroyComponentWithRemoteService;
 
 
     //create mutex

--- a/bundles/remote_services/remote_service_admin_dfi/gtest/src/tst_activator.c
+++ b/bundles/remote_services/remote_service_admin_dfi/gtest/src/tst_activator.c
@@ -291,6 +291,14 @@ static bool bndTestCreateDestroyComponentWithRemoteService(void *handle) {
     return true;
 }
 
+static bool testCreateRemoteServiceInRemoteCall(void *handle) {
+    struct activator *act = handle;
+    int rc;
+    TIMED_EXPR(rc = act->remoteExample->createAdditionalRemoteService(act->remoteExample->handle));
+    printf("Call createAdditionalRemoteService took %f ms\n", diff);
+    return rc == 0;
+}
+
 static celix_status_t bndStart(struct activator *act, celix_bundle_context_t* ctx) {
     //initialize service struct
     act->ctx = ctx;
@@ -304,6 +312,7 @@ static celix_status_t bndStart(struct activator *act, celix_bundle_context_t* ct
     act->testSvc.testRemoteEnum = bndTestRemoteEnum;
     act->testSvc.testRemoteAction = bndTestRemoteAction;
     act->testSvc.testRemoteComplex = bndTestRemoteComplex;
+    act->testSvc.testCreateRemoteServiceInRemoteCall = testCreateRemoteServiceInRemoteCall;
     act->testSvc.testCreateDestroyComponentWithRemoteService = bndTestCreateDestroyComponentWithRemoteService;
 
 

--- a/bundles/remote_services/remote_service_admin_dfi/gtest/src/tst_service.h
+++ b/bundles/remote_services/remote_service_admin_dfi/gtest/src/tst_service.h
@@ -34,6 +34,7 @@ struct tst_service {
     bool (*testRemoteAction)(void *handle);
     bool (*testRemoteComplex)(void *handle);
     bool (*testCreateDestroyComponentWithRemoteService)(void *handle);
+    bool (*testCreateRemoteServiceInRemoteCall)(void *handle);
 };
 
 typedef struct tst_service tst_service_t;

--- a/bundles/remote_services/remote_service_admin_dfi/gtest/src/tst_service.h
+++ b/bundles/remote_services/remote_service_admin_dfi/gtest/src/tst_service.h
@@ -33,6 +33,7 @@ struct tst_service {
     bool (*testRemoteEnum)(void *handle);
     bool (*testRemoteAction)(void *handle);
     bool (*testRemoteComplex)(void *handle);
+    bool (*testCreateDestroyComponentWithRemoteService)(void *handle);
 };
 
 typedef struct tst_service tst_service_t;

--- a/bundles/remote_services/remote_service_admin_dfi/src/export_registration_dfi.h
+++ b/bundles/remote_services/remote_service_admin_dfi/src/export_registration_dfi.h
@@ -34,5 +34,9 @@ void exportRegistration_setActive(export_registration_t *registration, bool acti
 
 celix_status_t exportRegistration_call(export_registration_t *export, char *data, int datalength, celix_properties_t *metadata, char **response, int *responseLength);
 
+void exportRegistration_increaseUsage(export_registration_t *export);
+void exportRegistration_decreaseUsage(export_registration_t *export);
+void exportRegistration_waitTillNotUsed(export_registration_t *export);
+
 
 #endif //CELIX_EXPORT_REGISTRATION_DFI_H

--- a/bundles/remote_services/remote_service_admin_dfi/src/export_registration_dfi.h
+++ b/bundles/remote_services/remote_service_admin_dfi/src/export_registration_dfi.h
@@ -26,11 +26,11 @@
 #include "endpoint_description.h"
 
 celix_status_t exportRegistration_create(celix_log_helper_t *helper, service_reference_pt reference, endpoint_description_t *endpoint, celix_bundle_context_t *context, FILE *logFile, export_registration_t **registration);
-celix_status_t exportRegistration_close(export_registration_t *registration);
 void exportRegistration_destroy(export_registration_t *registration);
 
 celix_status_t exportRegistration_start(export_registration_t *registration);
 celix_status_t exportRegistration_stop(export_registration_t *registration);
+void exportRegistration_setActive(export_registration_t *registration, bool active);
 
 celix_status_t exportRegistration_call(export_registration_t *export, char *data, int datalength, celix_properties_t *metadata, char **response, int *responseLength);
 

--- a/bundles/remote_services/remote_service_admin_dfi/src/remote_service_admin_dfi.c
+++ b/bundles/remote_services/remote_service_admin_dfi/src/remote_service_admin_dfi.c
@@ -65,7 +65,7 @@
  * celix_bundleContext_stopTrackerAsync is available.
  *
  */
-#define CELIX_RSA_USE_STOP_EXPORT_THREAD false
+#define CELIX_RSA_USE_STOP_EXPORT_THREAD true
 
 struct remote_service_admin {
     celix_bundle_context_t *context;

--- a/libs/framework/src/service_registry.c
+++ b/libs/framework/src/service_registry.c
@@ -604,7 +604,7 @@ static void serviceRegistry_logWarningServiceReferenceUsageCount(service_registr
         fw_log(registry->framework->logger, CELIX_LOG_LEVEL_WARNING, "Dangling service reference. Reference count is %zu, expected 1.  Look for missing bundleContext_ungetServiceReference calls.", refCount);
     }
 
-    if(usageCount > 0 || refCount > 0) {
+    if (usageCount > 0 || refCount > 0) {
         const char* bundle_name = celix_bundle_getSymbolicName(bundle);
         const char* service_name = "unknown";
         const char* bundle_provider_name = "unknown";
@@ -613,8 +613,12 @@ static void serviceRegistry_logWarningServiceReferenceUsageCount(service_registr
             service_registration_pt reg = NULL;
             bundle_pt providedBnd = NULL;
             serviceReference_getServiceRegistration(ref, &reg);
-            serviceRegistration_getBundle(reg, &providedBnd);
-            bundle_provider_name = celix_bundle_getSymbolicName(providedBnd);
+            if (reg != NULL) {
+                serviceRegistration_getBundle(reg, &providedBnd);
+                if (providedBnd != NULL) {
+                    bundle_provider_name = celix_bundle_getSymbolicName(providedBnd);
+                }
+            }
         }
 
         fw_log(registry->framework->logger, CELIX_LOG_LEVEL_WARNING, "Previous Dangling service reference warnings caused by bundle '%s', for service '%s', provided by bundle '%s'", bundle_name, service_name, bundle_provider_name);


### PR DESCRIPTION
The previous pr did not solve the deadlock issue.

This PR adds a test to reproduce the deadlock and adds a "export service closing" thread to the Remote Service Admin DFI to prevent the deadlock. 
Not a perfect solution, but IMO fine for now. 

A more long term solution can be implemented when the feature/async_svc_registration branch is ready and merged.
This branch should solve the deadlock issue in the service registry.

For an indication why this deadlock occurs see
https://github.com/apache/celix/blob/921ed6e142707926b2b5edfdf83b58e749759369/libs/framework/src/service_registry.c#L1229
