### PR TITLE
Updates BundleActivator to always use the ctx->getDependencyManager().

### DIFF
--- a/libs/framework/include/celix/BundleActivator.h
+++ b/libs/framework/include/celix/BundleActivator.h
@@ -32,7 +32,6 @@ namespace celix {
         struct BundleActivatorData {
             long bndId;
             std::shared_ptr<celix::BundleContext> ctx;
-            std::shared_ptr<celix::dm::DependencyManager> dm;
             std::unique_ptr<I> bundleActivator;
         };
 
@@ -41,9 +40,8 @@ namespace celix {
         typename std::enable_if<std::is_constructible<I, std::shared_ptr<celix::BundleContext>>::value, celix_status_t>::type
         createActivator(celix_bundle_context_t *cCtx, void **out) {
             auto ctx = std::make_shared<celix::BundleContext>(cCtx);
-            auto dm = std::make_shared<celix::dm::DependencyManager>(cCtx);
             auto act = std::unique_ptr<I>(new I{ctx});
-            auto *data = new BundleActivatorData<I>{ctx->getBundleId(), std::move(ctx), std::move(dm), std::move(act)};
+            auto *data = new BundleActivatorData<I>{ctx->getBundleId(), std::move(ctx), std::move(act)};
             *out = (void *) data;
             return CELIX_SUCCESS;
         }
@@ -52,10 +50,10 @@ namespace celix {
         typename std::enable_if<std::is_constructible<I, std::shared_ptr<celix::dm::DependencyManager>>::value, celix_status_t>::type
         createActivator(celix_bundle_context_t *cCtx, void **out) {
             auto ctx = std::make_shared<celix::BundleContext>(cCtx);
-            auto dm = std::make_shared<celix::dm::DependencyManager>(cCtx);
+            auto dm = ctx->getDependencyManager();
             auto act = std::unique_ptr<I>(new I{dm});
             dm->start();
-            auto *data = new BundleActivatorData<I>{ctx->getBundleId(), std::move(ctx), std::move(dm), std::move(act)};
+            auto *data = new BundleActivatorData<I>{ctx->getBundleId(), std::move(ctx), std::move(act)};
             *out = (void *) data;
             return CELIX_SUCCESS;
         }
@@ -84,9 +82,9 @@ namespace celix {
         celix_status_t destroyActivator(void *userData) {
             auto *data = static_cast<BundleActivatorData<I> *>(userData);
             std::weak_ptr<celix::BundleContext> ctx = data->ctx;
-            std::weak_ptr<celix::dm::DependencyManager> dm = data->dm;
+            std::weak_ptr<celix::dm::DependencyManager> dm = data->ctx->getDependencyManager();
             auto bndId = data->bndId;
-            data->dm->clear();
+            data->ctx->getDependencyManager()->clear();
             delete data;
             waitForExpired(bndId, ctx, "celix::BundleContext", ctx);
             waitForExpired(bndId, ctx, "celix::dm::DependencyManager", dm);

--- a/libs/framework/include/celix/Trackers.h
+++ b/libs/framework/include/celix/Trackers.h
@@ -25,6 +25,8 @@
 #include <cassert>
 #include <set>
 #include <unordered_map>
+#include <functional>
+#include <thread>
 
 #include "celix_utils.h"
 #include "celix/Properties.h"
@@ -33,6 +35,8 @@
 #include "celix/Constants.h"
 #include "celix/Filter.h"
 #include "celix_bundle_context.h"
+#include "celix_framework.h"
+
 
 namespace celix {
 


### PR DESCRIPTION
The C++ BundleActivator was using a own constructed dependency manager object which differs from the BundleContext::getDependencyManager() object. This lead to some issues. 

Also adds some missing includes when using celix/Trackers.h directly (instead of through celix/BundleContext.h)