### PR TITLE
Fix assertion failure when using C++ ServiceTracker in the event loop.

### DIFF
--- a/libs/framework/gtest/src/CxxBundleContextTestSuite.cc
+++ b/libs/framework/gtest/src/CxxBundleContextTestSuite.cc
@@ -550,6 +550,20 @@ TEST_F(CxxBundleContextTestSuite, UnregisterServiceWhileRegistering) {
     ctx->waitForEvents();
 }
 
+TEST_F(CxxBundleContextTestSuite, GetServiceInEventLoop) {
+    auto context = ctx;
+    ctx->getFramework()->fireGenericEvent(
+            ctx->getBundleId(),
+            "register/unregister in Celix event thread",
+            [context]() {
+                auto tracker = context->trackServices<TestInterface>().build();
+                auto svc = tracker->getHighestRankingService();
+                EXPECT_TRUE(svc.get() == nullptr);
+            }
+    );
+    ctx->waitForEvents();
+}
+
 TEST_F(CxxBundleContextTestSuite, KeepSharedPtrActiveWhileDeregistering) {
     auto svcReg = ctx->registerService<TestInterface>(std::make_shared<TestImplementation>())
             .build();

--- a/libs/framework/include/celix/Trackers.h
+++ b/libs/framework/include/celix/Trackers.h
@@ -159,7 +159,7 @@ namespace celix {
          */
         void waitIfAble() const {
             auto* fw = celix_bundleContext_getFramework(cCtx.get());
-            if (celix_framework_isCurrentThreadTheEventLoop(fw)) {
+            if (!celix_framework_isCurrentThreadTheEventLoop(fw)) {
                 wait();
             }
         }


### PR DESCRIPTION
The code did quite the opposite to what the comment said.