### PR TITLE
Fixes pubsub scope issue 

### DIFF
--- a/bundles/pubsub/pubsub_utils/src/pubsub_utils.c
+++ b/bundles/pubsub/pubsub_utils/src/pubsub_utils.c
@@ -57,10 +57,15 @@ celix_status_t pubsub_getPubSubInfoFromFilter(const char* filterstr, char **scop
     objectClass = (char *) celix_filter_findAttribute(filter, OSGI_FRAMEWORK_OBJECTCLASS);
 
     if (topic != NULL && objectClass != NULL && strncmp(objectClass, PUBSUB_PUBLISHER_SERVICE_NAME, 128) == 0) {
-        //NOTE topic must be present, scope can be present in the filter.
-        *topicOut = strdup(topic);
+        //NOTE topic must be present, scope can be present in the filter
+        *topicOut = celix_utils_strdup(topic);
         if (scope != NULL) {
-            *scopeOut = strdup(scope);
+            if (strncmp("*", scope, 2) == 0) {
+                //if scope attribute is present with a *, assume this is a negative test e.g. (&(topic=foo)(!(scope=*)))
+                *scopeOut = NULL;
+            } else {
+                *scopeOut = celix_utils_strdup(scope);
+            }
         } else {
             *scopeOut = NULL;
         }
@@ -70,8 +75,8 @@ celix_status_t pubsub_getPubSubInfoFromFilter(const char* filterstr, char **scop
     }
 
     if (filter != NULL) {
-             filter_destroy(filter);
-        }
+         filter_destroy(filter);
+    }
     return status;
 }
 

--- a/bundles/pubsub/test/CMakeLists.txt
+++ b/bundles/pubsub/test/CMakeLists.txt
@@ -206,7 +206,7 @@ if (BUILD_PUBSUB_PSA_TCP)
             Celix::pubsub_admin_tcp
             pubsub_sut
             pubsub_tst
-            )
+    )
     target_link_libraries(pubsub_tcp_wire_v1_tests PRIVATE Celix::pubsub_api ${CppUTest_LIBRARIES} Jansson Celix::dfi)
     target_include_directories(pubsub_tcp_wire_v1_tests SYSTEM PRIVATE ${CppUTest_INCLUDE_DIR} test)
     add_test(NAME pubsub_tcp_wire_v1_tests COMMAND pubsub_tcp_wire_v1_tests WORKING_DIRECTORY $<TARGET_PROPERTY:pubsub_tcp_wire_v1_tests,CONTAINER_LOC>)
@@ -228,11 +228,34 @@ if (BUILD_PUBSUB_PSA_TCP)
             Celix::pubsub_admin_tcp
             pubsub_sut
             pubsub_tst
-            )
+    )
     target_link_libraries(pubsub_tcp_wire_v2_tests PRIVATE Celix::pubsub_api ${CppUTest_LIBRARIES} Jansson Celix::dfi)
     target_include_directories(pubsub_tcp_wire_v2_tests SYSTEM PRIVATE ${CppUTest_INCLUDE_DIR} test)
     add_test(NAME pubsub_tcp_wire_v2_tests COMMAND pubsub_tcp_wire_v2_tests WORKING_DIRECTORY $<TARGET_PROPERTY:pubsub_tcp_wire_v2_tests,CONTAINER_LOC>)
     setup_target_for_coverage(pubsub_tcp_wire_v2_tests SCAN_DIR ..)
