### PR TITLE
Eliminate unnecessary blocking and mutext from useServiceWithOptions.

### DIFF
--- a/libs/framework/gtest/src/bundle_context_services_test.cpp
+++ b/libs/framework/gtest/src/bundle_context_services_test.cpp
@@ -793,12 +793,14 @@ TEST_F(CelixBundleContextServicesTests, useServiceDoesNotBlockInEventLoop) {
     opts.callbackHandle = (void*)ctx;
     opts.filter.serviceName = "NA";
     opts.set = set;
-    long trackerId = celix_bundleContext_trackServicesWithOptions(ctx, &opts);
+    long trackerId = celix_bundleContext_trackServicesWithOptionsAsync(ctx, &opts);
     ASSERT_TRUE(trackerId >= 0);
 
     void *svc2 = (void*)0x200; //no ranking
-    long svcId2 = celix_bundleContext_registerService(ctx, svc2, "NA", nullptr);
+    long svcId2 = celix_bundleContext_registerServiceAsync(ctx, svc2, "NotAvailable", nullptr);
     ASSERT_GE(svcId2, 0);
+    celix_bundleContext_waitForAsyncTracker(ctx, trackerId);
+    celix_bundleContext_waitForAsyncRegistration(ctx, svcId2);
 
     celix_bundleContext_unregisterService(ctx, svcId2);
     celix_bundleContext_stopTracker(ctx, trackerId);

--- a/libs/framework/include/celix_bundle_context.h
+++ b/libs/framework/include/celix_bundle_context.h
@@ -708,7 +708,7 @@ typedef struct celix_service_use_options {
 
     /**
      * An optional timeout (in seconds), if > 0 the use service call will block until the timeout is expired or
-     * when at least one service is found.
+     * when at least one service is found. Note that it will be ignored when use service on the event loop.
      * Default (0)
      */
      double waitTimeoutInSeconds OPTS_INIT;


### PR DESCRIPTION
Currently calling `celix_bundleContext_useServiceWithOptions` with non-zero timeout 
for a non-existent service in the Celix event loop will prevent the the loop from registering any new service.
Thus 'celix_bundleContext_useServiceWithOptions' blocks in vain. This PR fixed this and removed
the unnecessary mutex from 'celix_bundle_context_use_service_data_t'. By removing the mutex, 
there is no need to destroy the mutex anymore.

Why the mentioned mutex is unnecessary? 
In the language of C/C++11 memory model, `celixThreadMutex_unlock(&fw->dispatcher.mutex)` in `fw_removeTopEventFromQueue` **synchronizes with** `celixThreadMutex_lock(&fw->dispatcher.mutex)` 
in `celix_framework_waitForGenericEvent` and the implicit lock when `celixThreadCondition_timedwaitRelative` returns.
Note also that `fw_handleEventRequest` **happens before** `fw_removeTopEventFromQueue` in the event loop
thread and that `celix_framework_waitForGenericEvent` **happens before** what follows in the calling thread.
By the above three, we can safely conclude that `fw_handleEventRequest` happens before what follows `celix_framework_waitForGenericEvent` in the calling thread. See [C++ Concurrency in Action, Second Edition, Chapter 5](https://learning.oreilly.com/library/view/c-concurrency-in/9781617294693/kindle_split_015.html#ch05lev1sec3).
Please correct me if I'm wrong.