### PR TITLE
Updates Promise `resolve` and `fail` functions to make them robust.

### DIFF
--- a/libs/promises/README.md
+++ b/libs/promises/README.md
@@ -79,12 +79,9 @@ target_link_libraries(PromiseExamples PRIVATE Celix::Promises)
 4. The PromiseFactory also has a deferredTask method. This is a convenient method create a Deferred, execute a task async to resolve the Deferred and return a Promise of the created Deferred in one call.
 5. The celix::IExecutor abstraction has a priority argument (and as result also the calls in PromiseFactory, etc).
 6. The IExecutor has a added wait() method. This can be used to ensure an executor is done executing the tasks backlog.
-7. The `celix::Deferred<T>::fail` and `celix::Deferred<T>::resolve` are make robust for resolving a 
-   deferred if the associated promise is already resolved. This is different from the OSGi spec, 
-   because it always a race condition to check if a promise is already resolved (`isDone()`) 
-   and then resolve the deferred. The methods `celix::Deferred<T>::tryFail` and
-  `celix::Deferred<T>::tryResolve` exist to resolve a deferred and check if it was 
-   already resolved atomically.  
+7. The methods celix::Deferred<T>::fail and celix::Deferred<T>::resolve are robust for resolving a promise if it is already resolved. 
+  This is different from the OSGi spec and this is done because it always a race condition to check if a promise is already resolved (isDone()) and then resolve the promise. 
+  The methods `celix::Deferred<T>::tryFail` and `celix::Deferred<T>::tryResolve` can be used to resolve a promise and check if it was already resolved atomically.
 
 ## Open Issues & TODOs
 

--- a/libs/promises/README.md
+++ b/libs/promises/README.md
@@ -78,11 +78,16 @@ target_link_libraries(PromiseExamples PRIVATE Celix::Promises)
 3. The default constructor for celix::Deferred has been removed. A celix:Deferred can only be created through a PromiseFactory. This is done because the promise concept is heavily bound with the execution abstraction and thus a execution model. Creating a Deferred without a explicit executor is not desirable.
 4. The PromiseFactory also has a deferredTask method. This is a convenient method create a Deferred, execute a task async to resolve the Deferred and return a Promise of the created Deferred in one call.
 5. The celix::IExecutor abstraction has a priority argument (and as result also the calls in PromiseFactory, etc).
-6. The IExecutor has a added wait() method. This can be used to ensure a executor is done executing the tasks backlog.
-
-    
+6. The IExecutor has a added wait() method. This can be used to ensure an executor is done executing the tasks backlog.
+7. The `celix::Deferred<T>::fail` and `celix::Deferred<T>::resolve` are make robust for resolving a 
+   deferred if the associated promise is already resolved. This is different from the OSGi spec, 
+   because it always a race condition to check if a promise is already resolved (`isDone()`) 
+   and then resolve the deferred. The methods `celix::Deferred<T>::tryFail` and
+  `celix::Deferred<T>::tryResolve` exist to resolve a deferred and check if it was 
+   already resolved atomically.  
 
 ## Open Issues & TODOs
+
 - Documentation not complete
 - PromiseFactory is not complete yet
 - The static helper class Promises is not implemented yet (e.g. all/any)

