### PR TITLE
prevents unneeded suspend triggers in the dm component

### DIFF
--- a/libs/framework/src/dm_component_impl.c
+++ b/libs/framework/src/dm_component_impl.c
@@ -554,8 +554,12 @@ static bool celix_dmComponent_needsSuspend(celix_dm_component_t *component, cons
     }
     celixThreadMutex_unlock(&component->mutex);
     if (cmpActive) {
+        bool callbackConfigured = event->eventType == CELIX_DM_EVENT_SVC_SET ?
+                                  celix_dmServiceDependency_isSetCallbackConfigured(event->dep) :
+                                 /*add or rem*/ celix_dmServiceDependency_isAddRemCallbacksConfigured(event->dep);
         dm_service_dependency_strategy_t strategy = celix_dmServiceDependency_getStrategy(event->dep);
-        return strategy == DM_SERVICE_DEPENDENCY_STRATEGY_SUSPEND;
+        bool suspendStrategy = strategy == DM_SERVICE_DEPENDENCY_STRATEGY_SUSPEND;
+        return suspendStrategy && callbackConfigured;
     } else {
         return false;
     }

--- a/libs/framework/src/dm_service_dependency.c
+++ b/libs/framework/src/dm_service_dependency.c
@@ -244,9 +244,8 @@ celix_status_t celix_dmServiceDependency_disable(celix_dm_service_dependency_t *
 }
 
 bool celix_dmServiceDependency_isDisabled(celix_dm_service_dependency_t *dependency) {
-    bool isStopped;
     celixThreadMutex_lock(&dependency->mutex);
-    isStopped = dependency->svcTrackerId == -1L && dependency->nrOfActiveStoppingTrackers == 0;
+    bool isStopped = dependency->svcTrackerId == -1L && dependency->nrOfActiveStoppingTrackers == 0;
     celixThreadMutex_unlock(&dependency->mutex);
     return isStopped;
 }
@@ -324,9 +323,8 @@ celix_status_t celix_dmServiceDependency_invokeRemove(celix_dm_service_dependenc
 }
 
 bool celix_dmServiceDependency_isAvailable(celix_dm_service_dependency_t *dependency) {
-    bool avail;
     celixThreadMutex_lock(&dependency->mutex);
-    avail = dependency->trackedSvcCount > 0;
+    bool avail = dependency->trackedSvcCount > 0;
     celixThreadMutex_unlock(&dependency->mutex);
     return avail;
 }
@@ -343,18 +341,12 @@ bool celix_dmServiceDependency_isTrackerOpen(celix_dm_service_dependency_t* depe
 }
 
 bool celix_dmServiceDependency_isSetCallbackConfigured(celix_dm_service_dependency_t* dependency) {
-    bool isUsed;
-    celixThreadMutex_lock(&dependency->mutex);
-    isUsed = dependency->set != NULL || dependency->setWithProperties != NULL;
-    celixThreadMutex_unlock(&dependency->mutex);
+    bool isUsed = dependency->set != NULL || dependency->setWithProperties != NULL;
     return isUsed;
 }
 bool celix_dmServiceDependency_isAddRemCallbacksConfigured(celix_dm_service_dependency_t* dependency) {
-    bool isUsed;
-    celixThreadMutex_lock(&dependency->mutex);
-    isUsed = dependency->add != NULL || dependency->addWithProperties != NULL ||
+    bool isUsed = dependency->add != NULL || dependency->addWithProperties != NULL ||
             dependency->remove != NULL || dependency->remWithProperties != NULL;
-    celixThreadMutex_unlock(&dependency->mutex);
     return isUsed;
 }
 

--- a/libs/framework/src/dm_service_dependency.c
+++ b/libs/framework/src/dm_service_dependency.c
@@ -342,6 +342,22 @@ bool celix_dmServiceDependency_isTrackerOpen(celix_dm_service_dependency_t* depe
     return isOpen;
 }
 
