### PR TITLE
size_t casting and celix_array_list element allocation fix for 32 bits platforms

### DIFF
--- a/bundles/logging/log_admin/src/celix_log_admin.c
+++ b/bundles/logging/log_admin/src/celix_log_admin.c
@@ -468,7 +468,7 @@ static void celix_logAdmin_setLogLevelCmd(celix_log_admin_t* admin, const char* 
     celix_log_level_e logLevel = celix_logUtils_logLevelFromStringWithCheck(level, CELIX_LOG_LEVEL_TRACE, &converted);
     if (converted) {
         size_t count = celix_logAdmin_setActiveLogLevels(admin, select, logLevel);
-        fprintf(outStream, "Updated %lu log services to log level %s\n", count, celix_logUtils_logLevelToString(logLevel));
+        fprintf(outStream, "Updated %lu log services to log level %s\n", (long unsigned int) count, celix_logUtils_logLevelToString(logLevel));
     } else {
         fprintf(outStream, "Cannot convert '%s' to a valid celix log level.\n", level);
     }
@@ -486,7 +486,7 @@ static void celix_logAdmin_setSinkEnabledCmd(celix_log_admin_t* admin, const cha
     }
     if (valid) {
         size_t count = celix_logAdmin_setSinkEnabled(admin, select, enableSink);
-        fprintf(outStream, "Updated %lu log sinks to %s.\n", count, enableSink ? "enabled" : "disabled");
+        fprintf(outStream, "Updated %lu log sinks to %s.\n", (long unsigned int) count, enableSink ? "enabled" : "disabled");
     } else {
         fprintf(outStream, "Cannot convert '%s' to a boolean value.\n", enabled);
     }

--- a/bundles/pubsub/pubsub_utils/src/pubsub_serialization_provider.c
+++ b/bundles/pubsub/pubsub_utils/src/pubsub_serialization_provider.c
@@ -480,7 +480,7 @@ static void pubsub_serializationProvider_printEntryDetails(pubsub_serialization_
     fprintf(outStream, "|- %20s = %li\n", "svc id", entry->svcId);
     fprintf(outStream, "|- %20s = %s (bundle id %li)\n", "read from bundle", bndName, entry->readFromBndId);
     fprintf(outStream, "|- %20s = %s\n", "bundle entry name", entry->readFromEntryPath);
-    fprintf(outStream, "|- %20s = %lu\n", "nr of times found", entry->nrOfTimesRead);
+    fprintf(outStream, "|- %20s = %lu\n", "nr of times found", (long unsigned int) entry->nrOfTimesRead);
     fprintf(outStream, "|- %20s = %s\n", "valid", entry->valid ? "true" : "false");
     if (!entry->valid) {
         fprintf(outStream, "|- %20s = %s\n", "invalid reason", entry->invalidReason);

--- a/bundles/pubsub/test/test/tst_activator.c
+++ b/bundles/pubsub/test/test/tst_activator.c
@@ -128,6 +128,6 @@ static size_t tst_count(void *handle) {
     count1 = act->count1;
     count2 = act->count2;
     pthread_mutex_unlock(&act->mutex);
-    printf("msg count1 is %lu and msg count 2 is %lu\n", count1, count2);
+    printf("msg count1 is %lu and msg count 2 is %lu\n", (long unsigned int) count1, (long unsigned int) count2);
     return count1 >= count2 ? count1 : count2;
 }

--- a/bundles/shell/shell/src/query_command.c
+++ b/bundles/shell/shell/src/query_command.c
@@ -122,7 +122,7 @@ static void queryCommand_callback(void *handle, const celix_bundle_t *bnd) {
                 queryCommand_printBundleHeader(data->sout, bnd, &printBundleCalled);
                 fprintf(data->sout, "|- Service tracker '%s'\n", entry->filter);
                 if (data->opts->verbose) {
-                    fprintf(data->sout,"   |- nr of tracked services %lu\n", entry->nrOfTrackedServices);
+                    fprintf(data->sout,"   |- nr of tracked services %lu\n", (long unsigned int) entry->nrOfTrackedServices);
                 }
             }
         }
@@ -164,8 +164,8 @@ static void queryCommand_listServices(celix_bundle_context_t *ctx, const struct 
         fprintf(sout, "No results\n");
     } else {
         fprintf(sout, "Query result:\n");
-        fprintf(sout, "|- Provided services found %lu\n", data.nrOfProvidedServicesFound);
-        fprintf(sout, "|- Requested services found %lu\n", data.nrOfRequestedServicesFound);
+        fprintf(sout, "|- Provided services found %lu\n", (long unsigned int) data.nrOfProvidedServicesFound);
+        fprintf(sout, "|- Requested services found %lu\n", (long unsigned int) data.nrOfRequestedServicesFound);
         fprintf(sout, "\n");
     }
 }

--- a/libs/dfi/src/dyn_avpr_function.c
+++ b/libs/dfi/src/dyn_avpr_function.c
@@ -201,7 +201,7 @@ inline static bool dynAvprFunction_parseArgument(dyn_function_type * func, size_
     const char * entry_name = json_string_value(json_object_get(entry, "name"));
     if (!entry_name)  {
         LOG_INFO("ParseArgument: Could not find argument name for %d, using default", index);
-        snprintf(argBuffer, ARG_SIZE, "arg%04lu", index);
+        snprintf(argBuffer, ARG_SIZE, "arg%04lu", (long unsigned int) index);
         entry_name = argBuffer;
     }
 

--- a/libs/dfi/src/dyn_avpr_type.c
+++ b/libs/dfi/src/dyn_avpr_type.c
@@ -719,7 +719,7 @@ static inline bool dynAvprType_metaEntrySetValue(struct meta_entry * meta_entry_
         const size_t bufsize = sizeof(index) * CHAR_BIT + 1;
         meta_entry_ptr->value = calloc(bufsize, sizeof(char));
 
-        snprintf(meta_entry_ptr->value, bufsize, "%lu", index);
+        snprintf(meta_entry_ptr->value, bufsize, "%lu", (long unsigned int) index);
     }
 
     return true;

--- a/libs/utils/src/array_list.c
+++ b/libs/utils/src/array_list.c
@@ -79,7 +79,7 @@ void arrayList_trimToSize(array_list_pt list) {
     list->modCount++;
     size_t oldCapacity = list->capacity;
     if (list->size < oldCapacity) {
-        celix_array_list_entry_t * newList = realloc(list->elementData, sizeof(void *) * list->size);
+        celix_array_list_entry_t * newList = realloc(list->elementData, sizeof(celix_array_list_entry_t) * list->size);
         list->capacity = list->size;
         list->elementData = newList;
     }
@@ -94,7 +94,7 @@ void arrayList_ensureCapacity(array_list_pt list, int capacity) {
         if (newCapacity < capacity) {
             newCapacity = capacity;
         }
-        newList = realloc(list->elementData, sizeof(void *) * newCapacity);
+        newList = realloc(list->elementData, sizeof(celix_array_list_entry_t) * newCapacity);
         list->capacity = newCapacity;
         list->elementData = newList;
     }
@@ -365,7 +365,7 @@ celix_array_list_t* celix_arrayList_createWithEquals(celix_arrayList_equals_fp e
     array_list_t *list = calloc(1, sizeof(*list));
     if (list != NULL) {
         list->capacity = 10;
-        list->elementData = malloc(sizeof(void*) * list->capacity);
+        list->elementData = malloc(sizeof(celix_array_list_entry_t) * list->capacity);
         list->equals = equals;
     }
     return list;

--- a/libs/utils/src/properties.c
+++ b/libs/utils/src/properties.c
@@ -262,7 +262,7 @@ celix_properties_t* celix_properties_loadWithStream(FILE *file) {
             if (filebuffer) {
                 size_t rs = fread(filebuffer, sizeof(char), file_size, file);
                 if (rs != file_size) {
-                    fprintf(stderr,"fread read only %lu bytes out of %lu\n", rs, file_size);
+                    fprintf(stderr,"fread read only %lu bytes out of %lu\n", (long unsigned int) rs, (long unsigned int) file_size);
                 }
                 filebuffer[file_size]='\0';
                 line = strtok_r(filebuffer, "\n", &saveptr);


### PR DESCRIPTION
upcast size_t to long unsigned int for "%lu" formatting for 32 bits platforms, allocate sizeof(celix_array_list_entry_t) instead of sizeof(void*), which differ in size on 32 bits systems.