### PR TITLE
Adds error handling for the dependency manager.

### DIFF
--- a/libs/framework/include/celix/dm/Component.h
+++ b/libs/framework/include/celix/dm/Component.h
@@ -354,6 +354,12 @@ namespace celix { namespace dm {
          * Can be called on the Celix event thread.
          */
         Component<T>& buildAsync();
+    private:
+        /**
+         * @brief try to invoke a lifecycle method (init, start, stop and deinit) and catch and log a possible exception.
+         * @returns 0 if no exception occurred else -1.
+         */
+        int invokeLifecycleMethod(const std::string& methodName, void (T::*lifecycleMethod)());
     };
 }}
 


### PR DESCRIPTION
Adds error handling for the dependency manager. 

The dependency manager did not have a handling of errors from the component lifecycle methods (init, start, stop, deinit). 
This has been added and now if any of the lifecycle methods return an error (or for C++ throw a exception) to component will be disabled.