### PR TITLE
Do not set std=c++17 on library level

### DIFF
--- a/.github/workflows/celix_etcdlib.yml
+++ b/.github/workflows/celix_etcdlib.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04]
+        os: [ubuntu-20.04]
         compiler: [gcc]
     timeout-minutes: 15
     steps:

--- a/.github/workflows/celix_promise.yml
+++ b/.github/workflows/celix_promise.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04]
+        os: [ubuntu-20.04]
         compiler: [gcc]
     timeout-minutes: 15
     steps:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   coverage:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout source code
         uses: actions/checkout@v2

--- a/.github/workflows/coverity-scan.yml
+++ b/.github/workflows/coverity-scan.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   latest:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: Checkout source code
         uses: actions/checkout@v2

--- a/.github/workflows/ubuntu-nightly.yml
+++ b/.github/workflows/ubuntu-nightly.yml
@@ -13,17 +13,17 @@ jobs:
         #os: [ubuntu-18.04, ubuntu-16.04]
         #compiler: [gcc, clang]
         include:
-          - os: ubuntu-18.04
+          - os: ubuntu-20.04
             name: clang
             sanitizer: false #note sanitizer on clang with cpputest does not work
             compiler: clang
             cxx_compiler: clang++
-          - os: ubuntu-18.04
+          - os: ubuntu-20.04
             name: gcc
             sanitizer: true
             compiler: gcc
             cxx_compiler: g++
-          - os: ubuntu-18.04
+          - os: ubuntu-20.04
             name: only v3 api
             sanitizer: true
             compiler: gcc

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -11,17 +11,17 @@ jobs:
         #os: [ubuntu-18.04, ubuntu-16.04]
         #compiler: [gcc, clang]
         include:
-          - os: ubuntu-18.04
+          - os: ubuntu-20.04
             name: clang
             sanitizer: false #note sanitizer on clang with cpputest does not work
             compiler: clang
             cxx_compiler: clang++
-          - os: ubuntu-18.04
+          - os: ubuntu-20.04
             name: gcc
             sanitizer: true
             compiler: gcc
             cxx_compiler: g++
-          - os: ubuntu-18.04
+          - os: ubuntu-20.04
             name: only v3 api
             sanitizer: true
             compiler: gcc

--- a/libs/promises/CMakeLists.txt
+++ b/libs/promises/CMakeLists.txt
@@ -46,10 +46,10 @@ if (PROMISES OR PROMISES_STANDALONE)
         $<INSTALL_INTERFACE:include/celix/promises>
     )
     target_link_libraries(Promises INTERFACE Threads::Threads)
-    target_compile_options(Promises INTERFACE -std=c++17)
     add_library(Celix::Promises ALIAS Promises)
 
     add_executable(PromiseExamples src/PromiseExamples.cc)
+    target_compile_options(PromiseExamples PRIVATE -std=c++17)
     target_link_libraries(PromiseExamples PRIVATE Celix::Promises)
 
     if (ENABLE_TESTING AND NOT PROMISE_STANDALONE)

--- a/libs/promises/gtest/CMakeLists.txt
+++ b/libs/promises/gtest/CMakeLists.txt
@@ -20,6 +20,7 @@ add_executable(test_celix_promises
         src/PromisesTestSuite.cc
         src/VoidPromisesTestSuite.cc
 )
+target_compile_options(test_celix_promises PRIVATE -std=c++17)
 target_link_libraries(test_celix_promises PRIVATE GTest::gtest GTest::gtest_main Celix::Promises)
 
 add_test(NAME test_celix_promises COMMAND test_celix_promises)


### PR DESCRIPTION
The Celix::promises library was setting the std=c++17 compile option on its library target with INTERFACE. This can give uses when linking (but not always using) against Celix::promises.

Also cherry-picked the github ci upgrade to ubuntu 20.04 to ensure the builds can run.