### PR TITLE
Feature/add find dep to cmake config

### DIFF
--- a/bundles/deployment_admin/CMakeLists.txt
+++ b/bundles/deployment_admin/CMakeLists.txt
@@ -17,7 +17,8 @@
 
 celix_subproject(DEPLOYMENT_ADMIN "Option to enable building the Deployment Admin Service bundles" ON DEPS framework launcher shell_tui log_writer)
 if (DEPLOYMENT_ADMIN)
-	
+    message(WARNING "Celix::deployment_admin is considered unstable, because develop of this bundle has been dormant for a while")
+
     find_package(CURL REQUIRED)
     find_package(UUID REQUIRED)
     find_package(ZLIB REQUIRED)
@@ -34,15 +35,15 @@ if (DEPLOYMENT_ADMIN)
         NAME "Apache Celix Deployment Admin"
         GROUP "Celix/DeploymentAdmin"
         SOURCES
-            src/deployment_package
-            src/deployment_admin
-            src/deployment_admin_activator
-            src/ioapi
-            src/miniunz
-            src/unzip
-            src/log
-            src/log_store
-            src/log_sync
+            src/deployment_package.c
+            src/deployment_admin.c
+            src/deployment_admin_activator.c
+            src/ioapi.c
+            src/miniunz.c
+            src/unzip.c
+            src/log.c
+            src/log_store.c
+            src/log_sync.c
     )
 
     target_compile_definitions(deployment_admin PRIVATE -DUSE_FILE32API)

--- a/bundles/device_access/CMakeLists.txt
+++ b/bundles/device_access/CMakeLists.txt
@@ -17,9 +17,9 @@
 
 celix_subproject(DEVICE_ACCESS "Option to enable building the Device Access Service bundles" ON DEPS LAUNCHER LOG_SERVICE SHELL shell_tui)
 if(DEVICE_ACCESS)
+    message(WARNING "DEVICE_ACCESS is considered unstable, because develop of these bundles has been dormant for a while")
 
     add_subdirectory(device_access)
     add_subdirectory(driver_locator)   
     add_subdirectory(example)
-
 endif(DEVICE_ACCESS)

--- a/bundles/device_access/device_access/CMakeLists.txt
+++ b/bundles/device_access/device_access/CMakeLists.txt
@@ -28,11 +28,11 @@ add_celix_bundle(device_manager
 	NAME "Apache Celix Device Access Device Manager"
 	GROUP "Celix/DeviceAccess"
 	SOURCES
-		src/activator
-		src/driver_attributes
-		src/device_manager
-		src/driver_loader
-		src/driver_matcher
+		src/activator.c
+		src/driver_attributes.c
+		src/device_manager.c
+		src/driver_loader.c
+		src/driver_matcher.c
 )
 target_link_libraries(device_manager PRIVATE Celix::log_helper)
 

--- a/bundles/device_access/driver_locator/CMakeLists.txt
+++ b/bundles/device_access/driver_locator/CMakeLists.txt
@@ -21,8 +21,8 @@ add_celix_bundle(driver_locator
 	NAME "Apache Celix Device Access Driver Locator"
 	GROUP "Celix/DeviceAccess"
 	SOURCES
-		src/activator
-		src/driver_locator
+		src/activator.c
+		src/driver_locator.c
 )
 
 target_include_directories(driver_locator PRIVATE src)

--- a/bundles/device_access/example/base_driver/CMakeLists.txt
+++ b/bundles/device_access/example/base_driver/CMakeLists.txt
@@ -20,8 +20,8 @@ add_celix_bundle(base_driver
  	VERSION "0.0.1"
  	NAME "Apache Celix Device Access Base Driver Example"
 	SOURCES
-		src/activator
-		src/base_driver
+		src/activator.c
+		src/base_driver.c
 )
 target_include_directories(base_driver PRIVATE src)
 target_include_directories(base_driver PUBLIC include)

