### PR TITLE
Adds framework benchmark 

### DIFF
--- a/libs/framework/CMakeLists.txt
+++ b/libs/framework/CMakeLists.txt
@@ -56,3 +56,5 @@ add_library(Celix::framework ALIAS framework)
 if (ENABLE_TESTING)
     add_subdirectory(gtest)
 endif()
+
+add_subdirectory(benchmark)

--- a/libs/framework/benchmark/CMakeLists.txt
+++ b/libs/framework/benchmark/CMakeLists.txt
@@ -1,0 +1,33 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set(FRAMEWORK_BENCHMARK_DEFAULT "OFF")
+find_package(benchmark QUIET)
+if (benchmark_FOUND)
+    set(FRAMEWORK_BENCHMARK_DEFAULT "ON")
+endif ()
+
+celix_subproject(FRAMEWORK_BENCHMARK "Option to enable Celix framework benchmark" ${FRAMEWORK_BENCHMARK_DEFAULT})
+if (FRAMEWORK_BENCHMARK)
+    find_package(benchmark REQUIRED)
+
+    add_executable(celix_framework_benchmark
+            src/RegisterServicesBenchmark.cc
+            src/LookupServicesBenchmark.cc
+    )
+    target_link_libraries(celix_framework_benchmark PRIVATE Celix::framework benchmark::benchmark_main benchmark::benchmark)
+endif ()

--- a/libs/framework/benchmark/src/LookupServicesBenchmark.cc
+++ b/libs/framework/benchmark/src/LookupServicesBenchmark.cc
@@ -20,7 +20,7 @@
 #include <benchmark/benchmark.h>
 #include "celix/FrameworkFactory.h"
 
