### PR TITLE
Fix memory leak in celix_properties_unset.

### DIFF
--- a/libs/utils/private/test/properties_test.cpp
+++ b/libs/utils/private/test/properties_test.cpp
@@ -165,6 +165,24 @@ TEST(properties, getSet) {
     celix_properties_destroy(properties);
 }
 
+TEST(properties, setUnset) {
+    properties = celix_properties_create();
+    char keyA[] = "x";
+    char *keyD = strndup("a", 1);
+    char valueA[] = "1";
+    char *valueD = strndup("4", 1);
+    celix_properties_set(properties, keyA, valueA);
+    celix_properties_setWithoutCopy(properties, keyD, valueD);
+    STRCMP_EQUAL(valueA, celix_properties_get(properties, keyA, NULL));
+    STRCMP_EQUAL(valueD, celix_properties_get(properties, keyD, NULL));
+
+    celix_properties_unset(properties, keyA);
+    celix_properties_unset(properties, keyD);
+    POINTERS_EQUAL(NULL, celix_properties_get(properties, keyA, NULL));
+    POINTERS_EQUAL(NULL, celix_properties_get(properties, "a", NULL));
+    celix_properties_destroy(properties);
+}
+
 TEST(properties, longTest) {
     properties = celix_properties_create();
 

--- a/libs/utils/src/properties.c
+++ b/libs/utils/src/properties.c
@@ -398,7 +398,7 @@ void celix_properties_setWithoutCopy(celix_properties_t *properties, char *key, 
 }
 
 void celix_properties_unset(celix_properties_t *properties, const char *key) {
-    char* oldValue = hashMap_remove(properties, key);
+    char* oldValue = hashMap_removeFreeKey(properties, key);
     free(oldValue);
 }
 


### PR DESCRIPTION
Key is leaked when invoking `celix_properties_unset`. With `ENABLE_ADDRESS_SANITIZER=ON`, the new test case produced error report. 