--- a/libs/promises/api/celix/Deferred.h
+++ b/libs/promises/api/celix/Deferred.h
@@ -53,7 +53,8 @@ namespace celix {
         explicit Deferred(std::shared_ptr<celix::impl::SharedPromiseState<T>> state);
 
         /**
-         * Fail the Promise associated with this Deferred.
+         * @brief Fail the Promise associated with this Deferred.
+         *
          * <p/>
          * After the associated Promise is resolved with the specified failure, all registered callbacks are called and any
          * chained Promises are resolved.
@@ -61,13 +62,23 @@ namespace celix {
          * Resolving the associated Promise happens-before any registered callback is called. That is, in a registered
          * callback, Promise.isDone() must return true and Promise.getValue() and Promise.getFailure() must not block.
          *
+         * If the associated promise is already resolved, the call will be ignored.
+         *
          * @param failure The failure in the form of an exception pointer.
-         * @throws PromiseInvocationException If the associated Promise was already resolved.
          */
         void fail(std::exception_ptr failure);
 
         /**
-         * Fail the Promise associated with this Deferred.
+         * @brief Try to fail the Promise associated with this Deferred.
+         *
+         * Same as `fail`, but will return `true` if the associated promise was successfully failed and `false` if
+         * the associated promise was already resolved.
+         */
+        bool tryFail(std::exception_ptr failure);
+
+        /**
+         * @brief Fail the Promise associated with this Deferred.
+         *
          * <p/>
          * After the associated Promise is resolved with the specified failure, all registered callbacks are called and any
          * chained Promises are resolved.
@@ -75,24 +86,38 @@ namespace celix {
          * Resolving the associated Promise happens-before any registered callback is called. That is, in a registered
          * callback, Promise.isDone() must return true and Promise.getValue() and Promise.getFailure() must not block.
          *
+         * If the associated promise is already resolved, the call will be ignored.
+         *
          * @param failure The failure in the form of an const std::exception reference.
-         * @throws PromiseInvocationException If the associated Promise was already resolved.
          */
-        template<typename E, typename std::enable_if_t< std::is_base_of<std::exception, E>::value, bool> = true >
+        template<typename E, typename std::enable_if_t< std::is_base_of_v<std::exception, E>, bool> = true >
         void fail(const E& failure);
 
+
         /**
-         * Returns the Promise associated with this Deferred.
+         * @brief Try to fail the Promise associated with this Deferred.
+         *
+         * Same as `fail`, but will return `true` if the associated promise was successfully failed and `false` if
+         * the associated promise was already resolved.
+         */
+        template<typename E, typename std::enable_if_t< std::is_base_of_v<std::exception, E>, bool> = true >
+        bool tryFail(const E& failure);
+
+        /**
+         * @brief Returns the Promise associated with this Deferred.
+         *
          * <p>
          * All Promise objects created by the associated Promise will use the
          * executors of the associated Promise.
+         * </p>
          *
          * @return The Promise associated with this Deferred.
          */
         [[nodiscard]] Promise<T> getPromise();
 
         /**
-         * Successfully resolve the Promise associated with this Deferred.
+         * @brief Resolve the Promise associated with this Deferred.
+         *
          * <p/>
          * After the associated Promise is resolved with the specified value, all registered callbacks are called and any
          * chained Promises are resolved.
@@ -100,14 +125,47 @@ namespace celix {
          * Resolving the associated Promise happens-before any registered callback is called. That is, in a registered
          * callback, Promise.isDone() must return true and Promise.getValue() and Promise.getFailure() must not block.
          *
+         * If the associated promise is already resolved, the call will be ignored.
+         *
          * @param value The value of the resolved Promise.
-         * @throws PromiseInvocationException If the associated Promise was already resolved.
          */
         void resolve(T&& value);
+
+        /**
+         * @brief Resolve the Promise associated with this Deferred.
+         *
+         * <p/>
+         * After the associated Promise is resolved with the specified value, all registered callbacks are called and any
+         * chained Promises are resolved.
+         * <p/>
+         * Resolving the associated Promise happens-before any registered callback is called. That is, in a registered
+         * callback, Promise.isDone() must return true and Promise.getValue() and Promise.getFailure() must not block.
+         *
+         * If the associated promise is already resolved, the call will be ignored.
+         *
+         * @param value The value of the resolved Promise.
+         */
         void resolve(const T& value);
 
         /**
-         * Resolve the Promise associated with this Deferred with the specified Promise.
+         * @brief Try to resolve the Promise associated with this Deferred.
+         *
+         * Same as `resolve`, but will return `true` if the associated promise was successfully resolved and `false` if
+         * the associated promise was already resolved.
+         */
+        bool tryResolve(T&& value);
+
+        /**
+         * @brief Try to resolve the Promise associated with this Deferred.
+         *
+         * Same as `resolve`, but will return `true` if the associated promise was successfully resolved and `false` if
+         * the associated promise was already resolved.
+         */
+        bool tryResolve(const T& value);
+
+        /**
+         * @brief Resolve the Promise associated with this Deferred with the specified Promise.
+         *
          * <p/>
          * If the specified Promise is successfully resolved, the associated Promise is resolved with the value of the
          * specified Promise. If the specified Promise is resolved with a failure, the associated Promise is resolved with
@@ -140,10 +198,9 @@ namespace celix {
 
         explicit Deferred(std::shared_ptr<celix::impl::SharedPromiseState<void>> state);
 
-        //TODO deferred ctor with factory
-
         /**
-         * Fail the Promise associated with this Deferred.
+         * @brief Fail the Promise associated with this Deferred.
+         *
          * <p/>
          * After the associated Promise is resolved with the specified failure, all registered callbacks are called and any
          * chained Promises are resolved.
@@ -151,13 +208,23 @@ namespace celix {
          * Resolving the associated Promise happens-before any registered callback is called. That is, in a registered
          * callback, Promise.isDone() must return true and Promise.getValue() and Promise.getFailure() must not block.
          *
+         * If the associated promise is already resolved, the call will be ignored.
+         *
          * @param failure The failure in the form of an exception pointer.
-         * @throws PromiseInvocationException If the associated Promise was already resolved.
          */
         void fail(std::exception_ptr failure);
 
         /**
-         * Fail the Promise associated with this Deferred.
+         * @brief Try to fail the Promise associated with this Deferred.
+         *
+         * Same as `fail`, but will return `true` if the associated promise was successfully failed and `false` if
+         * the associated promise was already resolved.
+         */
+        bool tryFail(std::exception_ptr failure);
+
+        /**
+         * @brief Fail the Promise associated with this Deferred.
+         *
          * <p/>
          * After the associated Promise is resolved with the specified failure, all registered callbacks are called and any
          * chained Promises are resolved.
@@ -165,24 +232,37 @@ namespace celix {
          * Resolving the associated Promise happens-before any registered callback is called. That is, in a registered
          * callback, Promise.isDone() must return true and Promise.getValue() and Promise.getFailure() must not block.
          *
+         * If the associated promise is already resolved, the call will be ignored.
+         *
          * @param failure The failure in the form of an const std::exception reference.
-         * @throws PromiseInvocationException If the associated Promise was already resolved.
          */
-        template<typename E, typename std::enable_if_t< std::is_base_of<std::exception, E>::value, bool> = true >
+        template<typename E, typename std::enable_if_t< std::is_base_of_v<std::exception, E>, bool> = true >
         void fail(const E& failure);
 
         /**
-         * Returns the Promise associated with this Deferred.
+         * @brief Try to fail the Promise associated with this Deferred.
+         *
+         * Same as `fail`, but will return `true` if the associated promise was successfully failed and `false` if
+         * the associated promise was already resolved.
+         */
+        template<typename E, typename std::enable_if_t< std::is_base_of_v<std::exception, E>, bool> = true >
+        bool tryFail(const E& failure);
+
+        /**
+         * @brief Returns the Promise associated with this Deferred.
+         *
          * <p>
          * All Promise objects created by the associated Promise will use the
          * executors of the associated Promise.
+         * </p>
          *
          * @return The Promise associated with this Deferred.
          */
         [[nodiscard]] Promise<void> getPromise();
 
         /**
-         * Successfully resolve the Promise associated with this Deferred.
+         * @brief Resolve the Promise associated with this Deferred.
+         *
          * <p/>
          * After the associated Promise is resolved with the specified value, all registered callbacks are called and any
          * chained Promises are resolved.
@@ -190,10 +270,19 @@ namespace celix {
          * Resolving the associated Promise happens-before any registered callback is called. That is, in a registered
          * callback, Promise.isDone() must return true and Promise.getValue() and Promise.getFailure() must not block.
          *
+         * If the associated promise is already resolved, the call will be ignored.
+         *
          * @param value The value of the resolved Promise.
-         * @throws PromiseInvocationException If the associated Promise was already resolved.
          */
         void resolve();
+
+        /**
+         * @brief Try to resolve the Promise associated with this Deferred.
+         *
+         * Same as `resolve`, but will return `true` if the associated promise was successfully resolved and `false` if
+         * the associated promise was already resolved.
+         */
+        bool tryResolve();
 
         template<typename U>
         celix::Promise<void> resolveWith(celix::Promise<U> with);
@@ -215,22 +304,42 @@ inline celix::Deferred<void>::Deferred(std::shared_ptr<celix::impl::SharedPromis
 
 template<typename T>
 void celix::Deferred<T>::fail(std::exception_ptr failure) {
-    state->fail(std::move(failure));
-}
-
-inline void celix::Deferred<void>::fail(std::exception_ptr failure) {
-    state->fail(std::move(failure));
+    state->tryFail(std::move(failure));
 }
 
 template<typename T>
-template<typename E, typename std::enable_if_t< std::is_base_of<std::exception, E>::value, bool>>
-void celix::Deferred<T>::fail(const E& failure) {
-    state->template fail<E>(failure);
+bool celix::Deferred<T>::tryFail(std::exception_ptr failure) {
+    return state->tryFail(std::move(failure));
 }
 
-template<typename E, typename std::enable_if_t< std::is_base_of<std::exception, E>::value, bool>>
-inline void celix::Deferred<void>::fail(const E& failure) {
-    state->template fail<E>(failure);
+inline void celix::Deferred<void>::fail(std::exception_ptr failure) {
+    state->tryFail(std::move(failure));
+}
+
+inline bool celix::Deferred<void>::tryFail(std::exception_ptr failure) {
+    return state->tryFail(std::move(failure));
+}
+
+template<typename T>
+template<typename E, typename std::enable_if_t< std::is_base_of_v<std::exception, E>, bool>>
+void celix::Deferred<T>::fail(const E& failure) {
+    state->template tryFail<E>(failure);
+}
+
+template<typename T>
+template<typename E, typename std::enable_if_t< std::is_base_of_v<std::exception, E>, bool>>
+bool celix::Deferred<T>::tryFail(const E& failure) {
+    return state->template tryFail<E>(failure);
+}
+
+template<typename E, typename std::enable_if_t< std::is_base_of_v<std::exception, E>, bool>>
+void celix::Deferred<void>::fail(const E& failure) {
+    state->tryFail<E>(failure);
+}
+
+template<typename E, typename std::enable_if_t< std::is_base_of_v<std::exception, E>, bool>>
+bool celix::Deferred<void>::tryFail(const E& failure) {
+    return state->tryFail<E>(failure);
 }
 
 template<typename T>
@@ -286,14 +395,28 @@ inline celix::Promise<void> celix::Deferred<void>::resolveWith(celix::Promise<U>
 
 template<typename T>
 void celix::Deferred<T>::resolve(T&& value) {
-    state->resolve(std::forward<T>(value));
+    state->tryResolve(std::forward<T>(value));
 }
 
 template<typename T>
 void celix::Deferred<T>::resolve(const T& value) {
-    state->resolve(value);
+    state->tryResolve(value);
 }
 
 inline void celix::Deferred<void>::resolve() {
-    state->resolve();
+    state->tryResolve();
+}
+
+template<typename T>
+bool celix::Deferred<T>::tryResolve(T&& value) {
+    return state->tryResolve(std::forward<T>(value));
+}
+
+template<typename T>
+bool celix::Deferred<T>::tryResolve(const T& value) {
+    return state->tryResolve(value);
+}
+
+inline bool celix::Deferred<void>::tryResolve() {
+    return state->tryResolve();
 }

--- a/libs/promises/api/celix/Promise.h
+++ b/libs/promises/api/celix/Promise.h
@@ -745,14 +745,13 @@ inline celix::Promise<U> celix::Promise<T>::then(std::function<celix::Promise<U>
                 auto tmpPromise = success(celix::Promise<T>{s});
                 p->resolveWith(*tmpPromise.state);
             } catch (...) {
-                //failure(); TODO not sure if this needs to be called
-                p->fail(std::current_exception());
+                p->tryFail(std::current_exception());
             }
         } else {
             if (failure) {
                 failure(celix::Promise<T>{s});
             }
-            p->fail(s->getFailure());
+            p->tryFail(s->getFailure());
         }
     };
     state->addChain(std::move(chain));
@@ -770,14 +769,13 @@ inline celix::Promise<U> celix::Promise<void>::then(std::function<celix::Promise
                 auto tmpPromise = success(celix::Promise<void>{s});
                 p->resolveWith(*tmpPromise.state);
             } catch (...) {
-                //failure(); TODO not sure if this needs to be called
-                p->fail(std::current_exception());
+                p->tryFail(std::current_exception());
             }
         } else {
             if (failure) {
                 failure(celix::Promise<void>{s});
             }
-            p->fail(s->getFailure());
+            p->tryFail(s->getFailure());
         }
     };
     state->addChain(std::move(chain));


### PR DESCRIPTION
This PR makes the `celix::Deferred<T>::fail` and `celix::Deferred<T>::resolve` robust for resolving a  promise if it is already resolved. 

This is different from the OSGi spec and this is done  because it always a race condition to check if a promise is already resolved (`isDone()`) and then resolve the promise. 

The methods `celix::Deferred<T>::tryFail` and `celix::Deferred<T>::tryResolve` are added to resolve a promise and check if it was already resolved atomically.  