+
+    add_celix_container(pubsub_tcp_wire_v2_with_no_scope_tests
+        USE_CONFIG #ensures that a config.properties will be created with the launch bundles.
+        LAUNCHER_SRC ${CMAKE_CURRENT_LIST_DIR}/test/test_runner.cc
+        DIR ${CMAKE_CURRENT_BINARY_DIR}
+        PROPERTIES
+            LOGHELPER_STDOUT_FALLBACK_INCLUDE_DEBUG=true
+            CELIX_LOGGING_DEFAULT_ACTIVE_LOG_LEVEL=trace
+            CELIX_PUBSUB_TEST_USE_NEGATIVE_SCOPE_FILTER=false
+        BUNDLES
+            Celix::shell
+            Celix::shell_tui
+            Celix::pubsub_serializer_json
+            Celix::pubsub_protocol_wire_v2
+            Celix::pubsub_topology_manager
+            Celix::pubsub_admin_tcp
+            pubsub_sut
+            pubsub_tst
+    )
+    target_link_libraries(pubsub_tcp_wire_v2_with_no_scope_tests PRIVATE Celix::pubsub_api ${CppUTest_LIBRARIES} Jansson Celix::dfi)
+    target_include_directories(pubsub_tcp_wire_v2_with_no_scope_tests SYSTEM PRIVATE ${CppUTest_INCLUDE_DIR} test)
+    add_test(NAME pubsub_tcp_wire_v2_with_no_scope_tests COMMAND pubsub_tcp_wire_v2_with_no_scope_tests WORKING_DIRECTORY $<TARGET_PROPERTY:pubsub_tcp_wire_v2_with_no_scope_tests,CONTAINER_LOC>)
+    setup_target_for_coverage(pubsub_tcp_wire_v2_with_no_scope_tests SCAN_DIR ..)
 
     add_celix_container(pubsub_tcp_endpoint_tests
             USE_CONFIG #ensures that a config.properties will be created with the launch bundles.

--- a/bundles/pubsub/test/test/sut_activator.c
+++ b/bundles/pubsub/test/test/sut_activator.c
@@ -42,7 +42,12 @@ struct activator {
 celix_status_t bnd_start(struct activator *act, celix_bundle_context_t *ctx) {
 
     char filter[512];
-    snprintf(filter, 512, "(%s=%s)", PUBSUB_PUBLISHER_TOPIC, "ping");
+    bool useNegativeScopeFilter = celix_bundleContext_getPropertyAsBool(ctx, "CELIX_PUBSUB_TEST_USE_NEGATIVE_SCOPE_FILTER", true);
+    if (useNegativeScopeFilter) {
+        snprintf(filter, 512, "(%s=%s)(!(scope=*))", PUBSUB_PUBLISHER_TOPIC, "ping");
+    } else {
+        snprintf(filter, 512, "(%s=%s)", PUBSUB_PUBLISHER_TOPIC, "ping");
+    }
     celix_service_tracking_options_t opts = CELIX_EMPTY_SERVICE_TRACKING_OPTIONS;
     opts.set = sut_pubSet;
     opts.callbackHandle = act;

--- a/bundles/pubsub/test/test/sut_endpoint_activator.c
+++ b/bundles/pubsub/test/test/sut_endpoint_activator.c
@@ -42,7 +42,12 @@ struct activator {
 celix_status_t bnd_start(struct activator *act, celix_bundle_context_t *ctx) {
 
 	char filter[512];
-	snprintf(filter, 512, "(%s=%s)", PUBSUB_PUBLISHER_TOPIC, "ping2");
+    bool useNegativeScopeFilter = celix_bundleContext_getPropertyAsBool(ctx, "CELIX_PUBSUB_TEST_USE_NEGATIVE_SCOPE_FILTER", true);
+    if (useNegativeScopeFilter) {
+        snprintf(filter, 512, "(%s=%s)(!(scope=*))", PUBSUB_PUBLISHER_TOPIC, "ping");
+    } else {
+        snprintf(filter, 512, "(%s=%s)", PUBSUB_PUBLISHER_TOPIC, "ping");
+    }
 	celix_service_tracking_options_t opts = CELIX_EMPTY_SERVICE_TRACKING_OPTIONS;
 	opts.set = sut_pubSet;
 	opts.callbackHandle = act;


### PR DESCRIPTION
This PR fixes a pubsub scope issue.

The celix_filter_findAttribute now also find attributes used in a negative ldap expression (!(expr)).
pubsub did not correctly handle scope=* filter entries.