### PR TITLE
remove unwanted slicing of exception type

### DIFF
--- a/libs/promises/api/celix/Deferred.h
+++ b/libs/promises/api/celix/Deferred.h
@@ -77,7 +77,8 @@ namespace celix {
          * @param failure The failure in the form of an const std::exception reference.
          * @throws PromiseInvocationException If the associated Promise was already resolved.
          */
-        void fail(const std::exception& failure);
+        template<typename E, typename std::enable_if_t< std::is_base_of<std::exception, E>::value, bool> = true >
+        void fail(const E& failure);
 
         /**
          * Returns the Promise associated with this Deferred.
@@ -221,8 +222,9 @@ inline void celix::Deferred<void>::fail(std::exception_ptr failure) {
 }
 
 template<typename T>
-void celix::Deferred<T>::fail(const std::exception& failure) {
-    state->fail(failure);
+template<typename E, typename std::enable_if_t< std::is_base_of<std::exception, E>::value, bool>>
+void celix::Deferred<T>::fail(const E& failure) {
+    state->template fail<E>(failure);
 }
 
 inline void celix::Deferred<void>::fail(const std::exception& failure) {

--- a/libs/promises/api/celix/impl/SharedPromiseState.h
+++ b/libs/promises/api/celix/impl/SharedPromiseState.h
@@ -55,7 +55,8 @@ namespace celix::impl {
 
         void fail(std::exception_ptr e);
 
-        void fail(const std::exception &e);
+        template<typename E>
+        void fail(const E &e);
 
         void tryResolve(T &&value);
 
@@ -152,7 +153,8 @@ namespace celix::impl {
 
         void fail(std::exception_ptr e);
 
-        void fail(const std::exception &e);
+        template<typename E>
+        void fail(const E &e);
 
         void tryResolve();
 
@@ -317,12 +319,14 @@ inline void celix::impl::SharedPromiseState<void>::fail(std::exception_ptr e) {
 }
 
 template<typename T>
-void celix::impl::SharedPromiseState<T>::fail(const std::exception& e) {
+template<typename E>
+void celix::impl::SharedPromiseState<T>::fail(const E& e) {
     fail(std::make_exception_ptr(e));
 }
 
-inline void celix::impl::SharedPromiseState<void>::fail(const std::exception& e) {
-    fail(std::make_exception_ptr(e));
+template<typename E>
+inline void celix::impl::SharedPromiseState<void>::fail(const E& e) {
+    fail(std::make_exception_ptr<E>(e));
 }
 
 template<typename T>

--- a/libs/promises/gtest/src/PromisesTestSuite.cc
+++ b/libs/promises/gtest/src/PromisesTestSuite.cc
@@ -183,7 +183,7 @@ TEST_F(PromiseTestSuite, onFailureHandling) {
             })
             .onFailure([&](const std::exception &e) {
                 failureCalled = true;
-                std::cout << "got error: " << e.what() << std::endl;
+                ASSERT_TRUE(0 == strcmp("basic_string::at: __n (which is 1) >= this->size() (which is 0)",  e.what())) << std::string(e.what());
             })
             .onResolve([&]() {
                 resolveCalled = true;
@@ -194,6 +194,31 @@ TEST_F(PromiseTestSuite, onFailureHandling) {
     } catch (...) {
         deferred.fail(std::current_exception());
     }
+
+    factory->wait();
+    EXPECT_EQ(false, successCalled);
+    EXPECT_EQ(true, failureCalled);
+    EXPECT_EQ(true, resolveCalled);
+}
+
+TEST_F(PromiseTestSuite, onFailureHandlingLogicError) {
+    auto deferred =  factory->deferred<long>();
+    std::atomic<bool> successCalled = false;
+    std::atomic<bool> failureCalled = false;
+    std::atomic<bool> resolveCalled = false;
+    auto p = deferred.getPromise()
+            .onSuccess([&](long /*value*/) {
+                successCalled = true;
+            })
+            .onFailure([&](const std::exception &e) {
+                failureCalled = true;
+                ASSERT_TRUE(0 == strcmp("Some Exception",  e.what())) << std::string(e.what());
+            })
+            .onResolve([&]() {
+                resolveCalled = true;
+            });
+
+    deferred.fail(std::logic_error("Some Exception"));
 
     factory->wait();
     EXPECT_EQ(false, successCalled);


### PR DESCRIPTION
Call to fail(const std::exception& e) with object derived from exception was sliced in the internal state processing. 