### PR TITLE
Feature/promise scheduler abstraction

### DIFF
--- a/libs/promises/api/celix/DefaultExecutor.h
+++ b/libs/promises/api/celix/DefaultExecutor.h
@@ -34,7 +34,7 @@ namespace celix {
     public:
         explicit DefaultExecutor(std::launch _policy = std::launch::async | std::launch::deferred) : policy{_policy} {}
 
-        void execute(std::function<void()> task, int /*priority*/) override {
+        void execute(int /*priority*/, std::function<void()> task) override {
             std::lock_guard<std::mutex> lck{mutex};
             futures.emplace_back(std::async(policy, std::move(task)));
             removeCompletedFutures();

--- a/libs/promises/api/celix/DefaultExecutor.h
+++ b/libs/promises/api/celix/DefaultExecutor.h
@@ -35,7 +35,7 @@ namespace celix {
         explicit DefaultExecutor(std::launch _policy = std::launch::async | std::launch::deferred) : policy{_policy} {}
 
         void execute(int /*priority*/, std::function<void()> task) override {
-            std::lock_guard<std::mutex> lck{mutex};
+            std::lock_guard lck{mutex};
             futures.emplace_back(std::async(policy, std::move(task)));
             removeCompletedFutures();
         }
@@ -43,7 +43,7 @@ namespace celix {
         void wait() override {
             bool done = false;
             while (!done) {
-                std::lock_guard<std::mutex> lck{mutex};
+                std::lock_guard lck{mutex};
                 removeCompletedFutures();
                 done = futures.empty();
             }

--- a/libs/promises/api/celix/DefaultScheduledExecutor.h
+++ b/libs/promises/api/celix/DefaultScheduledExecutor.h
@@ -22,6 +22,7 @@
 #include <memory>
 #include <future>
 #include <functional>
+#include <unordered_map>
 
 #include "celix/IScheduledExecutor.h"
 

--- a/libs/promises/api/celix/DefaultScheduledExecutor.h
+++ b/libs/promises/api/celix/DefaultScheduledExecutor.h
@@ -102,7 +102,7 @@ namespace celix {
                 future.wait_for(std::chrono::seconds{0}); //trigger async execution
                 std::lock_guard<std::mutex> lck{mutex};
                 futures[scheduledFuture] = std::move(future);
-
+                removeCompletedFutures();
                 return scheduledFuture;
             } catch (std::system_error& /*sysExp*/) {
                 throw celix::RejectedExecutionException{};

--- a/libs/promises/api/celix/DefaultScheduledExecutor.h
+++ b/libs/promises/api/celix/DefaultScheduledExecutor.h
@@ -35,41 +35,36 @@ namespace celix {
         ~DefaultDelayedScheduledFuture() noexcept override = default;
 
         bool isCancelled() const override {
-            std::lock_guard<std::mutex> lock{mutex};
+            std::lock_guard lock{mutex};
             return cancelled;
         }
 
         bool isDone() const override {
-            std::lock_guard<std::mutex> lock{mutex};
+            std::lock_guard lock{mutex};
             return done;
         }
 
         void setDone() {
-            std::lock_guard<std::mutex> lock{mutex};
+            std::lock_guard lock{mutex};
             done = true;
             cond.notify_all();
         }
 
         void cancel() override {
-            std::lock_guard<std::mutex> lock{mutex};
+            std::lock_guard lock{mutex};
             cancelled = true;
             cond.notify_all();
         }
 
         std::chrono::duration<double, std::milli> getDelayInMs() const {
-            std::lock_guard<std::mutex> lock{mutex};
             return delayInMs;
         }
 
         void waitFor(std::chrono::duration<double, std::milli> time) {
-            std::unique_lock<std::mutex> lock{mutex};
+            std::unique_lock lock{mutex};
             cond.wait_for(lock, time);
         }
     private:
-        [[nodiscard]] std::chrono::duration<double, std::milli> getDelayOrPeriodInMilli() const override {
-            return delayInMs;
-        }
-
         const std::chrono::duration<double, std::milli> delayInMs;
         mutable std::mutex mutex{}; //protects below
         std::condition_variable cond{};

--- a/libs/promises/api/celix/DefaultScheduledExecutor.h
+++ b/libs/promises/api/celix/DefaultScheduledExecutor.h
@@ -1,0 +1,140 @@
+/**
+ *Licensed to the Apache Software Foundation (ASF) under one
+ *or more contributor license agreements.  See the NOTICE file
+ *distributed with this work for additional information
+ *regarding copyright ownership.  The ASF licenses this file
+ *to you under the Apache License, Version 2.0 (the
+ *"License"); you may not use this file except in compliance
+ *with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *Unless required by applicable law or agreed to in writing,
+ *software distributed under the License is distributed on an
+ *"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ *specific language governing permissions and limitations
+ *under the License.
+ */
+
+#pragma once
+
+#include <memory>
+#include <future>
+#include <functional>
+
+#include "celix/IScheduledExecutor.h"
+
+namespace celix {
+
+    class DefaultDelayedScheduledFuture : public celix::IScheduledFuture {
+    public:
+        static std::shared_ptr<DefaultDelayedScheduledFuture> create(std::function<void()> task, std::chrono::duration<double, std::milli> delayInMs) {
+            auto delayedFuture = std::shared_ptr<DefaultDelayedScheduledFuture>{new DefaultDelayedScheduledFuture{std::move(task), delayInMs}};
+            delayedFuture->start();
+            return delayedFuture;
+        }
+
+        virtual ~DefaultDelayedScheduledFuture() noexcept override = default;
+
+        bool isCancelled() const override {
+            std::lock_guard<std::mutex> lock{mutex};
+            return cancelled;
+        }
+
+        bool isDone() const override {
+            std::lock_guard<std::mutex> lock{mutex};
+            return done;
+        }
+
+        void cancel() override {
+            std::lock_guard<std::mutex> lock{mutex};
+            cancelled = true;
+        }
+
+        void start() {
+            std::lock_guard<std::mutex> lock{mutex};
+            //TODO ensure that async is possible or throw RejectedExecutionException
+            future = std::async(std::launch::async, [this] {
+                auto t = std::chrono::steady_clock::now();
+                std::unique_lock<std::mutex> lock{mutex};
+                while (!cancelled && std::chrono::duration_cast<std::chrono::milliseconds>(t - startTime) < delayInMs) {
+                    auto timeLeft = delayInMs - std::chrono::duration_cast<std::chrono::milliseconds>(t - startTime);
+                    cond.wait_for(lock, timeLeft);
+                    t = std::chrono::steady_clock::now();
+                }
+                if (!cancelled) {
+                    task();
+                }
+                done = true;
+            });
+
+            //trigger async future for execution
+            future.wait_for(std::chrono::seconds{0});
+        }
+
+        const std::future<void>& getFuture() const {
+            std::lock_guard<std::mutex> lock{mutex};
+            return future;
+        }
+    private:
+        explicit DefaultDelayedScheduledFuture(std::function<void()> _task, std::chrono::duration<double, std::milli> _delay) :
+                startTime{std::chrono::steady_clock::now()},
+                task{std::move(_task)},
+                delayInMs{_delay} {}
+
+        std::chrono::duration<double, std::milli> getDelayOrPeriodInMilli() const override {
+            return delayInMs;
+        }
+
+        const std::chrono::steady_clock::time_point startTime;
+        const std::function<void()> task;
+        const std::chrono::duration<double, std::milli> delayInMs;
+        mutable std::mutex mutex{}; //protects below
+        std::future<void> future{};
+        std::condition_variable cond{};
+        bool cancelled{false};
+        bool done{false};
+    };
+
+    /**
+     * @brief Simple default scheduled executor which uses std::async to run delayed tasks and steady_clock to measure delay.
+     *
+     * Does not support priority argument.
+     */
+    class DefaultScheduledExecutor : public celix::IScheduledExecutor {
+    public:
+        std::shared_ptr<celix::IScheduledFuture> scheduleInMilli(int /*priority*/, std::chrono::duration<double, std::milli> delay, std::function<void()> task) override {
+            std::lock_guard<std::mutex> lck{mutex};
+            auto scheduledFuture = DefaultDelayedScheduledFuture::create(std::move(task), delay);
+            futures.emplace_back(scheduledFuture);
+            removeCompletedFutures();
+            return scheduledFuture;
+        }
+
+        void wait() override {
+            bool done = false;
+            while (!done) {
+                std::lock_guard<std::mutex> lck{mutex};
+                removeCompletedFutures();
+                done = futures.empty();
+            }
+        }
+    private:
+        void removeCompletedFutures() {
+            //note should be called while mutex is lock.
+            auto it = futures.begin();
+            while (it != futures.end()) {
+                if ((*it)->isDone()) {
+                    //remove scheduled future
+                    it = futures.erase(it);
+                } else {
+                    ++it;
+                }
+            }
+        }
+
+        std::mutex mutex{}; //protect futures.
+        std::vector<std::shared_ptr<DefaultDelayedScheduledFuture>> futures{};
+    };
+}

--- a/libs/promises/api/celix/IExecutor.h
+++ b/libs/promises/api/celix/IExecutor.h
@@ -26,7 +26,7 @@
 namespace celix {
 
     /**
-     * An object that executes submitted Runnable tasks. This interface provides a way of decoupling task submission
+     * @brief An object that executes submitted Runnable tasks. This interface provides a way of decoupling task submission
      * from the mechanics of how each task will be run, including details of thread use, scheduling, etc.
      *
      * Note that supporting the priority argument is optional. If not priority values are ignored.
@@ -36,17 +36,30 @@ namespace celix {
         virtual ~IExecutor() noexcept = default;
 
         /**
-         * Executes the given command at some time in the future. The command may execute in a new thread,
+         * @brief Executes the given command at some time in the future. The command may execute in a new thread,
          * in a pooled thread, or in the calling thread, at the discretion of the Executor implementation.
          *
-         * @param command the "runnable" task
          * @param priority the priority of the task. It depends on the executor implementation whether this is supported.
+         * @param command the "runnable" task
          * @throws celix::RejectedExecutionException if this task cannot be accepted for execution.
          */
-        virtual void execute(std::function<void()> task, int priority = 0) = 0;
+        virtual void execute(int priority, std::function<void()> task) = 0;
 
         /**
-         * Wait until the executor has no pending task left.
+         * @brief Executes the given command at some time in the future. The command may execute in a new thread,
+         * in a pooled thread, or in the calling thread, at the discretion of the Executor implementation.
+         *
+         * Task will be executed int the default priority (0)
+         *
+         * @param command the "runnable" task
+         * @throws celix::RejectedExecutionException if this task cannot be accepted for execution.
+         */
+        void execute(std::function<void()> task) {
+            execute(0, std::move(task));
+        }
+
+        /**
+         * @brief Wait until the executor has no pending task left.
          */
         virtual void wait() = 0;
     };

--- a/libs/promises/api/celix/IScheduledExecutor.h
+++ b/libs/promises/api/celix/IScheduledExecutor.h
@@ -26,19 +26,16 @@
 
 namespace celix {
 
-    class enum ScheduledType {
-        OneShot,
-        FixedDelay,
-        FixedRate
-    };
-
+    /**
+     * @brief a Cancelable Scheduled Future.
+     */
     class IScheduledFuture {
     public:
         virtual ~IScheduledFuture() noexcept = default;
 
-        virtual ScheduledType getType() const = 0;
-
         virtual bool isCancelled() const = 0;
+
+        virtual bool isDone() const = 0;
 
         virtual void cancel() = 0;
 
@@ -55,73 +52,48 @@ namespace celix {
 
 
     /**
-     * An ExecutorService that can schedule commands to run after a given delay, or to execute periodically.
+     * @brief An ScheduledExecutor that can schedule commands to run after a given delay.
+     * (TODO or execute tasks periodically)
      *
      * The schedule methods create tasks with various delays and return a task object that can be used to cancel or check execution.
-     * The scheduleAtFixedRate and scheduleWithFixedDelay methods create and execute tasks that run periodically until cancelled.
-     * Commands submitted using the celix::IExecutor::execute method are scheduled with a requested delay of zero.
+     *
+     * (TODO The scheduleAtFixedRate and scheduleWithFixedDelay methods create and execute tasks that run periodically until cancelled)
      * Zero and negative delays (but not periods) are also allowed in schedule methods, and are treated as requests for immediate execution.
      * All schedule methods accept relative delays and periods as arguments, not absolute times or dates.
      */
-    class IScheduledExecutor : public celix::IExecutor {
+    class IScheduledExecutor {
     public:
         virtual ~IScheduledExecutor () noexcept = default;
 
-        //TODO TBD schedule uses a executor, is a executor abstraction still needed or is a scheduled executor enough?
-
         /**
-         * Creates and executes a ScheduledFuture that becomes enabled after the given delay.
+         * @brief Creates and executes a ScheduledFuture that becomes enabled after the given delay.
          * @throws celix::RejectedExecutionException if this task cannot be accepted for execution.
          */
         template<typename Rep, typename Period>
-        std::shared_ptr<celix::IScheduledFuture> schedule(std::function<void()> task, std::chrono::duration<Rep, Period> delay) {
+        std::shared_ptr<celix::IScheduledFuture> schedule(int priority, std::chrono::duration<Rep, Period> delay, std::function<void()> task) {
             std::chrono::duration<double, std::milli> delayInMilli = delay;
-            return scheduleInMilli(std::move(task), delayInMilli);
+            return scheduleInMilli(priority, delayInMilli, std::move(task));
         }
 
         /**
-         * Creates and executes a periodic action that becomes enabled first after the given initial delay,
-         * and subsequently with the given period; that is executions will commence after initialDelay then
-         * initialDelay+period, then initialDelay + 2 * period, and so on.
-         * If any execution of the task encounters an exception, subsequent executions are suppressed.
-         * Otherwise, the task will only terminate via cancellation or termination of the executor.
-         * If any execution of this task takes longer than its period,
-         * then subsequent executions may start late, but will not concurrently execute.
-         *
-         * @param task          the task to execute
-         * @param period        the period between successive executions
-         * @param initialDelay  the time to delay first execution
-         * @return a ScheduledFuture representing pending completion of the task.
+         * @brief Creates and executes a ScheduledFuture that becomes enabled after the given delay.
+         * @throws celix::RejectedExecutionException if this task cannot be accepted for execution.
          */
-        template<typename Rep1, typename Period1, typename Rep2 = double, typename Period2 = std::milli>
-        std::shared_ptr<celix::IScheduledFuture> scheduleAtFixedRate(std::function<void()> task, std::chrono::duration<std::chrono::duration<Rep1, Period1> period, std::chrono::duration<Rep2, Period2> initialDelay = 0) {
-            std::chrono::duration<double, std::milli> periodInMilli = period;
-            std::chrono::duration<double, std::milli> initialDelayInMilli = initialDelay;
-            return scheduleAtFixedRateInMilli(std::move(task), periodInMilli, initialDelay);
+        template<typename Rep, typename Period>
+        std::shared_ptr<celix::IScheduledFuture> schedule(std::chrono::duration<Rep, Period> delay, std::function<void()> task) {
+            std::chrono::duration<double, std::milli> delayInMilli = delay;
+            return scheduleInMilli(0, delayInMilli, std::move(task));
         }
 
         /**
-         * Creates and executes a periodic action that becomes enabled first after the given initial delay,
-         * and subsequently with the given delay between the termination of one execution and the commencement of
-         * the next. If any execution of the task encounters an exception, subsequent executions are suppressed.
-         * Otherwise, the task will only terminate via cancellation or termination of the executor.
-         *
-         * @param task          the task to execute
-         * @param delay         the delay between the termination of one execution and the commencement of the next
-         * @param initialDelay  the time to delay first execution
-         * @return a ScheduledFuture representing pending completion of the task.
+         * @brief Wait until the scheduled executor has no pending task left.
          */
-        template<typename Rep1, typename Period1, typename Rep2 = double, typename Period2 = std::milli>
-        std::shared_ptr<celix::IScheduledFuture> scheduleWithFixedDelay(std::function<void()> task, std::chrono::duration<Rep, Period> delay, std::chrono::duration<Rep2, Period2> initialDelay = 0) {
-            std::chrono::duration<double, std::milli> delayInMilli = delay;
-            std::chrono::duration<double, std::milli> initialDelayInMilli = initialDelay;
-            return scheduleWithFixedDelayInMilli(std::move(task), delayInMilli, initialDelay);
-        }
+        virtual void wait() = 0;
     private:
-        virtual std::shared_ptr<celix::IScheduledFuture> scheduleInMilli(std::function<void()> task, std::chrono::duration<double, std::milli> delay) = 0;
-
-        virtual std::shared_ptr<celix::IScheduledFuture> scheduleAtFixedRateInMilli(std::function<void()> task, std::chrono::duration<double, std::milli> period, std::chrono::duration<double, std::milli> initialDelay) = 0;
-
-        virtual std::shared_ptr<celix::IScheduledFuture> scheduleWithFixedDelayInMilli(std::function<void()> task, std::chrono::duration<double, std::milli> delay, std::chrono::duration<double, std::milli> initialDelay) = 0;
+        /**
+         * @brief Creates and executes a ScheduledFuture that becomes enabled after the given delay in milli.
+         * @throws celix::RejectedExecutionException if this task cannot be accepted for execution.
+         */
+        virtual std::shared_ptr<celix::IScheduledFuture> scheduleInMilli(int priority, std::chrono::duration<double, std::milli> delay, std::function<void()> task) = 0;
     };
 }

--- a/libs/promises/api/celix/IScheduledExecutor.h
+++ b/libs/promises/api/celix/IScheduledExecutor.h
@@ -38,18 +38,7 @@ namespace celix {
         virtual bool isDone() const = 0;
 
         virtual void cancel() = 0;
-
-        template<typename Rep, typename Period>
-        std::chrono::duration<Rep, Period> getDelayOrPeriod() const {
-            auto milli = getDelayOrPeriodInMilli();
-            return std::chrono::duration<Rep, Period>{milli};
-        }
-
-    private:
-        virtual std::chrono::duration<double, std::milli> getDelayOrPeriodInMilli() const = 0;
     };
-
-
 
     /**
      * @brief An ScheduledExecutor that can schedule commands to run after a given delay.

--- a/libs/promises/api/celix/Promise.h
+++ b/libs/promises/api/celix/Promise.h
@@ -616,7 +616,7 @@ inline void celix::Promise<void>::wait() const {
 template<typename T>
 template<typename U>
 inline celix::Promise<U> celix::Promise<T>::then(std::function<celix::Promise<U>(celix::Promise<T>)> success, std::function<void(celix::Promise<T>)> failure) {
-    auto p = celix::impl::SharedPromiseState<U>::create(state->getExecutor(), state->getPriority());
+    auto p = celix::impl::SharedPromiseState<U>::create(state->getExecutor(), state->getScheduledExecutor(), state->getPriority());
 
     auto chain = [s = state, p, success = std::move(success), failure = std::move(failure)]() {
         //chain is called when s is resolved
@@ -641,7 +641,7 @@ inline celix::Promise<U> celix::Promise<T>::then(std::function<celix::Promise<U>
 
 template<typename U>
 inline celix::Promise<U> celix::Promise<void>::then(std::function<celix::Promise<U>(celix::Promise<void>)> success, std::function<void(celix::Promise<void>)> failure) {
-    auto p = celix::impl::SharedPromiseState<U>::create(state->getExecutor(), state->getPriority());
+    auto p = celix::impl::SharedPromiseState<U>::create(state->getExecutor(), state->getScheduledExecutor(), state->getPriority());
 
     auto chain = [s = state, p, success = std::move(success), failure = std::move(failure)]() {
         //chain is called when s is resolved

--- a/libs/promises/api/celix/PromiseFactory.h
+++ b/libs/promises/api/celix/PromiseFactory.h
@@ -67,6 +67,11 @@ namespace celix {
 
         //TODO
         //[[nodiscard]] std::shared_ptr<celix::IScheduledExecutor> getScheduledExecutor() const;
+
+        /**
+         * @brief Wait (block) until all tasks for the executor and scheduled executor are completed
+         */
+         void wait();
     private:
         std::shared_ptr<celix::IExecutor> executor;
         std::shared_ptr<celix::IScheduledExecutor> scheduledExecutor;
@@ -86,8 +91,7 @@ inline celix::PromiseFactory::PromiseFactory(
 
 inline celix::PromiseFactory::~PromiseFactory() noexcept {
     //ensure that the executors tasks are empty before allowing the to be deallocated.
-    executor->wait();
-    scheduledExecutor->wait();
+    wait();
 }
 
 template<typename T>
@@ -142,4 +146,9 @@ inline celix::Promise<void> celix::PromiseFactory::resolvedWithPrio(int priority
 
 inline std::shared_ptr<celix::IExecutor> celix::PromiseFactory::getExecutor() const {
     return executor;
+}
+
+inline void celix::PromiseFactory::wait() {
+    scheduledExecutor->wait();
+    executor->wait();
 }

--- a/libs/promises/api/celix/PromiseFactory.h
+++ b/libs/promises/api/celix/PromiseFactory.h
@@ -22,6 +22,7 @@
 #include "celix/Deferred.h"
 #include "celix/IExecutor.h"
 #include "celix/DefaultExecutor.h"
+#include "celix/DefaultScheduledExecutor.h"
 
 namespace celix {
 
@@ -29,7 +30,9 @@ namespace celix {
     //TODO documentation
     class PromiseFactory {
     public:
-        explicit PromiseFactory(std::shared_ptr<celix::IExecutor> _executor = std::make_shared<celix::DefaultExecutor>());
+        explicit PromiseFactory(
+                std::shared_ptr<celix::IExecutor> _executor = std::make_shared<celix::DefaultExecutor>(),
+                std::shared_ptr<celix::IScheduledExecutor> _scheduledExecutor = std::make_shared<celix::DefaultScheduledExecutor>());
 
         ~PromiseFactory() noexcept;
 
@@ -66,6 +69,7 @@ namespace celix {
         //[[nodiscard]] std::shared_ptr<celix::IScheduledExecutor> getScheduledExecutor() const;
     private:
         std::shared_ptr<celix::IExecutor> executor;
+        std::shared_ptr<celix::IScheduledExecutor> scheduledExecutor;
     };
 
 }
@@ -74,29 +78,35 @@ namespace celix {
  Implementation
 *********************************************************************************/
 
-inline celix::PromiseFactory::PromiseFactory(std::shared_ptr<celix::IExecutor> _executor) : executor{std::move(_executor)} {}
+inline celix::PromiseFactory::PromiseFactory(
+        std::shared_ptr<celix::IExecutor> _executor,
+        std::shared_ptr<celix::IScheduledExecutor> _scheduledExecutor) :
+        executor{std::move(_executor)},
+        scheduledExecutor{std::move(_scheduledExecutor)} {}
 
 inline celix::PromiseFactory::~PromiseFactory() noexcept {
-    executor->wait(); //ensure that the executor is empty before allowing the to be deallocated.
+    //ensure that the executors tasks are empty before allowing the to be deallocated.
+    executor->wait();
+    scheduledExecutor->wait();
 }
 
 template<typename T>
 celix::Deferred<T> celix::PromiseFactory::deferred(int priority) const {
-    return celix::Deferred<T>{celix::impl::SharedPromiseState<T>::create(executor, priority)};
+    return celix::Deferred<T>{celix::impl::SharedPromiseState<T>::create(executor, scheduledExecutor, priority)};
 }
 
 template<typename T>
 [[nodiscard]] celix::Promise<T> celix::PromiseFactory::deferredTask(std::function<void(celix::Deferred<T>)> task, int priority) const {
     auto def = deferred<T>(priority);
-    executor->execute([def, task=std::move(task)]{
+    executor->execute(priority, [def, task=std::move(task)]{
        task(def);
-    }, priority);
+    });
     return def.getPromise();
 }
 
 template<typename T>
 celix::Promise<T> celix::PromiseFactory::failed(const std::exception &e, int priority) const {
-    auto p = celix::impl::SharedPromiseState<T>::create(executor, priority);
+    auto p = celix::impl::SharedPromiseState<T>::create(executor, scheduledExecutor, priority);
     p->fail(e);
     return celix::Promise<T>{p};
 }
@@ -115,7 +125,7 @@ celix::Promise<T> celix::PromiseFactory::resolved(T &&value) const {
 
 template<typename T>
 celix::Promise<T> celix::PromiseFactory::resolvedWithPrio(T &&value, int priority) const {
-    auto p = celix::impl::SharedPromiseState<T>::create(executor, priority);
+    auto p = celix::impl::SharedPromiseState<T>::create(executor, scheduledExecutor, priority);
     p->resolve(std::forward<T>(value));
     return celix::Promise<T>{p};
 }
@@ -125,7 +135,7 @@ inline celix::Promise<void> celix::PromiseFactory::resolved() const {
 }
 
 inline celix::Promise<void> celix::PromiseFactory::resolvedWithPrio(int priority) const {
-    auto p = celix::impl::SharedPromiseState<void>::create(executor, priority);
+    auto p = celix::impl::SharedPromiseState<void>::create(executor, scheduledExecutor, priority);
     p->resolve();
     return celix::Promise<void>{p};
 }

--- a/libs/promises/api/celix/impl/SharedPromiseState.h
+++ b/libs/promises/api/celix/impl/SharedPromiseState.h
@@ -105,9 +105,9 @@ namespace celix::impl {
 
         void addChain(std::function<void()> chainFunction);
 
-        std::shared_ptr<celix::IExecutor> getExecutor() const;
+        [[nodiscard]] std::shared_ptr<celix::IExecutor> getExecutor() const;
 
-        std::shared_ptr<celix::IScheduledExecutor> getScheduledExecutor() const;
+        [[nodiscard]] std::shared_ptr<celix::IScheduledExecutor> getScheduledExecutor() const;
 
         int getPriority() const;
     private:
@@ -191,9 +191,9 @@ namespace celix::impl {
 
         void addChain(std::function<void()> chainFunction);
 
-        std::shared_ptr<celix::IExecutor> getExecutor() const;
+        [[nodiscard]] std::shared_ptr<celix::IExecutor> getExecutor() const;
 
-        std::shared_ptr<celix::IScheduledExecutor> getScheduledExecutor() const;
+        [[nodiscard]] std::shared_ptr<celix::IScheduledExecutor> getScheduledExecutor() const;
 
         int getPriority() const;
     private:
@@ -361,23 +361,23 @@ inline void celix::impl::SharedPromiseState<void>::tryFail(std::exception_ptr e)
 
 template<typename T>
 bool celix::impl::SharedPromiseState<T>::isDone() const {
-    std::lock_guard<std::mutex> lck{mutex};
+    std::lock_guard lck{mutex};
     return done;
 }
 
 inline bool celix::impl::SharedPromiseState<void>::isDone() const {
-    std::lock_guard<std::mutex> lck{mutex};
+    std::lock_guard lck{mutex};
     return done;
 }
 
 template<typename T>
 bool celix::impl::SharedPromiseState<T>::isSuccessfullyResolved() const {
-    std::lock_guard<std::mutex> lck{mutex};
+    std::lock_guard lck{mutex};
     return done && !exp;
 }
 
 inline bool celix::impl::SharedPromiseState<void>::isSuccessfullyResolved() const {
-    std::lock_guard<std::mutex> lck{mutex};
+    std::lock_guard lck{mutex};
     return done && !exp;
 }
 
@@ -722,7 +722,7 @@ template<typename T>
 void celix::impl::SharedPromiseState<T>::addChain(std::function<void()> chainFunction) {
     std::function<void()> localChain{};
     {
-        std::lock_guard<std::mutex> lck{mutex};
+        std::lock_guard lck{mutex};
         if (!done) {
             chain.emplace_back([func = std::move(chainFunction)]() {
                 func();
@@ -739,7 +739,7 @@ void celix::impl::SharedPromiseState<T>::addChain(std::function<void()> chainFun
 inline void celix::impl::SharedPromiseState<void>::addChain(std::function<void()> chainFunction) {
     std::function<void()> localChain{};
     {
-        std::lock_guard<std::mutex> lck{mutex};
+        std::lock_guard lck{mutex};
         if (!done) {
             chain.emplace_back([func = std::move(chainFunction)]() {
                 func();

--- a/libs/promises/api/celix/impl/SharedPromiseState.h
+++ b/libs/promises/api/celix/impl/SharedPromiseState.h
@@ -580,10 +580,10 @@ std::shared_ptr<celix::impl::SharedPromiseState<T>> celix::impl::SharedPromiseSt
                 if (v) {
                     state->resolve(std::move(*v));
                 } else {
-                    state->fail(std::move(e));
+                    state->fail(e);
                 }
             } catch (celix::PromiseInvocationException &) {
-                //somebody already resolved p?
+                //somebody already resolved promise?
             } catch (...) {
                 state->fail(std::current_exception());
             }
@@ -604,7 +604,7 @@ std::shared_ptr<celix::impl::SharedPromiseState<void>> celix::impl::SharedPromis
                     state->fail(*e);
                 }
             } catch (celix::PromiseInvocationException &) {
-                //somebody already resolved p?
+                //somebody already resolved promise?
             } catch (...) {
                 state->fail(std::current_exception());
             }

--- a/libs/promises/api/celix/impl/SharedPromiseState.h
+++ b/libs/promises/api/celix/impl/SharedPromiseState.h
@@ -29,6 +29,7 @@
 #include <optional>
 
 #include "celix/IExecutor.h"
+#include "celix/IScheduledExecutor.h"
 
 #include "celix/PromiseInvocationException.h"
 #include "celix/PromiseTimeoutException.h"
@@ -40,7 +41,7 @@ namespace celix::impl {
         // Pointers make using promises properly unnecessarily complicated.
         static_assert(!std::is_pointer_v<T>, "Cannot use pointers with promises.");
     public:
-        static std::shared_ptr<SharedPromiseState<T>> create(std::shared_ptr<celix::IExecutor> _executor, int priority);
+        static std::shared_ptr<SharedPromiseState<T>> create(std::shared_ptr<celix::IExecutor> _executor, std::shared_ptr<celix::IScheduledExecutor> _scheduledExecutor, int priority);
 
         ~SharedPromiseState() = default;
 
@@ -106,9 +107,11 @@ namespace celix::impl {
 
         std::shared_ptr<celix::IExecutor> getExecutor() const;
 
+        std::shared_ptr<celix::IScheduledExecutor> getScheduledExecutor() const;
+
         int getPriority() const;
     private:
-        explicit SharedPromiseState(std::shared_ptr<celix::IExecutor> _executor, int _priority);
+        explicit SharedPromiseState(std::shared_ptr<celix::IExecutor> _executor, std::shared_ptr<celix::IScheduledExecutor> _scheduledExecutor, int _priority);
 
         void setSelf(std::weak_ptr<SharedPromiseState<T>> self);
 
@@ -124,6 +127,7 @@ namespace celix::impl {
         void waitForAndCheckData(std::unique_lock<std::mutex> &lck, bool expectValid) const;
 
         const std::shared_ptr<celix::IExecutor> executor;
+        const std::shared_ptr<celix::IScheduledExecutor> scheduledExecutor;
         const int priority;
         std::weak_ptr<SharedPromiseState<T>> self{};
 
@@ -139,7 +143,7 @@ namespace celix::impl {
     template<>
     class SharedPromiseState<void> {
     public:
-        static std::shared_ptr<SharedPromiseState<void>> create(std::shared_ptr<celix::IExecutor> _executor, int priority);
+        static std::shared_ptr<SharedPromiseState<void>> create(std::shared_ptr<celix::IExecutor> _executor, std::shared_ptr<celix::IScheduledExecutor> _scheduledExecutor, int priority);
         ~SharedPromiseState() = default;
 
         void resolve();
@@ -189,9 +193,11 @@ namespace celix::impl {
 
         std::shared_ptr<celix::IExecutor> getExecutor() const;
 
+        std::shared_ptr<celix::IScheduledExecutor> getScheduledExecutor() const;
+
         int getPriority() const;
     private:
-        explicit SharedPromiseState(std::shared_ptr<celix::IExecutor> _executor, int _priority);
+        explicit SharedPromiseState(std::shared_ptr<celix::IExecutor> _executor, std::shared_ptr<celix::IScheduledExecutor> _scheduledExecutor, int _priority);
 
         void setSelf(std::weak_ptr<SharedPromiseState<void>> self);
 
@@ -207,6 +213,7 @@ namespace celix::impl {
         void waitForAndCheckData(std::unique_lock<std::mutex> &lck, bool expectValid) const;
 
         const std::shared_ptr<celix::IExecutor> executor;
+        const std::shared_ptr<celix::IScheduledExecutor> scheduledExecutor;
         const int priority;
         std::weak_ptr<SharedPromiseState<void>> self{};
 
@@ -224,22 +231,22 @@ namespace celix::impl {
 *********************************************************************************/
 
 template<typename T>
-std::shared_ptr<celix::impl::SharedPromiseState<T>> celix::impl::SharedPromiseState<T>::create(std::shared_ptr<celix::IExecutor> _executor, int priority) {
-    auto state = std::shared_ptr<celix::impl::SharedPromiseState<T>>{new celix::impl::SharedPromiseState<T>{std::move(_executor), priority}};
+std::shared_ptr<celix::impl::SharedPromiseState<T>> celix::impl::SharedPromiseState<T>::create(std::shared_ptr<celix::IExecutor> _executor, std::shared_ptr<celix::IScheduledExecutor> _scheduledExecutor, int priority) {
+    auto state = std::shared_ptr<celix::impl::SharedPromiseState<T>>{new celix::impl::SharedPromiseState<T>{std::move(_executor), std::move(_scheduledExecutor), priority}};
     state->setSelf(state);
     return state;
 }
 
-inline std::shared_ptr<celix::impl::SharedPromiseState<void>> celix::impl::SharedPromiseState<void>::create(std::shared_ptr<celix::IExecutor> _executor, int priority) {
-    auto state = std::shared_ptr<celix::impl::SharedPromiseState<void>>{new celix::impl::SharedPromiseState<void>{std::move(_executor), priority}};
+inline std::shared_ptr<celix::impl::SharedPromiseState<void>> celix::impl::SharedPromiseState<void>::create(std::shared_ptr<celix::IExecutor> _executor, std::shared_ptr<celix::IScheduledExecutor> _scheduledExecutor, int priority) {
+    auto state = std::shared_ptr<celix::impl::SharedPromiseState<void>>{new celix::impl::SharedPromiseState<void>{std::move(_executor), std::move(_scheduledExecutor), priority}};
     state->setSelf(state);
     return state;
 }
 
 template<typename T>
-celix::impl::SharedPromiseState<T>::SharedPromiseState(std::shared_ptr<celix::IExecutor> _executor, int _priority) : executor{std::move(_executor)}, priority{_priority} {}
+celix::impl::SharedPromiseState<T>::SharedPromiseState(std::shared_ptr<celix::IExecutor> _executor, std::shared_ptr<celix::IScheduledExecutor> _scheduledExecutor, int _priority) : executor{std::move(_executor)}, scheduledExecutor{std::move(_scheduledExecutor)}, priority{_priority} {}
 
-inline celix::impl::SharedPromiseState<void>::SharedPromiseState(std::shared_ptr<celix::IExecutor> _executor, int _priority) : executor{std::move(_executor)}, priority{_priority} {}
+inline celix::impl::SharedPromiseState<void>::SharedPromiseState(std::shared_ptr<celix::IExecutor> _executor, std::shared_ptr<celix::IScheduledExecutor> _scheduledExecutor, int _priority) : executor{std::move(_executor)}, scheduledExecutor{std::move(_scheduledExecutor)}, priority{_priority} {}
 
 template<typename T>
 void celix::impl::SharedPromiseState<T>::setSelf(std::weak_ptr<SharedPromiseState<T>> _self) {
@@ -474,6 +481,15 @@ inline std::shared_ptr<celix::IExecutor> celix::impl::SharedPromiseState<void>::
 }
 
 template<typename T>
+std::shared_ptr<celix::IScheduledExecutor> celix::impl::SharedPromiseState<T>::getScheduledExecutor() const {
+    return scheduledExecutor;
+}
+
+inline std::shared_ptr<celix::IScheduledExecutor> celix::impl::SharedPromiseState<void>::getScheduledExecutor() const {
+    return scheduledExecutor;
+}
+
+template<typename T>
 int celix::impl::SharedPromiseState<T>::getPriority() const {
     return priority;
 }
@@ -530,79 +546,71 @@ inline void celix::impl::SharedPromiseState<void>::resolveWith(std::shared_ptr<S
 template<typename T>
 template<typename Rep, typename Period>
 std::shared_ptr<celix::impl::SharedPromiseState<T>> celix::impl::SharedPromiseState<T>::timeout(std::shared_ptr<SharedPromiseState<T>> state, std::chrono::duration<Rep, Period> duration) {
-    auto p = celix::impl::SharedPromiseState<T>::create(state->executor, state->priority);
+    auto p = celix::impl::SharedPromiseState<T>::create(state->executor, state->scheduledExecutor, state->priority);
     p->resolveWith(state);
-    /*TODO use scheduler instead of sleep on thread (using unnecessary resources)
-    auto schedFuture = scheduler->schedule<Rep, Period>([]{
-            p->tryFail(std::make_exception_ptr(celix::PromiseTimeoutException{}));}, duration);
-    p->addOnResolve([schedFuture]() {
+    auto schedFuture = state->scheduledExecutor->schedule(state->priority, duration, [p]{
+        p->tryFail(std::make_exception_ptr(celix::PromiseTimeoutException{}));
+    });
+    p->addOnSuccessConsumeCallback([schedFuture](T /*val*/){
         schedFuture->cancel();
     });
-    */
-    state->executor->execute([duration, p]{
-        std::this_thread::sleep_for(duration);
-        p->tryFail(std::make_exception_ptr(celix::PromiseTimeoutException{}));
-    }, state->priority);
     return p;
 }
 
 template<typename Rep, typename Period>
 std::shared_ptr<celix::impl::SharedPromiseState<void>> celix::impl::SharedPromiseState<void>::timeout(std::shared_ptr<SharedPromiseState<void>> state, std::chrono::duration<Rep, Period> duration) {
-    auto p = celix::impl::SharedPromiseState<void>::create(state->executor, state->priority);
+    auto p = celix::impl::SharedPromiseState<void>::create(state->executor, state->scheduledExecutor, state->priority);
     p->resolveWith(state);
-    /*TODO use scheduler instead of sleep on thread (using unnecessary resources)
-    auto schedFuture = scheduler->schedule<Rep, Period>([]{
-            p->tryFail(std::make_exception_ptr(celix::PromiseTimeoutException{}));}, duration);
-    p->addOnResolve([schedFuture]() {
-        schedFuture->cancel();
+    auto schedFuture = state->scheduledExecutor->schedule(state->priority, duration, [p]{
+            p->tryFail(std::make_exception_ptr(celix::PromiseTimeoutException{}));
     });
-    */
-    state->executor->execute([duration, p]{
-        std::this_thread::sleep_for(duration);
-        p->tryFail(std::make_exception_ptr(celix::PromiseTimeoutException{}));
-    }, state->priority);
+    p->addOnSuccessConsumeCallback([schedFuture]{
+       schedFuture->cancel();
+    });
     return p;
 }
 
 template<typename T>
 template<typename Rep, typename Period>
 std::shared_ptr<celix::impl::SharedPromiseState<T>> celix::impl::SharedPromiseState<T>::delay(std::chrono::duration<Rep, Period> duration) {
-    auto p = celix::impl::SharedPromiseState<T>::create(executor, priority);
-    addOnResolve([p, duration](std::optional<T> v, std::exception_ptr e) {
-        std::this_thread::sleep_for(duration); //TODO use scheduler instead of sleep on thread (using unnecessary resources)
-        try {
-            if (v) {
-                p->resolve(std::move(*v));
-            } else {
-                p->fail(std::move(e));
+    auto state = celix::impl::SharedPromiseState<T>::create(executor, scheduledExecutor, priority);
+    addOnResolve([state, duration](std::optional<T> v, std::exception_ptr e) {
+        state->scheduledExecutor->schedule(state->priority, duration, [v = std::move(v), e, state] {
+            try {
+                if (v) {
+                    state->resolve(std::move(*v));
+                } else {
+                    state->fail(std::move(e));
+                }
+            } catch (celix::PromiseInvocationException &) {
+                //somebody already resolved p?
+            } catch (...) {
+                state->fail(std::current_exception());
             }
-        } catch (celix::PromiseInvocationException&) {
-            //somebody already resolved p?
-        } catch (...) {
-            p->fail(std::current_exception());
-        }
+        });
     });
-    return p;
+    return state;
 }
 
 template<typename Rep, typename Period>
 std::shared_ptr<celix::impl::SharedPromiseState<void>> celix::impl::SharedPromiseState<void>::delay(std::chrono::duration<Rep, Period> duration) {
-    auto p = celix::impl::SharedPromiseState<void>::create(executor, priority);
-    addOnResolve([p, duration](std::optional<std::exception_ptr> e) {
-        std::this_thread::sleep_for(duration); //TODO use scheduler instead of sleep on thread (using unnecessary resources)
-        try {
-            if (!e) {
-                p->resolve();
-            } else {
-                p->fail(std::move(*e));
+    auto state = celix::impl::SharedPromiseState<void>::create(executor, scheduledExecutor, priority);
+    addOnResolve([state, duration](std::optional<std::exception_ptr> e) {
+        state->scheduledExecutor->schedule(state->priority, duration, [e, state] {
+            try {
+                if (!e) {
+                    state->resolve();
+                } else {
+                    state->fail(*e);
+                }
+            } catch (celix::PromiseInvocationException &) {
+                //somebody already resolved p?
+            } catch (...) {
+                state->fail(std::current_exception());
             }
-        } catch (celix::PromiseInvocationException&) {
-            //somebody already resolved p?
-        } catch (...) {
-            p->fail(std::current_exception());
-        }
+        });
     });
-    return p;
+    return state;
 }
 
 template<typename T>
@@ -610,7 +618,7 @@ std::shared_ptr<celix::impl::SharedPromiseState<T>> celix::impl::SharedPromiseSt
     if (!recover) {
         throw celix::PromiseInvocationException{"provided recover callback is not valid"};
     }
-    auto p = celix::impl::SharedPromiseState<T>::create(executor, priority);
+    auto p = celix::impl::SharedPromiseState<T>::create(executor, scheduledExecutor, priority);
     addOnResolve([p, recover = std::move(recover)](std::optional<T> v, const std::exception_ptr& /*e*/) {
         if (v) {
             p->resolve(std::move(*v));
@@ -630,7 +638,7 @@ inline std::shared_ptr<celix::impl::SharedPromiseState<void>> celix::impl::Share
         throw celix::PromiseInvocationException{"provided recover callback is not valid"};
     }
 
-    auto p = celix::impl::SharedPromiseState<void>::create(executor, priority);
+    auto p = celix::impl::SharedPromiseState<void>::create(executor, scheduledExecutor, priority);
 
     addOnResolve([p, recover = std::move(recover)](std::optional<std::exception_ptr> e) {
         if (!e) {
@@ -652,7 +660,7 @@ std::shared_ptr<celix::impl::SharedPromiseState<T>> celix::impl::SharedPromiseSt
     if (!predicate) {
         throw celix::PromiseInvocationException{"provided predicate callback is not valid"};
     }
-    auto p = celix::impl::SharedPromiseState<T>::create(executor, priority);
+    auto p = celix::impl::SharedPromiseState<T>::create(executor, scheduledExecutor, priority);
     auto chainFunction = [s = self.lock(), p, predicate = std::move(predicate)] {
         if (s->isSuccessfullyResolved()) {
             try {
@@ -675,7 +683,7 @@ std::shared_ptr<celix::impl::SharedPromiseState<T>> celix::impl::SharedPromiseSt
 
 template<typename T>
 std::shared_ptr<celix::impl::SharedPromiseState<T>> celix::impl::SharedPromiseState<T>::fallbackTo(std::shared_ptr<celix::impl::SharedPromiseState<T>> fallbackTo) {
-    auto p = celix::impl::SharedPromiseState<T>::create(executor, priority);
+    auto p = celix::impl::SharedPromiseState<T>::create(executor, scheduledExecutor, priority);
     auto chainFunction = [s = self.lock(), p, fallbackTo = std::move(fallbackTo)] {
         if (s->isSuccessfullyResolved()) {
             p->resolve(s->moveOrGetValue());
@@ -692,7 +700,7 @@ std::shared_ptr<celix::impl::SharedPromiseState<T>> celix::impl::SharedPromiseSt
 }
 
 inline std::shared_ptr<celix::impl::SharedPromiseState<void>> celix::impl::SharedPromiseState<void>::fallbackTo(std::shared_ptr<celix::impl::SharedPromiseState<void>> fallbackTo) {
-    auto p = celix::impl::SharedPromiseState<void>::create(executor, priority);
+    auto p = celix::impl::SharedPromiseState<void>::create(executor, scheduledExecutor, priority);
     auto chainFunction = [s = self.lock(), p, fallbackTo = std::move(fallbackTo)] {
         if (s->isSuccessfullyResolved()) {
             s->getValue();
@@ -724,7 +732,7 @@ void celix::impl::SharedPromiseState<T>::addChain(std::function<void()> chainFun
         }
     }
     if (localChain) {
-        executor->execute(std::move(localChain), priority);
+        executor->execute(priority, std::move(localChain));
     }
 }
 
@@ -741,7 +749,7 @@ inline void celix::impl::SharedPromiseState<void>::addChain(std::function<void()
         }
     }
     if (localChain) {
-        executor->execute(std::move(localChain), priority);
+        executor->execute(priority, std::move(localChain));
     }
 }
 
@@ -751,7 +759,7 @@ std::shared_ptr<celix::impl::SharedPromiseState<R>> celix::impl::SharedPromiseSt
     if (!mapper) {
         throw celix::PromiseInvocationException("provided mapper is not valid");
     }
-    auto p = celix::impl::SharedPromiseState<R>::create(executor, priority);
+    auto p = celix::impl::SharedPromiseState<R>::create(executor, scheduledExecutor, priority);
     auto chainFunction = [s = self.lock(), p, mapper = std::move(mapper)] {
         try {
             if (s->isSuccessfullyResolved()) {
@@ -772,7 +780,7 @@ std::shared_ptr<celix::impl::SharedPromiseState<R>> celix::impl::SharedPromiseSt
     if (!mapper) {
         throw celix::PromiseInvocationException("provided mapper is not valid");
     }
-    auto p = celix::impl::SharedPromiseState<R>::create(executor, priority);
+    auto p = celix::impl::SharedPromiseState<R>::create(executor, scheduledExecutor, priority);
     auto chainFunction = [s = self.lock(), p, mapper = std::move(mapper)] {
         try {
             if (s->isSuccessfullyResolved()) {
@@ -794,7 +802,7 @@ std::shared_ptr<celix::impl::SharedPromiseState<T>> celix::impl::SharedPromiseSt
     if (!consumer) {
         throw celix::PromiseInvocationException("provided consumer is not valid");
     }
-    auto p = celix::impl::SharedPromiseState<T>::create(executor, priority);
+    auto p = celix::impl::SharedPromiseState<T>::create(executor, scheduledExecutor, priority);
     auto chainFunction = [s = self.lock(), p, consumer = std::move(consumer)] {
         if (s->isSuccessfullyResolved()) {
             try {
@@ -815,7 +823,7 @@ inline std::shared_ptr<celix::impl::SharedPromiseState<void>> celix::impl::Share
     if (!consumer) {
         throw celix::PromiseInvocationException("provided consumer is not valid");
     }
-    auto p = celix::impl::SharedPromiseState<void>::create(executor, priority);
+    auto p = celix::impl::SharedPromiseState<void>::create(executor, scheduledExecutor, priority);
     auto chainFunction = [s = self.lock(), p, consumer = std::move(consumer)] {
         if (s->isSuccessfullyResolved()) {
             try {
@@ -934,7 +942,7 @@ void celix::impl::SharedPromiseState<T>::complete(std::unique_lock<std::mutex>& 
         localChains.swap(chain);
         lck.unlock();
         for (auto &chainTask : localChains) {
-            executor->execute(std::move(chainTask), priority);
+            executor->execute(priority, std::move(chainTask));
         }
         localChains.clear();
         lck.lock();
@@ -957,7 +965,7 @@ inline void celix::impl::SharedPromiseState<void>::complete(std::unique_lock<std
         localChains.swap(chain);
         lck.unlock();
         for (auto &chainTask : localChains) {
-            executor->execute(std::move(chainTask), priority);
+            executor->execute(priority, std::move(chainTask));
         }
         localChains.clear();
         lck.lock();

--- a/libs/promises/gtest/CMakeLists.txt
+++ b/libs/promises/gtest/CMakeLists.txt
@@ -16,6 +16,7 @@
 # under the License.
 
 add_executable(test_celix_promises
+        src/ExecutorTestSuite.cc
         src/PromisesTestSuite.cc
         src/VoidPromisesTestSuite.cc
 )

--- a/libs/promises/gtest/src/ExecutorTestSuite.cc
+++ b/libs/promises/gtest/src/ExecutorTestSuite.cc
@@ -1,0 +1,56 @@
+/**
+ *Licensed to the Apache Software Foundation (ASF) under one
+ *or more contributor license agreements.  See the NOTICE file
+ *distributed with this work for additional information
+ *regarding copyright ownership.  The ASF licenses this file
+ *to you under the Apache License, Version 2.0 (the
+ *"License"); you may not use this file except in compliance
+ *with the License.  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *Unless required by applicable law or agreed to in writing,
+ *software distributed under the License is distributed on an
+ *"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ *specific language governing permissions and limitations
+ *under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include <future>
+#include <utility>
+
+#include "celix/DefaultExecutor.h"
+#include "celix/DefaultScheduledExecutor.h"
+
+class ExecutorTestSuite : public ::testing::Test {
+public:
+    ~ExecutorTestSuite() noexcept override = default;
+    std::shared_ptr<celix::IExecutor> executor = std::make_shared<celix::DefaultExecutor>();
+    std::shared_ptr<celix::IScheduledExecutor> scheduledExecutor = std::make_shared<celix::DefaultScheduledExecutor>();
+};
+
+
+TEST_F(ExecutorTestSuite, ExecuteTasks) {
+    std::atomic<int> counter{0};
+    executor->execute([&counter]{counter++;});
+    executor->execute([&counter]{counter++;});
+    executor->execute([&counter]{counter++;});
+    executor->wait();
+    EXPECT_EQ(3, counter.load());
+}
+
+TEST_F(ExecutorTestSuite, ScheduledExecuteTasks) {
+    std::atomic<int> counter{0};
+    auto t1 = std::chrono::steady_clock::now();
+    scheduledExecutor->schedule(std::chrono::milliseconds{50}, [&counter]{counter++;});
+    scheduledExecutor->schedule(std::chrono::milliseconds{50}, [&counter]{counter++;});
+    scheduledExecutor->schedule(std::chrono::milliseconds{50}, [&counter]{counter++;});
+    scheduledExecutor->wait();
+    auto t2 = std::chrono::steady_clock::now();
+    auto diff = std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1);
+    EXPECT_EQ(3, counter.load());
+    EXPECT_GT(diff, std::chrono::milliseconds{49});
+}

--- a/libs/promises/gtest/src/VoidPromisesTestSuite.cc
+++ b/libs/promises/gtest/src/VoidPromisesTestSuite.cc
@@ -200,8 +200,8 @@ TEST_F(VoidPromiseTestSuite, resolveWithTimeout) {
             .onFailure([&](const std::exception&) {
                 secondFailedCalled = true;
             });
+    p.wait();
     t.join();
-    executor->wait();
     EXPECT_EQ(true, firstSuccessCalled);
     EXPECT_EQ(false, secondSuccessCalled);
     EXPECT_EQ(true, secondFailedCalled);
@@ -243,7 +243,7 @@ TEST_F(VoidPromiseTestSuite, resolveWithDelay) {
                 failedCalled = true;
             });
     deferred1.resolve();
-    executor->wait();
+    p.wait();
     EXPECT_EQ(true, successCalled);
     EXPECT_EQ(false, failedCalled);
     auto durationInMs = std::chrono::duration_cast<std::chrono::milliseconds>(t2.load() - t1);

--- a/libs/promises/src/PromiseExamples.cc
+++ b/libs/promises/src/PromiseExamples.cc
@@ -18,7 +18,6 @@
  */
 
 
-#include <thread>
 #include <iostream>
 #include "celix/PromiseFactory.h"
 
@@ -45,20 +44,20 @@ int main() {
     fib(factory, 1000000000)
         .timeout(std::chrono::milliseconds {100})
         .onSuccess([](long val) {
-            std::cout << "Success p1 : " << std::to_string(val) << std::endl;
+            std::cout << "Success promise 1 : " << std::to_string(val) << std::endl;
         })
         .onFailure([](const std::exception& e) {
-            std::cerr << "Failure p1 : " << e.what() << std::endl;
+            std::cerr << "Failure promise 1 : " << e.what() << std::endl;
         });
 
     fib(factory, 39)
         .timeout(std::chrono::milliseconds{100})
         .onSuccess([](long val) {
-            std::cout << "Success p2 : " << std::to_string(val) << std::endl;
+            std::cout << "Success promise 2 : " << std::to_string(val) << std::endl;
         })
         .onFailure([](const std::exception& e) {
-            std::cerr << "Failure p2 : " << e.what() << std::endl;
+            std::cerr << "Failure promise 2 : " << e.what() << std::endl;
         });
 
-    //NOTE the program can only exit if the executor is done executing all task (even the timeout version).
+    //NOTE the program can only exit if the executor in the PromiseFactory is done executing all tasks.
 }


### PR DESCRIPTION
This PR add a scheduled executor abstraction to celix Promises. 

The celix::IScheduledExecutor is based on Java ScheduleExecutorService, but only what is required for promises.
This PR also add a simple default scheduled executor based on std::async.