--- a/bundles/device_access/example/consuming_driver/CMakeLists.txt
+++ b/bundles/device_access/example/consuming_driver/CMakeLists.txt
@@ -20,8 +20,8 @@ add_celix_bundle(word_consumingdriver
  	VERSION "0.0.1"
  	NAME "Apache Celix Device Access Word Consuming Driver Example"
 	SOURCES
-		src/activator
-		src/consuming_driver
+		src/activator.c
+		src/consuming_driver.c
 )
 
 target_include_directories(word_consumingdriver PRIVATE src)

--- a/bundles/device_access/example/refining_driver/CMakeLists.txt
+++ b/bundles/device_access/example/refining_driver/CMakeLists.txt
@@ -20,8 +20,8 @@ add_celix_bundle(char_refiningdriver
  	NAME "Apache Celix Device Access Char Refining Driver Example"
  	VERSION "0.0.1"
 	SOURCES
-		src/activator
-		src/refining_driver
+		src/activator.c
+		src/refining_driver.c
 )
 
 target_include_directories(char_refiningdriver PRIVATE src)

--- a/bundles/http_admin/http_admin/CMakeLists.txt
+++ b/bundles/http_admin/http_admin/CMakeLists.txt
@@ -17,10 +17,10 @@
 
 add_celix_bundle(http_admin
     SOURCES
-        src/http_admin
-        src/websocket_admin
-        src/activator
-        src/service_tree
+        src/http_admin.c
+        src/websocket_admin.c
+        src/activator.c
+        src/service_tree.c
     VERSION 0.0.1
     SYMBOLIC_NAME "apache_celix_http_admin"
     GROUP "Celix/HTTP_admin"

--- a/bundles/logging/log_service_v2/CMakeLists.txt
+++ b/bundles/logging/log_service_v2/CMakeLists.txt
@@ -23,12 +23,12 @@ add_celix_bundle(log_service
 	VERSION "1.1.0"
 	SOURCES
 		#v2 api
-		src/log
-		src/log_entry
-		src/log_factory
-		src/log_service_impl
-		src/log_service_activator
-		src/log_reader_service_impl
+		src/log.c
+		src/log_entry.c
+		src/log_factory.c
+		src/log_service_impl.c
+		src/log_service_activator.c
+		src/log_reader_service_impl.c
 )
 target_include_directories(log_service PRIVATE src)
 target_link_libraries(log_service PRIVATE Celix::log_service_api)

--- a/bundles/remote_services/examples/calculator_service/CMakeLists.txt
+++ b/bundles/remote_services/examples/calculator_service/CMakeLists.txt
@@ -17,8 +17,8 @@
 
 add_celix_bundle(calculator
     SOURCES
-        src/calculator_impl
-        src/calculator_activator
+        src/calculator_impl.c
+        src/calculator_activator.c
     SYMBOLIC_NAME "apache_celix_remoting_calculator_impl"
     VERSION 0.0.1
 )

--- a/bundles/remote_services/examples/calculator_shell/CMakeLists.txt
+++ b/bundles/remote_services/examples/calculator_shell/CMakeLists.txt
@@ -17,10 +17,10 @@
 
 add_celix_bundle(calculator_shell
     SOURCES
-        src/add_command
-        src/sub_command
-        src/sqrt_command
-        src/calculator_shell_activator
+        src/add_command.c
+        src/sub_command.c
+        src/sqrt_command.c
+        src/calculator_shell_activator.c
     VERSION 0.0.1
     SYMBOLIC_NAME "apache_celix_remoting_calculator_shell"
 )

--- a/bundles/remote_services/topology_manager/CMakeLists.txt
+++ b/bundles/remote_services/topology_manager/CMakeLists.txt
@@ -17,9 +17,9 @@
 
 add_celix_bundle(rsa_topology_manager
     SOURCES
-        src/topology_manager
-        src/scope
-        src/activator
+        src/topology_manager.c
+        src/scope.c
+        src/activator.c
     VERSION 0.9.0
     SYMBOLIC_NAME "apache_celix_rs_topology_manager"
     GROUP "Celix/RSA"

--- a/bundles/shell/remote_shell/CMakeLists.txt
+++ b/bundles/shell/remote_shell/CMakeLists.txt
@@ -24,10 +24,10 @@ if (REMOTE_SHELL)
 		FILENAME celix_remote_shell
 		GROUP "Celix/Shell"
 		SOURCES
-			src/activator
-			src/connection_listener
-			src/shell_mediator
-			src/remote_shell
+			src/activator.c
+			src/connection_listener.c
+			src/shell_mediator.c
+			src/remote_shell.c
 	)
 
 	target_include_directories(remote_shell PRIVATE src)

--- a/bundles/shell/shell/CMakeLists.txt
+++ b/bundles/shell/shell/CMakeLists.txt
@@ -32,14 +32,14 @@ if (SHELL)
 	endif ()
 
 	add_library(shell_commands STATIC
-			src/lb_command
-			src/start_command
-			src/stop_command
-			src/install_command
-			src/update_command
-			src/uninstall_command
-			src/help_command
-			src/dm_shell_list_command
+			src/lb_command.c
+			src/start_command.c
+			src/stop_command.c
+			src/install_command.c
+			src/update_command.c
+			src/uninstall_command.c
+			src/help_command.c
+			src/dm_shell_list_command.c
 			src/query_command.c
 			src/quit_command.c
 			src/std_commands.c

--- a/bundles/shell/shell_bonjour/CMakeLists.txt
+++ b/bundles/shell/shell_bonjour/CMakeLists.txt
@@ -17,6 +17,7 @@
 
 celix_subproject(SHELL_BONJOUR "Option to enable building the Bonjour Shell (shell access by chat clients)" OFF DEPS LAUNCHER shell)
 if (SHELL_BONJOUR)
+	message(WARNING "Celix::bonjour_shell is considered unstable, because develop of this bundle has been dormant for a while")
 	find_package(LibXml2 REQUIRED)
 	
 	#TODO create/add FindDNS_SD.cmake and use it (with required)

--- a/bundles/shell/shell_tui/CMakeLists.txt
+++ b/bundles/shell/shell_tui/CMakeLists.txt
@@ -24,9 +24,9 @@ if (SHELL_TUI)
 		FILENAME celix_shell_tui
 		GROUP "Celix/Shell"
     	SOURCES 
-    		private/src/activator 
-    		private/src/shell_tui
-    		private/src/history
+    		private/src/activator.c
+    		private/src/shell_tui.c
+    		private/src/history.c
 	)
 	
 	target_include_directories(shell_tui PRIVATE

--- a/cmake/CelixConfig.cmake
+++ b/cmake/CelixConfig.cmake
@@ -50,7 +50,6 @@ set(CELIX_INCLUDE_DIRS
 set(CELIX_FRAMEWORK_LIBRARY Celix::framework)
 set(CELIX_UTILS_LIBRARY Celix::utils)
 set(CELIX_DFI_LIBRARY Celix::dfi)
-
 set(CELIX_LAUNCHER Celix::launcher)
 
 if (TARGET Celix::etcdlib)
@@ -73,9 +72,25 @@ set(CELIX_SHELL_BUNDLE ${CELIX_BUNDLES_DIR}/shell.zip)
 set(CELIX_SHELL_TUI_BUNDLE ${CELIX_BUNDLES_DIR}/shell_tui.zip)
 
 include(CMakeFindDependencyMacro)
-find_dependency(ZLIB)
-find_dependency(UUID)
-find_dependency(OpenSSL)
-find_dependency(CURL)
-find_dependency(FFI)
-find_dependency(Jansson)
+
+find_dependency(ZLIB REQUIRED) #Needed by framework
+find_dependency(UUID REQUIRED) #Needed by framework
+find_dependency(CURL REQUIRED) #Needed by framework (used for curl initialization)
+find_dependency(Jansson REQUIRED) #Needed by dfi, etcdlib, remote services, pubsub
+
+if (TARGET Celix::dfi)
+  find_dependency(FFI REQUIRED)
+endif()
+if (TARGET Celix::RsaConfiguredDiscovery)
+  find_dependency(RapidJSON REQUIRED)
+endif ()
+if (TARGET Celix::rsa_discovery_common)
+  find_dependency(LibXml2 REQUIRED)
+endif ()
+if (TARGET Celix::celix_pubsub_admin_zmq OR TARGET Celix::celix_pubsub_admin_zmq_v2)
+  find_dependency(ZMQ REQUIRED)
+  find_dependency(CZMQ REQUIRED)
+endif ()
+if (TARGET Celix::pubsub_admin_nanomsg)
+  find_dependency(NanoMsg REQUIRED)
+endif ()

--- a/examples/celix-examples/dm_example/phase1/CMakeLists.txt
+++ b/examples/celix-examples/dm_example/phase1/CMakeLists.txt
@@ -20,7 +20,7 @@ add_celix_bundle(dm_example_phase1
     SYMBOLIC_NAME phase1
     VERSION 0.0.1
     SOURCES
-        src/phase1_activator
+        src/phase1_activator.c
         src/phase1_cmp.c
 )
 target_include_directories(dm_example_phase1 PRIVATE src)

--- a/examples/celix-examples/dm_example/phase2a/CMakeLists.txt
+++ b/examples/celix-examples/dm_example/phase2a/CMakeLists.txt
@@ -19,8 +19,8 @@ add_celix_bundle(dm_example_phase2a
         SYMBOLIC_NAME phase2a
         VERSION 0.0.1
         SOURCES
-            src/phase2a_activator
-            src/phase2a_cmp
+            src/phase2a_activator.c
+            src/phase2a_cmp.c
 )
 target_include_directories(dm_example_phase2a PRIVATE src)
 target_link_libraries(dm_example_phase2a PRIVATE dm_example_api)

--- a/examples/celix-examples/dm_example/phase2b/CMakeLists.txt
+++ b/examples/celix-examples/dm_example/phase2b/CMakeLists.txt
@@ -19,8 +19,8 @@ add_celix_bundle(dm_example_phase2b
         SYMBOLIC_NAME phase2b
         VERSION 0.0.1
         SOURCES
-            src/phase2b_activator
-            src/phase2b_cmp
+            src/phase2b_activator.c
+            src/phase2b_cmp.c
 )
 target_include_directories(dm_example_phase2b PRIVATE src)
 target_link_libraries(dm_example_phase2b PRIVATE dm_example_api)

--- a/examples/celix-examples/dm_example/phase3/CMakeLists.txt
+++ b/examples/celix-examples/dm_example/phase3/CMakeLists.txt
@@ -19,8 +19,8 @@ add_celix_bundle(dm_example_phase3
         SYMBOLIC_NAME phase3
         VERSION 0.0.1
         SOURCES
-            src/phase3_activator
-            src/phase3_cmp
+            src/phase3_activator.c
+            src/phase3_cmp.c
 )
 target_include_directories(dm_example_phase3 PRIVATE src)
 target_link_libraries(dm_example_phase3 PRIVATE dm_example_api)

--- a/examples/celix-examples/embedding/CMakeLists.txt
+++ b/examples/celix-examples/embedding/CMakeLists.txt
@@ -16,5 +16,5 @@
 # under the License.
 
 
-add_executable(embedding src/main)
+add_executable(embedding src/main.c)
 target_link_libraries(embedding Celix::framework )


### PR DESCRIPTION
Updates CelixConfig to include `find_dependency` if certain targets (bundles) are present.

Update sources files used in cmake config to always specific an extension as Is required by the cmake policy 
CMP0115