### PR TITLE
Fix serializing/deserializing json for pubsub

### DIFF
--- a/bundles/pubsub/pubsub_admin_websocket/src/pubsub_websocket_topic_sender.c
+++ b/bundles/pubsub/pubsub_admin_websocket/src/pubsub_websocket_topic_sender.c
@@ -324,7 +324,7 @@ static int psa_websocket_topicPublicationSend(void* handle, unsigned int msgType
             json_object_set_new_nocheck(jsMsg, "seqNr", json_integer(entry->header.seqNr++));
 
             json_t *jsData;
-            jsData = json_loadb((const char *)serializedOutput->iov_base, serializedOutput->iov_len - 1, 0, &jsError);
+            jsData = json_loadb((const char *)serializedOutput->iov_base, serializedOutput->iov_len, 0, &jsError);
             if(jsData != NULL) {
                 json_object_set_new_nocheck(jsMsg, "data", jsData);
                 const char *msg = json_dumps(jsMsg, 0);

--- a/bundles/pubsub/pubsub_serializer_json/gtest/src/PubSubJsonSerializationProviderTestSuite.cc
+++ b/bundles/pubsub/pubsub_serializer_json/gtest/src/PubSubJsonSerializationProviderTestSuite.cc
@@ -109,7 +109,7 @@ TEST_F(PubSubJsonSerializationProviderTestSuite, DeserializeTest) {
         poi1 *p = nullptr;
         iovec inVec;
         inVec.iov_base = static_cast<void*>(const_cast<char*>(data));
-        inVec.iov_len = strlen(data) + 1;
+        inVec.iov_len = strlen(data);
         ser->deserialize(ser->handle, &inVec, 1, (void**)(&p));
         EXPECT_EQ(42,p->location.lat);
         EXPECT_EQ(43,p->location.lon);

--- a/bundles/pubsub/pubsub_serializer_json/src/pubsub_json_serialization_provider.c
+++ b/bundles/pubsub/pubsub_serializer_json/src/pubsub_json_serialization_provider.c
@@ -60,7 +60,7 @@ static celix_status_t pubsub_jsonSerializationProvider_serialize(pubsub_serializ
 
     if (status == CELIX_SUCCESS) {
         (**output).iov_base = (void*)jsonOutput;
-        (**output).iov_len  = strlen(jsonOutput) + 1;
+        (**output).iov_len  = strlen(jsonOutput);
     }
 
     return status;
@@ -88,7 +88,7 @@ static celix_status_t pubsub_jsonSerializationProvider_deserialize(pubsub_serial
     dyn_type* dynType;
     dynMessage_getMessageType(entry->msgType, &dynType);
 
-    if (jsonSerializer_deserialize(dynType, (const char*)input->iov_base, &msg) != 0) {
+    if (jsonSerializer_deserialize(dynType, (const char*)input->iov_base, input->iov_len, &msg) != 0) {
         status = CELIX_BUNDLE_EXCEPTION;
     } else{
         *out = msg;

--- a/bundles/pubsub/pubsub_serializer_json/src/pubsub_serializer_impl.c
+++ b/bundles/pubsub/pubsub_serializer_json/src/pubsub_serializer_impl.c
@@ -177,7 +177,7 @@ celix_status_t pubsubMsgSerializer_serialize(void *handle, const void* msg, stru
 
     if (status == CELIX_SUCCESS) {
         (**output).iov_base = (void*)jsonOutput;
-        (**output).iov_len  = strlen(jsonOutput) + 1;
+        (**output).iov_len  = strlen(jsonOutput);
         if (outputIovLen) *outputIovLen = 1;
     }
 
@@ -192,7 +192,7 @@ celix_status_t pubsubMsgSerializer_deserialize(void* handle, const struct iovec*
     dyn_type* dynType;
     dynMessage_getMessageType(impl->msgType, &dynType);
 
-    if (jsonSerializer_deserialize(dynType, (const char*)input->iov_base, &msg) != 0) {
+    if (jsonSerializer_deserialize(dynType, (const char*)input->iov_base, input->iov_len, &msg) != 0) {
         status = CELIX_BUNDLE_EXCEPTION;
     }
     else{

--- a/libs/dfi/gtest/src/json_serializer_tests.cpp
+++ b/libs/dfi/gtest/src/json_serializer_tests.cpp
@@ -795,7 +795,7 @@ static void parseAvprTests() {
     inst = nullptr;
     type = dynType_parseAvprWithStr(avpr_example1_descriptor, avpr_example1_fqn);
     ASSERT_TRUE(type != nullptr);
-	rc = jsonSerializer_deserialize(type, example1_input, &inst);
+	rc = jsonSerializer_deserialize(type, example1_input, strlen(example1_input), &inst);
 	ASSERT_EQ(0, rc);
 	check_example1(inst);
 	dynType_free(type, inst);
@@ -804,7 +804,7 @@ static void parseAvprTests() {
     inst = nullptr;
     type = dynType_parseAvprWithStr(avpr_example2_descriptor, avpr_example2_fqn);
     ASSERT_TRUE(type != nullptr);
-	rc = jsonSerializer_deserialize(type, example2_input, &inst);
+	rc = jsonSerializer_deserialize(type, example2_input, strlen(example2_input), &inst);
 	ASSERT_EQ(0, rc);
 	check_example2(inst);
 	dynType_free(type, inst);
@@ -813,7 +813,7 @@ static void parseAvprTests() {
     inst = nullptr;
     type = dynType_parseAvprWithStr(avpr_example3_descriptor, avpr_example3_fqn);
     ASSERT_TRUE(type != nullptr);
-	rc = jsonSerializer_deserialize(type, example3_input, &inst);
+	rc = jsonSerializer_deserialize(type, example3_input, strlen(example3_input), &inst);
 	ASSERT_EQ(0, rc);
 	check_example3(inst);
 	dynType_free(type, inst);
@@ -822,7 +822,7 @@ static void parseAvprTests() {
     inst = nullptr;
     type = dynType_parseAvprWithStr(avpr_example4_descriptor, avpr_example4_fqn);
     ASSERT_TRUE(type != nullptr);
-	rc = jsonSerializer_deserialize(type, example4_input, &inst);
+	rc = jsonSerializer_deserialize(type, example4_input, strlen(example4_input), &inst);
 	ASSERT_EQ(0, rc);
 	check_example4(inst);
 	dynType_free(type, inst);
@@ -831,7 +831,7 @@ static void parseAvprTests() {
     inst = nullptr;
     type = dynType_parseAvprWithStr(avpr_example5_descriptor, avpr_example5_fqn);
     ASSERT_TRUE(type != nullptr);
-	rc = jsonSerializer_deserialize(type, example5_input, &inst);
+	rc = jsonSerializer_deserialize(type, example5_input, strlen(example5_input), &inst);
 	ASSERT_EQ(0, rc);
 	check_example5(inst);
 	dynType_free(type, inst);
@@ -841,7 +841,7 @@ static void parseAvprTests() {
     inst = nullptr;
     type = dynType_parseAvprWithStr(avpr_example6_descriptor, avpr_example6_fqn);
     ASSERT_TRUE(type != nullptr);
-	rc = jsonSerializer_deserialize(type, avpr_example6_input, &inst);
+	rc = jsonSerializer_deserialize(type, avpr_example6_input, strlen(avpr_example6_input), &inst);
 	ASSERT_EQ(0, rc);
 	check_example6_avpr(inst);
 	dynType_free(type, inst);
@@ -850,7 +850,7 @@ static void parseAvprTests() {
     inst = nullptr;
     type = dynType_parseAvprWithStr(avpr_example7_descriptor, avpr_example7_fqn);
     ASSERT_TRUE(type != nullptr);
-	rc = jsonSerializer_deserialize(type, example7_input, &inst);
+	rc = jsonSerializer_deserialize(type, example7_input, strlen(example7_input), &inst);
 	ASSERT_EQ(0, rc);
 	check_example7(inst);
 	dynType_free(type, inst);
@@ -859,7 +859,7 @@ static void parseAvprTests() {
     inst = nullptr;
     type = dynType_parseAvprWithStr(avpr_example8_descriptor, avpr_example8_fqn);
     ASSERT_TRUE(type != nullptr);
-	rc = jsonSerializer_deserialize(type, example8_input, &inst);
+	rc = jsonSerializer_deserialize(type, example8_input, strlen(example8_input), &inst);
 	ASSERT_EQ(0, rc);
 	check_example8(inst);
 	dynType_free(type, inst);
@@ -868,15 +868,15 @@ static void parseAvprTests() {
     inst = nullptr;
     type = dynType_parseAvprWithStr(avpr_example9_descriptor, avpr_example9_fqn);
     ASSERT_TRUE(type != nullptr);
-	rc = jsonSerializer_deserialize(type, example9_input_1, &inst);
+	rc = jsonSerializer_deserialize(type, example9_input_1, strlen(example9_input_1), &inst);
 	ASSERT_EQ(0, rc);
 	check_example9_1(inst);
 	dynType_free(type, inst);
-	rc = jsonSerializer_deserialize(type, example9_input_2, &inst);
+	rc = jsonSerializer_deserialize(type, example9_input_2, strlen(example9_input_2), &inst);
 	ASSERT_EQ(0, rc);
 	check_example9_2(inst);
 	dynType_free(type, inst);
-    rc = jsonSerializer_deserialize(type, example9_input_3, &inst);
+    rc = jsonSerializer_deserialize(type, example9_input_3, strlen(example9_input_3), &inst);
     ASSERT_EQ(0, rc);
     check_example9_3(inst);
     dynType_free(type, inst);
@@ -892,7 +892,7 @@ static void parseTests() {
 	inst = nullptr;
 	rc = dynType_parseWithStr(example1_descriptor, nullptr, nullptr, &type);
 	ASSERT_EQ(0, rc);
-	rc = jsonSerializer_deserialize(type, example1_input, &inst);
+	rc = jsonSerializer_deserialize(type, example1_input, strlen(example1_input), &inst);
 	ASSERT_EQ(0, rc);
 	check_example1(inst);
 	dynType_free(type, inst);
@@ -902,7 +902,7 @@ static void parseTests() {
 	inst = nullptr;
 	rc = dynType_parseWithStr(example2_descriptor, nullptr, nullptr, &type);
 	ASSERT_EQ(0, rc);
-	rc = jsonSerializer_deserialize(type, example2_input, &inst);
+	rc = jsonSerializer_deserialize(type, example2_input, strlen(example2_input), &inst);
 	ASSERT_EQ(0, rc);
 	check_example2(inst);
 	dynType_free(type, inst);
@@ -912,7 +912,7 @@ static void parseTests() {
 	inst = nullptr;
 	rc = dynType_parseWithStr(example3_descriptor, nullptr, nullptr, &type);
 	ASSERT_EQ(0, rc);
-	rc = jsonSerializer_deserialize(type, example3_input, &inst);
+	rc = jsonSerializer_deserialize(type, example3_input, strlen(example3_input), &inst);
 	ASSERT_EQ(0, rc);
 	check_example3(inst);
 	dynType_free(type, inst);
@@ -922,7 +922,7 @@ static void parseTests() {
 	inst = nullptr;
 	rc = dynType_parseWithStr(example4_descriptor, nullptr, nullptr, &type);
 	ASSERT_EQ(0, rc);
-	rc = jsonSerializer_deserialize(type, example4_input, &inst);
+	rc = jsonSerializer_deserialize(type, example4_input, strlen(example4_input), &inst);
 	ASSERT_EQ(0, rc);
 	check_example4(inst);
 	dynType_free(type, inst);
@@ -932,7 +932,7 @@ static void parseTests() {
 	inst = nullptr;
 	rc = dynType_parseWithStr(example5_descriptor, nullptr, nullptr, &type);
 	ASSERT_EQ(0, rc);
-	rc = jsonSerializer_deserialize(type, example5_input, &inst);
+	rc = jsonSerializer_deserialize(type, example5_input, strlen(example5_input), &inst);
 	ASSERT_EQ(0, rc);
 	check_example5(inst);
 	dynType_free(type, inst);
@@ -942,7 +942,7 @@ static void parseTests() {
 	struct ex6_sequence *seq;
 	rc = dynType_parseWithStr(example6_descriptor, nullptr, nullptr, &type);
 	ASSERT_EQ(0, rc);
-	rc = jsonSerializer_deserialize(type, example6_input, (void **)&seq);
+	rc = jsonSerializer_deserialize(type, example6_input, strlen(example6_input), (void **)&seq);
 	ASSERT_EQ(0, rc);
 	check_example6((*seq));
 	dynType_free(type, seq);
@@ -952,7 +952,7 @@ static void parseTests() {
 	inst = nullptr;
 	rc = dynType_parseWithStr(example7_descriptor, nullptr, nullptr, &type);
 	ASSERT_EQ(0, rc);
-	rc = jsonSerializer_deserialize(type, example7_input, &inst);
+	rc = jsonSerializer_deserialize(type, example7_input, strlen(example7_input), &inst);
 	ASSERT_EQ(0, rc);
 	check_example7(inst);
 	dynType_free(type, inst);
@@ -962,7 +962,7 @@ static void parseTests() {
 	inst = nullptr;
 	rc = dynType_parseWithStr(example8_descriptor, nullptr, nullptr, &type);
 	ASSERT_EQ(0, rc);
-	rc = jsonSerializer_deserialize(type, example8_input, &inst);
+	rc = jsonSerializer_deserialize(type, example8_input, strlen(example8_input), &inst);
 	ASSERT_EQ(0, rc);
 	check_example8(inst);
 	dynType_free(type, inst);
@@ -972,11 +972,11 @@ static void parseTests() {
 	inst = nullptr;
 	rc = dynType_parseWithStr(example9_descriptor, nullptr, nullptr, &type);
 	ASSERT_EQ(0, rc);
-	rc = jsonSerializer_deserialize(type, example9_input_1, &inst);
+	rc = jsonSerializer_deserialize(type, example9_input_1, strlen(example9_input_1), &inst);
 	ASSERT_EQ(0, rc);
 	check_example9_1(inst);
 	dynType_free(type, inst);
-	rc = jsonSerializer_deserialize(type, example9_input_2, &inst);
+	rc = jsonSerializer_deserialize(type, example9_input_2, strlen(example9_input_2), &inst);
 	ASSERT_EQ(0, rc);
 	check_example9_2(inst);
 	dynType_free(type, inst);
@@ -986,7 +986,7 @@ static void parseTests() {
     inst = nullptr;
     rc = dynType_parseWithStr(exampleA_descriptor, nullptr, nullptr, &type);
     ASSERT_EQ(0, rc);
-    rc = jsonSerializer_deserialize(type, exampleA_input, &inst);
+    rc = jsonSerializer_deserialize(type, exampleA_input, strlen(exampleA_input), &inst);
     ASSERT_EQ(0, rc);
     check_exampleA(inst);
     dynType_free(type, inst);

--- a/libs/dfi/include/json_serializer.h
+++ b/libs/dfi/include/json_serializer.h
@@ -33,7 +33,7 @@ extern "C" {
 //logging
 DFI_SETUP_LOG_HEADER(jsonSerializer);
 
-int jsonSerializer_deserialize(dyn_type *type, const char *input, void **result);
+int jsonSerializer_deserialize(dyn_type *type, const char *input, size_t length, void **result);
 int jsonSerializer_deserializeJson(dyn_type *type, json_t *input, void **result);
 
 int jsonSerializer_serialize(dyn_type *type, const void* input, char **output);

--- a/libs/dfi/src/json_serializer.c
+++ b/libs/dfi/src/json_serializer.c
@@ -45,12 +45,12 @@ static int ERROR = 1;
 
 DFI_SETUP_LOG(jsonSerializer);
 
-int jsonSerializer_deserialize(dyn_type *type, const char *input, void **result) {
+int jsonSerializer_deserialize(dyn_type *type, const char *input, size_t length, void **result) {
     assert(dynType_type(type) == DYN_TYPE_COMPLEX || dynType_type(type) == DYN_TYPE_SEQUENCE);
     int status = 0;
 
     json_error_t error;
-    json_t *root = json_loads(input, JSON_DECODE_ANY, &error);
+    json_t *root = json_loadb(input, length, JSON_DECODE_ANY, &error);
 
     if (root != NULL) {
         status = jsonSerializer_deserializeJson(type, root, result);


### PR DESCRIPTION
My guess is that with the introduction of iovec, the buffer that gets passed in various places is non-null terminated. This is fine, except that `json_loads` requires a null-terminated string. This PR fixes these issues.