-//note using c++ service for both the C and C++ lookup, because this should not impact the lookup performance per language.
+//note using c++ service for both the C and C++ benchmark, because this should not impact the performance.
 class IService {
 public:
     static constexpr const char * const NAME = "IService";
@@ -155,11 +155,14 @@ static void LookupServicesBenchmark_cxxCreateDestroyTracker(benchmark::State& st
     createDestroyServiceTracker(state, false);
 }
 
-BENCHMARK(LookupServicesBenchmark_cFindSingleService)->Unit(benchmark::kMillisecond)->RangeMultiplier(10)->Range(1, 10000);
-BENCHMARK(LookupServicesBenchmark_cxxFindSingleService)->Unit(benchmark::kMillisecond)->RangeMultiplier(10)->Range(1, 10000);
+#define CELIX_BENCHMARK(name) \
+    BENCHMARK(name)->MeasureProcessCPUTime()->UseRealTime()->Unit(benchmark::kMillisecond)
 
-BENCHMARK(LookupServicesBenchmark_cFindServiceWithFilter)->Unit(benchmark::kMillisecond)->RangeMultiplier(10)->Range(1, 10000);
-BENCHMARK(LookupServicesBenchmark_cxxFindServiceWithFilter)->Unit(benchmark::kMillisecond)->RangeMultiplier(10)->Range(1, 10000);
+CELIX_BENCHMARK(LookupServicesBenchmark_cFindSingleService)->RangeMultiplier(10)->Range(1, 10000);
+CELIX_BENCHMARK(LookupServicesBenchmark_cxxFindSingleService)->RangeMultiplier(10)->Range(1, 10000);
 
-BENCHMARK(LookupServicesBenchmark_cCreateDestroyTracker)->Unit(benchmark::kMillisecond)->RangeMultiplier(10)->Range(1, 1000);
-BENCHMARK(LookupServicesBenchmark_cxxCreateDestroyTracker)->Unit(benchmark::kMillisecond)->RangeMultiplier(10)->Range(1, 1000);
+CELIX_BENCHMARK(LookupServicesBenchmark_cFindServiceWithFilter)->RangeMultiplier(10)->Range(1, 10000);
+CELIX_BENCHMARK(LookupServicesBenchmark_cxxFindServiceWithFilter)->RangeMultiplier(10)->Range(1, 10000);
+
+CELIX_BENCHMARK(LookupServicesBenchmark_cCreateDestroyTracker)->RangeMultiplier(10)->Range(1, 1000);
+CELIX_BENCHMARK(LookupServicesBenchmark_cxxCreateDestroyTracker)->RangeMultiplier(10)->Range(1, 1000);

--- a/libs/framework/benchmark/src/LookupServicesBenchmark.cc
+++ b/libs/framework/benchmark/src/LookupServicesBenchmark.cc
@@ -1,0 +1,165 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <benchmark/benchmark.h>
+#include "celix/FrameworkFactory.h"
+
+//note using c++ service for both the C and C++ lookup, because this should not impact the lookup performance per language.
+class IService {
+public:
+    static constexpr const char * const NAME = "IService";
+    virtual ~IService() noexcept = default;
+};
+
+class ServiceImpl : public IService {
+public:
+    ~ServiceImpl() noexcept override = default;
+};
+
+/**
+ * Benchmark to measure to lookup/track services in Celix framework already containing more
+ * or less registered services.
+ */
+class LookupServicesBenchmark {
+public:
+    explicit LookupServicesBenchmark(int64_t _nrOfServiceRegistrations) : nrOfServiceRegistrations{_nrOfServiceRegistrations}, fw{createFw()} {
+        auto ctx = fw->getFrameworkBundleContext();
+        for (int i = 0; i < nrOfServiceRegistrations; ++i) {
+            auto reg = ctx->registerService<IService>(std::make_shared<ServiceImpl>(), IService::NAME)
+                    .addProperty("key", std::string{"value"} + std::to_string(i))
+                    .build();
+            registrations.emplace_back(std::move(reg));
+        }
+        ctx->waitForEvents();
+    }
+
+    static std::shared_ptr<celix::Framework> createFw() {
+        celix::Properties config{};
+        config.set(celix::FRAMEWORK_STATIC_EVENT_QUEUE_SIZE, 1024*10);
+        config.set("CELIX_LOGGING_DEFAULT_ACTIVE_LOG_LEVEL", "error");
+        return celix::createFramework(config);
+    }
+
+    const int64_t nrOfServiceRegistrations;
+    const std::shared_ptr<celix::Framework> fw;
+
+    std::vector<std::shared_ptr<celix::ServiceRegistration>> registrations{};
+};
+
+static void findSingleService(benchmark::State& state, bool cTest, bool useFilter) {
+    LookupServicesBenchmark benchmark{state.range(0)};
+    auto ctx = benchmark.fw->getFrameworkBundleContext();
+    auto* cCtx = ctx->getCBundleContext();
+
+    auto index = benchmark.nrOfServiceRegistrations / 2;
+    auto filter = std::string{"(key=value"} + std::to_string(index) + ")";
+
+    if (cTest) {
+        if (useFilter) {
+            celix_service_filter_options_t opts{};
+            opts.serviceName = IService::NAME;
+            opts.filter = filter.c_str();
+            for (auto _ : state) {
+                // This code gets timed
+                long svcId = celix_bundleContext_findServiceWithOptions(cCtx, &opts);
+                assert(svcId > 0);
+            }
+        } else {
+            for (auto _ : state) {
+                // This code gets timed
+                long svcId = celix_bundleContext_findService(cCtx, IService::NAME);
+                assert(svcId >= 0);
+            }
+        }
+    } else {
+        if (useFilter) {
+            for (auto _ : state) {
+                // This code gets timed
+                long svcId = ctx->findServiceWithName<IService>(IService::NAME, filter);
+                assert(svcId >= 0);
+            }
+        } else {
+            for (auto _ : state) {
+                // This code gets timed
+                long svcId = ctx->findServiceWithName<IService>(IService::NAME);
+                assert(svcId >= 0);
+            }
+        }
+
+    }
+    state.SetItemsProcessed(state.iterations());
+}
+
+static void createDestroyServiceTracker(benchmark::State& state, bool cTest) {
+    LookupServicesBenchmark benchmark{state.range(0)};
+    auto ctx = benchmark.fw->getFrameworkBundleContext();
+    auto* cCtx = ctx->getCBundleContext();
+
+    if (cTest) {
+        celix_service_tracking_options_t opts{};
+        opts.filter.serviceName = IService::NAME;
+        for (auto _ : state) {
+            // This code gets timed
+            long trkId = celix_bundleContext_trackServicesWithOptions(cCtx, &opts);
+            celix_bundleContext_stopTracker(cCtx, trkId);
+        }
+    } else {
+        for (auto _ : state) {
+            // This code gets timed
+            auto trk = ctx->trackServices<IService>(IService::NAME).build();
+            trk->wait();
+            trk->close();
+            trk->wait();
+        }
+    }
+    state.SetItemsProcessed(state.iterations());
+}
+
+static void LookupServicesBenchmark_cFindSingleService(benchmark::State& state) {
+    findSingleService(state, true, false);
+}
+
+static void LookupServicesBenchmark_cxxFindSingleService(benchmark::State& state) {
+    findSingleService(state, false, false);
+}
+
+static void LookupServicesBenchmark_cFindServiceWithFilter(benchmark::State& state) {
+    findSingleService(state, true, true);
+}
+
+static void LookupServicesBenchmark_cxxFindServiceWithFilter(benchmark::State& state) {
+    findSingleService(state, false, true);
+}
+
+static void LookupServicesBenchmark_cCreateDestroyTracker(benchmark::State& state) {
+    createDestroyServiceTracker(state, true);
+}
+
+static void LookupServicesBenchmark_cxxCreateDestroyTracker(benchmark::State& state) {
+    createDestroyServiceTracker(state, false);
+}
+
+BENCHMARK(LookupServicesBenchmark_cFindSingleService)->Unit(benchmark::kMillisecond)->RangeMultiplier(10)->Range(1, 10000);
+BENCHMARK(LookupServicesBenchmark_cxxFindSingleService)->Unit(benchmark::kMillisecond)->RangeMultiplier(10)->Range(1, 10000);
+
+BENCHMARK(LookupServicesBenchmark_cFindServiceWithFilter)->Unit(benchmark::kMillisecond)->RangeMultiplier(10)->Range(1, 10000);
+BENCHMARK(LookupServicesBenchmark_cxxFindServiceWithFilter)->Unit(benchmark::kMillisecond)->RangeMultiplier(10)->Range(1, 10000);
+
+BENCHMARK(LookupServicesBenchmark_cCreateDestroyTracker)->Unit(benchmark::kMillisecond)->RangeMultiplier(10)->Range(1, 1000);
+BENCHMARK(LookupServicesBenchmark_cxxCreateDestroyTracker)->Unit(benchmark::kMillisecond)->RangeMultiplier(10)->Range(1, 1000);

--- a/libs/framework/benchmark/src/RegisterServicesBenchmark.cc
+++ b/libs/framework/benchmark/src/RegisterServicesBenchmark.cc
@@ -20,7 +20,7 @@
 #include <benchmark/benchmark.h>
 #include "celix/FrameworkFactory.h"
 
-//note using c++ service for both the C and C++ lookup, because this should not impact the lookup performance per language.
+//note using c++ service for both the C and C++ benchmark, because this should not impact the performance.
 class IService {
 public:
     static constexpr const char * const NAME = "IService";
@@ -148,11 +148,14 @@ static void RegisterServicesBenchmark_cxxRegistration(benchmark::State& state) {
     registrationTest(state, false);
 }
 
-BENCHMARK(RegisterServicesBenchmark_cRegistrationAndUnregistration)->Unit(benchmark::kMillisecond)->RangeMultiplier(10)->Range(1, 10000);
-BENCHMARK(RegisterServicesBenchmark_cxxRegistrationAndUnregistration)->Unit(benchmark::kMillisecond)->RangeMultiplier(10)->Range(1, 10000);
+#define CELIX_BENCHMARK(name) \
+    BENCHMARK(name)->MeasureProcessCPUTime()->UseRealTime()->Unit(benchmark::kMillisecond)
 
-BENCHMARK(RegisterServicesBenchmark_cRegistrationAndUnregistrationWith100Trackers)->Unit(benchmark::kMillisecond)->RangeMultiplier(10)->Range(1, 1000);
-BENCHMARK(RegisterServicesBenchmark_cxxRegistrationAndUnregistrationWith100Trackers)->Unit(benchmark::kMillisecond)->RangeMultiplier(10)->Range(1, 1000);
+CELIX_BENCHMARK(RegisterServicesBenchmark_cRegistrationAndUnregistration)->RangeMultiplier(10)->Range(1, 10000);
+CELIX_BENCHMARK(RegisterServicesBenchmark_cxxRegistrationAndUnregistration)->RangeMultiplier(10)->Range(1, 10000);
 
-BENCHMARK(RegisterServicesBenchmark_cRegistration)->Unit(benchmark::kMillisecond)->RangeMultiplier(10)->Range(1, 1000);
-BENCHMARK(RegisterServicesBenchmark_cxxRegistration)->Unit(benchmark::kMillisecond)->RangeMultiplier(10)->Range(1, 1000);
+CELIX_BENCHMARK(RegisterServicesBenchmark_cRegistrationAndUnregistrationWith100Trackers)->RangeMultiplier(10)->Range(1, 1000);
+CELIX_BENCHMARK(RegisterServicesBenchmark_cxxRegistrationAndUnregistrationWith100Trackers)->RangeMultiplier(10)->Range(1, 1000);
+
+CELIX_BENCHMARK(RegisterServicesBenchmark_cRegistration)->RangeMultiplier(10)->Range(1, 1000);
+CELIX_BENCHMARK(RegisterServicesBenchmark_cxxRegistration)->RangeMultiplier(10)->Range(1, 1000);

--- a/libs/framework/benchmark/src/RegisterServicesBenchmark.cc
+++ b/libs/framework/benchmark/src/RegisterServicesBenchmark.cc
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <benchmark/benchmark.h>
+#include "celix/FrameworkFactory.h"
+
+//note using c++ service for both the C and C++ lookup, because this should not impact the lookup performance per language.
+class IService {
+public:
+    static constexpr const char * const NAME = "IService";
+    virtual ~IService() noexcept = default;
+};
+
+class ServiceImpl : public IService {
+public:
+    ~ServiceImpl() noexcept override = default;
+};
+
+/**
+ * Benchmark to measure to time needed registering and unregister services in Celix framework already containing more
+ * or less registered services.
+ */
+class RegisterServicesBenchmark {
+public:
+    explicit RegisterServicesBenchmark(int64_t _nrOfServiceRegistrations, int nrOfServiceTrackers = 0) : nrOfServiceRegistrations{_nrOfServiceRegistrations}, fw{createFw()} {
+        auto ctx = fw->getFrameworkBundleContext();
+        registrations.reserve(nrOfServiceRegistrations);
+        for (int64_t i = 0; i < nrOfServiceRegistrations; ++i) {
+            registrations.emplace_back(
+                    ctx->registerService<IService>(std::make_shared<ServiceImpl>(), IService::NAME).build());
+        }
+        for (int i = 0; i < nrOfServiceTrackers; ++i) {
+            trackers.emplace_back(
+                    ctx->trackServices<IService>(IService::NAME).build()
+            );
+        }
+        ctx->waitForEvents();
+    }
+
+    static std::shared_ptr<celix::Framework> createFw() {
+        celix::Properties config{};
+        config.set(celix::FRAMEWORK_STATIC_EVENT_QUEUE_SIZE, 1024*10);
+        config.set("CELIX_LOGGING_DEFAULT_ACTIVE_LOG_LEVEL", "error");
+        return celix::createFramework(config);
+    }
+
+    const int64_t nrOfServiceRegistrations;
+    const std::shared_ptr<celix::Framework> fw;
+
+    std::vector<std::shared_ptr<celix::ServiceRegistration>> registrations{};
+    std::vector<std::shared_ptr<celix::GenericServiceTracker>> trackers{};
+};
+
+static void registrationAndUnregistrationTest(benchmark::State& state, bool cTest, int nrOfTrackers) {
+    RegisterServicesBenchmark benchmark{state.range(0), nrOfTrackers};
+    auto ctx = benchmark.fw->getFrameworkBundleContext();
+    auto* cCtx = ctx->getCBundleContext();
+    auto svc = std::make_shared<ServiceImpl>();
+
+    if (cTest) {
+        for (auto _ : state) {
+            // This code gets timed
+            long svcId = celix_bundleContext_registerService(cCtx, svc.get(), IService::NAME, nullptr);
+            celix_bundleContext_unregisterService(cCtx, svcId);
+        }
+    } else {
+        for (auto _ : state) {
+            // This code gets timed
+            auto reg = ctx->registerService<IService>(svc, IService::NAME)
+                    .setRegisterAsync(false)
+                    .setUnregisterAsync(false)
+                    .build();
+            reg->unregister();
+        }
+    }
+
+    state.SetItemsProcessed(state.iterations());
+}
+
+static void registrationTest(benchmark::State& state, bool cTest) {
+    RegisterServicesBenchmark benchmark{state.range(0)};
+    auto ctx = benchmark.fw->getFrameworkBundleContext();
+    auto *cCtx = ctx->getCBundleContext();
+    auto svc = std::make_shared<ServiceImpl>();
+
+    if (cTest) {
+        for (auto _ : state) {
+            // This code gets timed
+            long svcId = celix_bundleContext_registerService(cCtx, svc.get(), IService::NAME, nullptr);
+            state.PauseTiming();
+            celix_bundleContext_unregisterService(cCtx, svcId);
+            state.ResumeTiming();
+        }
+    } else {
+        for (auto _ : state) {
+            // This code gets timed
+            auto reg = ctx->registerService<IService>(svc, IService::NAME)
+                    .setRegisterAsync(false)
+                    .setUnregisterAsync(false)
+                    .build();
+            state.PauseTiming();
+            reg->unregister();
+            state.ResumeTiming();
+        }
+    }
+
+    state.SetItemsProcessed(state.iterations());
+}
+
+static void RegisterServicesBenchmark_cRegistrationAndUnregistration(benchmark::State& state) {
+    registrationAndUnregistrationTest(state, true, 0);
+}
+
+
+static void RegisterServicesBenchmark_cxxRegistrationAndUnregistration(benchmark::State& state) {
+    registrationAndUnregistrationTest(state, false, 0);
+}
+
+static void RegisterServicesBenchmark_cRegistrationAndUnregistrationWith100Trackers(benchmark::State& state) {
+    registrationAndUnregistrationTest(state, true, 100);
+}
+
+static void RegisterServicesBenchmark_cxxRegistrationAndUnregistrationWith100Trackers(benchmark::State& state) {
+    registrationAndUnregistrationTest(state, false, 100);
+}
+
+static void RegisterServicesBenchmark_cRegistration(benchmark::State& state) {
+    registrationTest(state, true);
+}
+
+static void RegisterServicesBenchmark_cxxRegistration(benchmark::State& state) {
+    registrationTest(state, false);
+}
+
+BENCHMARK(RegisterServicesBenchmark_cRegistrationAndUnregistration)->Unit(benchmark::kMillisecond)->RangeMultiplier(10)->Range(1, 10000);
+BENCHMARK(RegisterServicesBenchmark_cxxRegistrationAndUnregistration)->Unit(benchmark::kMillisecond)->RangeMultiplier(10)->Range(1, 10000);
+
+BENCHMARK(RegisterServicesBenchmark_cRegistrationAndUnregistrationWith100Trackers)->Unit(benchmark::kMillisecond)->RangeMultiplier(10)->Range(1, 1000);
+BENCHMARK(RegisterServicesBenchmark_cxxRegistrationAndUnregistrationWith100Trackers)->Unit(benchmark::kMillisecond)->RangeMultiplier(10)->Range(1, 1000);
+
+BENCHMARK(RegisterServicesBenchmark_cRegistration)->Unit(benchmark::kMillisecond)->RangeMultiplier(10)->Range(1, 1000);
+BENCHMARK(RegisterServicesBenchmark_cxxRegistration)->Unit(benchmark::kMillisecond)->RangeMultiplier(10)->Range(1, 1000);

--- a/libs/framework/gtest/src/CxxBundleContextTestSuite.cc
+++ b/libs/framework/gtest/src/CxxBundleContextTestSuite.cc
@@ -82,6 +82,23 @@ TEST_F(CxxBundleContextTestSuite, RegisterServiceTest) {
     EXPECT_EQ(svcId, -1L);
 }
 
+TEST_F(CxxBundleContextTestSuite, RegisterServiceWithNameTest) {
+    long svcId = ctx->findServiceWithName<TestInterface>("foo");
+    EXPECT_EQ(svcId, -1L);
+
+    {
+        auto impl = std::make_shared<TestImplementation>();
+        auto svcReg = ctx->registerService<TestInterface>(impl, "foo").build();
+        svcReg->wait();
+        svcId = ctx->findServiceWithName<TestInterface>("foo");
+        EXPECT_GE(svcId, 0L);
+    }
+
+    ctx->waitForEvents();
+    svcId = ctx->findServiceWithName<TestInterface>("foo");
+    EXPECT_EQ(svcId, -1L);
+}
+
 TEST_F(CxxBundleContextTestSuite, RegisterCServiceTest) {
     auto svc = std::make_shared<CInterface>(CInterface{nullptr, nullptr});
     auto svcReg = ctx->registerService<CInterface>(svc).build();

--- a/libs/framework/gtest/src/bundle_context_services_test.cpp
+++ b/libs/framework/gtest/src/bundle_context_services_test.cpp
@@ -40,11 +40,12 @@ public:
     celix_properties_t *properties = nullptr;
 
     CelixBundleContextServicesTests() {
-        properties = properties_create();
-        properties_set(properties, "LOGHELPER_ENABLE_STDOUT_FALLBACK", "true");
-        properties_set(properties, "org.osgi.framework.storage.clean", "onFirstInit");
-        properties_set(properties, "org.osgi.framework.storage", ".cacheBundleContextTestFramework");
-        properties_set(properties, "CELIX_LOGGING_DEFAULT_ACTIVE_LOG_LEVEL", "trace");
+        properties = celix_properties_create();
+        celix_properties_set(properties, "LOGHELPER_ENABLE_STDOUT_FALLBACK", "true");
+        celix_properties_set(properties, "org.osgi.framework.storage.clean", "onFirstInit");
+        celix_properties_set(properties, "org.osgi.framework.storage", ".cacheBundleContextTestFramework");
+        celix_properties_set(properties, "CELIX_LOGGING_DEFAULT_ACTIVE_LOG_LEVEL", "trace");
+        celix_properties_setLong(properties, CELIX_FRAMEWORK_STATIC_EVENT_QUEUE_SIZE,  256); //ensure that the floodEventLoopTest overflows the static event queue size
 
         fw = celix_frameworkFactory_createFramework(properties);
         ctx = framework_getContext(fw);

--- a/libs/framework/include/celix/Constants.h
+++ b/libs/framework/include/celix/Constants.h
@@ -95,6 +95,19 @@ namespace celix {
      */
     constexpr const char * const FRAMEWORK_UUID = OSGI_FRAMEWORK_FRAMEWORK_UUID;
 
+    /**
+     * @brief Celix framework environment property (named "CELIX_FRAMEWORK_STATIC_EVENT_QUEUE_SIZE") which configures
+     * the static event size queue used by the Celix framework.
+     *
+     * The Celix framework handle service events in a event thread. This thread uses a static allocated event queue with
+     * a fixed size and dynamic event queue if the static event queue is full.
+     * The decrease the memory footprint a smaller static event queue size can be used and to improve performance during
+     * heavy load a bigger static event queue size can be used.
+     *
+     * Default is CELIX_FRAMEWORK_DEFAULT_STATIC_EVENT_QUEUE_SIZE which is 1024, but can be override with a compiler
+     * define (same name).
+     */
+    constexpr const char * const FRAMEWORK_STATIC_EVENT_QUEUE_SIZE = CELIX_FRAMEWORK_STATIC_EVENT_QUEUE_SIZE;
 
     /**
      * @brief Celix framework environment property (named "CELIX_AUTO_START_0") which specified a (ordered) space

--- a/libs/framework/include/celix/FrameworkFactory.h
+++ b/libs/framework/include/celix/FrameworkFactory.h
@@ -27,25 +27,18 @@
 #include "celix_framework_factory.h"
 
 namespace celix {
-
     /**
-     * @brief A factory for creating Celix framework instances.
+     * @brief Create a new celix Framework instance.
      */
-    class FrameworkFactory {
-    public:
-
-        /**
-         * @brief Create a new celix Framework instance.
-         */
-        static std::shared_ptr<celix::Framework> createFramework(const celix::Properties& properties = {}) {
-            auto* copy = celix_properties_copy(properties.getCProperties());
-            auto* cFw= celix_frameworkFactory_createFramework(copy);
-            auto fwCtx = std::make_shared<celix::BundleContext>(celix_framework_getFrameworkContext(cFw));
-            std::shared_ptr<celix::Framework> framework{new celix::Framework{std::move(fwCtx), cFw}, [](celix::Framework* fw) {
-                celix_frameworkFactory_destroyFramework(fw->getCFramework());
-                delete fw;
-            }};
-            return framework;
-        }
-    };
+    static std::shared_ptr<celix::Framework> createFramework(const celix::Properties& properties = {}) {
+        auto* copy = celix_properties_copy(properties.getCProperties());
+        auto* cFw= celix_frameworkFactory_createFramework(copy);
+        auto fwCtx = std::make_shared<celix::BundleContext>(celix_framework_getFrameworkContext(cFw));
+        std::shared_ptr<celix::Framework> framework{new celix::Framework{std::move(fwCtx), cFw}, [](celix::Framework* fw) {
+            celix_framework_waitForEmptyEventQueue(fw->getCFramework());
+            celix_frameworkFactory_destroyFramework(fw->getCFramework());
+            delete fw;
+        }};
+        return framework;
+    }
 }

--- a/libs/framework/include/celix_constants.h
+++ b/libs/framework/include/celix_constants.h
@@ -162,6 +162,19 @@ extern "C" {
  */
 #define CELIX_SYSTEM_BUNDLE_ARCHIVE_PATH "CELIX_SYSTEM_BUNDLE_ARCHIVE_PATH"
 
+/**
+ * @brief Celix framework environment property (named "CELIX_FRAMEWORK_STATIC_EVENT_QUEUE_SIZE") which configures
+ * the static event size queue used by the Celix framework.
+ *
+ * The Celix framework handle service events in a event thread. This thread uses a static allocated event queue with
+ * a fixed size and dynamic event queue if the static event queue is full.
+ * The decrease the memory footprint a smaller static event queue size can be used and to improve performance during
+ * heavy load a bigger static event queue size can be used.
+ *
+ * Default is CELIX_FRAMEWORK_DEFAULT_STATIC_EVENT_QUEUE_SIZE which is 1024, but can be override with a compiler
+ * define (same name).
+ */
+#define CELIX_FRAMEWORK_STATIC_EVENT_QUEUE_SIZE "CELIX_FRAMEWORK_STATIC_EVENT_QUEUE_SIZE"
 
 /**
  * @brief Celix framework environment property (named "CELIX_AUTO_START_0") which specified a (ordered) space

--- a/libs/framework/src/framework_private.h
+++ b/libs/framework/src/framework_private.h
@@ -41,7 +41,9 @@
 #include "celix_threads.h"
 #include "service_registry.h"
 
-#define CELIX_FRAMEWORK_STATIC_EVENT_QUEUE_SIZE 256
+#ifndef CELIX_FRAMEWORK_DEFAULT_STATIC_EVENT_QUEUE_SIZE
+#define CELIX_FRAMEWORK_DEFAULT_STATIC_EVENT_QUEUE_SIZE 1024
+#endif
 
 typedef struct celix_framework_bundle_entry {
     celix_bundle_t *bnd;
@@ -155,7 +157,8 @@ struct celix_framework {
         celix_thread_t thread;
         celix_thread_mutex_t mutex; //protects below
         bool active;
-        celix_framework_event_t eventQueue[CELIX_FRAMEWORK_STATIC_EVENT_QUEUE_SIZE]; //ring buffer
+        celix_framework_event_t* eventQueue; //ring buffer
+        int eventQueueCap;
         int eventQueueSize;
         int eventQueueFirstEntry;
         celix_array_list_t *dynamicEventQueue; //entry = celix_framework_event_t*. Used when the eventQueue is full

--- a/libs/framework/src/service_tracker.c
+++ b/libs/framework/src/service_tracker.c
@@ -42,13 +42,6 @@ static celix_status_t serviceTracker_invokeAddService(service_tracker_t *tracker
 static celix_status_t serviceTracker_invokeRemovingService(service_tracker_t *tracker, celix_tracked_entry_t *tracked);
 static void serviceTracker_checkAndInvokeSetService(void *handle, void *highestSvc, const properties_t *props, const bundle_t *bnd);
 
-
-#ifdef CELIX_SERVICE_TRACKER_USE_SHUTDOWN_THREAD
-static void serviceTracker_addInstanceFromShutdownList(celix_service_tracker_instance_t *instance);
-static void serviceTracker_remInstanceFromShutdownList(celix_service_tracker_instance_t *instance);
-static void* shutdownServiceTrackerInstanceHandler(void *data);
-#endif
-
 static void serviceTracker_serviceChanged(void *handle, celix_service_event_t *event);
 
 


### PR DESCRIPTION
This PR adds a benchmark - using google benchmark - for service registration and service lookup.

Also make the Celix framework static event queue size configurable with a config property. 