+bool celix_dmServiceDependency_isSetCallbackConfigured(celix_dm_service_dependency_t* dependency) {
+    bool isUsed;
+    celixThreadMutex_lock(&dependency->mutex);
+    isUsed = dependency->set != NULL || dependency->setWithProperties != NULL;
+    celixThreadMutex_unlock(&dependency->mutex);
+    return isUsed;
+}
+bool celix_dmServiceDependency_isAddRemCallbacksConfigured(celix_dm_service_dependency_t* dependency) {
+    bool isUsed;
+    celixThreadMutex_lock(&dependency->mutex);
+    isUsed = dependency->add != NULL || dependency->addWithProperties != NULL ||
+            dependency->remove != NULL || dependency->remWithProperties != NULL;
+    celixThreadMutex_unlock(&dependency->mutex);
+    return isUsed;
+}
+
 celix_status_t serviceDependency_getServiceDependencyInfo(celix_dm_service_dependency_t *dep, dm_service_dependency_info_t **out) {
 	if (out != NULL) {
 		*out = celix_dmServiceDependency_createInfo(dep);

--- a/libs/framework/src/dm_service_dependency_impl.h
+++ b/libs/framework/src/dm_service_dependency_impl.h
@@ -78,6 +78,10 @@ bool celix_dmServiceDependency_isAvailable(celix_dm_service_dependency_t *depend
 bool celix_dmServiceDependency_isRequired(const celix_dm_service_dependency_t* dependency);
 bool celix_dmServiceDependency_isTrackerOpen(celix_dm_service_dependency_t* dependency);
 
+
+bool celix_dmServiceDependency_isSetCallbackConfigured(celix_dm_service_dependency_t* dependency);
+bool celix_dmServiceDependency_isAddRemCallbacksConfigured(celix_dm_service_dependency_t* dependency);
+
 #ifdef __cplusplus
 }
 #endif

--- a/libs/framework/src/service_tracker.c
+++ b/libs/framework/src/service_tracker.c
@@ -114,6 +114,7 @@ celix_status_t serviceTracker_create(bundle_context_pt context, const char * ser
 celix_status_t serviceTracker_createWithFilter(bundle_context_pt context, const char * filter, service_tracker_customizer_pt customizer, service_tracker_pt *out) {
 	service_tracker_t* tracker = calloc(1, sizeof(*tracker));
 	*out = tracker;
+	tracker->state = CELIX_SERVICE_TRACKER_CLOSED;
     tracker->context = context;
     tracker->filter = celix_utils_strdup(filter);
     tracker->customizer = *customizer;
@@ -178,7 +179,7 @@ celix_status_t serviceTracker_open(service_tracker_pt tracker) {
     }
     celixThreadMutex_unlock(&tracker->mutex);
 
-    if (!addListener) {
+    if (addListener) {
         bundleContext_addServiceListener(tracker->context, &tracker->listener, tracker->filter);
     }
 
@@ -657,6 +658,7 @@ celix_service_tracker_t* celix_serviceTracker_createWithOptions(
         if (tracker != NULL) {
             tracker->context = ctx;
             tracker->serviceName = celix_utils_strdup(serviceName);
+            tracker->state = CELIX_SERVICE_TRACKER_CLOSED;
 
             //setting callbacks
             tracker->callbackHandle = opts->callbackHandle;

--- a/libs/framework/src/service_tracker_private.h
+++ b/libs/framework/src/service_tracker_private.h
@@ -23,6 +23,13 @@
 #include "service_tracker.h"
 #include "celix_types.h"
 
+enum celix_service_tracker_state {
+    CELIX_SERVICE_TRACKER_OPENING,
+    CELIX_SERVICE_TRACKER_OPEN,
+    CELIX_SERVICE_TRACKER_CLOSING,
+    CELIX_SERVICE_TRACKER_CLOSED
+};
+
 struct celix_serviceTracker {
 	bundle_context_t *context;
 
@@ -60,7 +67,7 @@ struct celix_serviceTracker {
     celix_thread_cond_t  cond;
     celix_array_list_t *trackedServices;
     celix_array_list_t *untrackingServices;
-    bool open;
+    enum celix_service_tracker_state state;
     long currentHighestServiceId;
 };
 


### PR DESCRIPTION
This PR updates the handling of set and add/rem callbacks to ensure that a component is not unnecessary suspended. 
Before these changes components where suspended for set, add and remove service events, even if they had no callbacks to handle these events.