### PR TITLE
gh-305: Adds ifndef test to prevent double define of MSG_NOSIGNAL for OSX

### DIFF
--- a/bundles/pubsub/pubsub_admin_tcp/src/pubsub_tcp_handler.c
+++ b/bundles/pubsub/pubsub_admin_tcp/src/pubsub_tcp_handler.c
@@ -54,7 +54,9 @@
 #define MAX_DEFAULT_BUFFER_SIZE 4u
 
 #if defined(__APPLE__)
+#ifndef MSG_NOSIGNAL
 #define MSG_NOSIGNAL (0)
+#endif
 #endif
 
 #define L_DEBUG(...) \


### PR DESCRIPTION
Fixes #305 