### PR TITLE
Update GH actions to not use the master branch

### DIFF
--- a/.github/workflows/celix_etcdlib.yml
+++ b/.github/workflows/celix_etcdlib.yml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout source code
-        uses: actions/checkout@master
+        uses: actions/checkout@v2
       - name: Install dependencies
         run: |
           sudo apt-get update

--- a/.github/workflows/celix_promise.yml
+++ b/.github/workflows/celix_promise.yml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout source code
-        uses: actions/checkout@master
+        uses: actions/checkout@v2
       - name: Install dependencies
         run: |
           sudo apt-get update

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - name: Checkout source code
-        uses: actions/checkout@master
+        uses: actions/checkout@v2
       - name: Install dependencies
         run: |
           sudo apt-get update
@@ -43,7 +43,7 @@ jobs:
           make coverage
           lcx="lcov --output-file=coverage.info " && for i in `find . -name "*.info.cleaned"`; do lcx+=" --add-tracefile=$i"; done && $lcx
       - name: Codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@e156083f13aff6830c92fc5faa23505779fbf649
         with:
           file: build/coverage.info
           name: codecov-celix

--- a/.github/workflows/coverity-scan.yml
+++ b/.github/workflows/coverity-scan.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - name: Checkout source code
-        uses: actions/checkout@master
+        uses: actions/checkout@v2
       - name: Install dependencies
         run: |
           sudo apt-get update

--- a/.github/workflows/macos-nightly.yml
+++ b/.github/workflows/macos-nightly.yml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 120
     steps:
     - name: Checkout source code
-      uses: actions/checkout@master
+      uses: actions/checkout@v2
     - name: Install dependencies
       run: |
         brew update

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -13,7 +13,7 @@ jobs:
     timeout-minutes: 120
     steps:
     - name: Checkout source code
-      uses: actions/checkout@master
+      uses: actions/checkout@v2
     - name: Install dependencies
       run: |
         brew update

--- a/.github/workflows/ubuntu-nightly.yml
+++ b/.github/workflows/ubuntu-nightly.yml
@@ -32,7 +32,7 @@ jobs:
     timeout-minutes: 120
     steps:
     - name: Checkout source code
-      uses: actions/checkout@master
+      uses: actions/checkout@v2
     - name: Install dependencies
       run: |
         sudo apt-get update

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -30,7 +30,7 @@ jobs:
     timeout-minutes: 120
     steps:
     - name: Checkout source code
-      uses: actions/checkout@master
+      uses: actions/checkout@v2
     - name: Install dependencies
       run: |
         sudo apt-get update


### PR DESCRIPTION
Also pin the 3rd party codecov action using a hash

Following the discussion on the builds@a.o & users@infra list it is recommended to not use branches for GH actions and instead use tags instead.
For third party actions (anything not from `github/`, `actions/` and `apache/`) it is advised to pin them using a hash.

For detailed info see the following threads:
- https://lists.apache.org/thread.html/r900f8f9a874006ed8121bdc901a0d1acccbb340882c1f94dad61a5e9%40%3Cusers.infra.apache.org%3E
- https://lists.apache.org/thread.html/r435c45dfc28ec74e28314aa9db8a216a2b45ff7f27b15932035d3f65%40%3Cbuilds.apache.org%3E