### PR TITLE
Updates exception test to ensure a predictable exception.what()

### DIFF
--- a/libs/promises/api/celix/impl/SharedPromiseState.h
+++ b/libs/promises/api/celix/impl/SharedPromiseState.h
@@ -944,7 +944,7 @@ void celix::impl::SharedPromiseState<T>::addOnFailureConsumeCallback(std::functi
             } catch (const std::exception &e) {
                 callback(e);
             } catch (...) {
-                //NOTE not a exception based on std::exception, "repacking" it to logical error
+                //NOTE not an exception based on std::exception, "repacking" it to logical error
                 std::logic_error logicError{"Unknown exception throw for the failure of A celix::Promise"};
                 callback(logicError);
             }
@@ -961,7 +961,7 @@ inline void celix::impl::SharedPromiseState<void>::addOnFailureConsumeCallback(s
             } catch (const std::exception &e) {
                 callback(e);
             } catch (...) {
-                //NOTE not a exception based on std::exception, "repacking" it to logical error
+                //NOTE not an exception based on std::exception, "repacking" it to logical error
                 std::logic_error logicError{"Unknown exception throw for the failure of A celix::Promise"};
                 callback(logicError);
             }

--- a/libs/promises/gtest/src/PromisesTestSuite.cc
+++ b/libs/promises/gtest/src/PromisesTestSuite.cc
@@ -172,6 +172,10 @@ TEST_F(PromiseTestSuite, onSuccessHandling) {
     EXPECT_EQ(true, resolveCalled);
 }
 
+static void test_throwing_function() {
+    throw celix::PromiseInvocationException{"PromiseInvocationException test"};
+}
+
 TEST_F(PromiseTestSuite, onFailureHandling) {
     auto deferred =  factory->deferred<long>();
     std::atomic<bool> successCalled = false;
@@ -183,14 +187,14 @@ TEST_F(PromiseTestSuite, onFailureHandling) {
             })
             .onFailure([&](const std::exception &e) {
                 failureCalled = true;
-                ASSERT_TRUE(0 == strcmp("basic_string::at: __n (which is 1) >= this->size() (which is 0)",  e.what())) << std::string(e.what());
+                auto what = e.what();
+                ASSERT_STREQ(what, "PromiseInvocationException test");
             })
             .onResolve([&]() {
                 resolveCalled = true;
             });
     try {
-        std::string{}.at(1); // this generates an std::out_of_range
-        //or use std::make_exception_ptr
+        test_throwing_function(); // this generates a celix::PromiseInvocationException
     } catch (...) {
         deferred.fail(std::current_exception());
     }


### PR DESCRIPTION
Fixes an issue that a promise failure test was not working on macOS, because the underlining used exception gave a different result. 