### PR TITLE
Feature/apply use stringview

### DIFF
--- a/libs/framework/include/celix/Bundle.h
+++ b/libs/framework/include/celix/Bundle.h
@@ -41,6 +41,7 @@ namespace celix {
      * Each bundle installed in the Celix framework must have an associated Bundle object.
      * A bundle must have a unique identity, a long, chosen by the Celix framework.
      *
+     * @note Provided `std::string_view` values must be null terminated strings.
      * @note Thread safe.
      */
     class Bundle {
@@ -63,9 +64,9 @@ namespace celix {
          * @param path The relative path to a bundle resource
          * @return The use-able entry path or an empty string if the entry is not found.
          */
-        [[nodiscard]] std::string getEntry(const std::string& path) const {
+        [[nodiscard]] std::string getEntry(std::string_view path) const {
             std::string result{};
-            char* entry = celix_bundle_getEntry(cBnd.get(), path.c_str());
+            char* entry = celix_bundle_getEntry(cBnd.get(), path.data());
             if (entry != nullptr) {
                 result = std::string{entry};
                 free(entry);
@@ -76,29 +77,29 @@ namespace celix {
         /**
          * @brief the symbolic name of the bundle.
          */
-        [[nodiscard]] std::string getSymbolicName() const {
-            return std::string{celix_bundle_getSymbolicName(cBnd.get())};
+        [[nodiscard]] std::string_view getSymbolicName() const {
+            return std::string_view{celix_bundle_getSymbolicName(cBnd.get())};
         }
 
         /**
          * @brief The name of the bundle.
          */
-        [[nodiscard]] std::string getName() const {
-            return std::string{celix_bundle_getName(cBnd.get())};
+        [[nodiscard]] std::string_view getName() const {
+            return std::string_view{celix_bundle_getName(cBnd.get())};
         }
 
         /**
          * @brief The group of the bundle.
          */
-        [[nodiscard]] std::string getGroup() const {
-            return std::string{celix_bundle_getGroup(cBnd.get())};
+        [[nodiscard]] std::string_view getGroup() const {
+            return std::string_view{celix_bundle_getGroup(cBnd.get())};
         }
 
         /**
-         * @brief The descriptoin of the bundle.
+         * @brief The description of the bundle.
          */
-        [[nodiscard]] std::string getDescription() const {
-            return std::string{celix_bundle_getDescription(cBnd.get())};
+        [[nodiscard]] std::string_view getDescription() const {
+            return std::string_view{celix_bundle_getDescription(cBnd.get())};
         }
 
         /**

--- a/libs/framework/include/celix/Bundle.h
+++ b/libs/framework/include/celix/Bundle.h
@@ -77,29 +77,29 @@ namespace celix {
         /**
          * @brief the symbolic name of the bundle.
          */
-        [[nodiscard]] std::string_view getSymbolicName() const {
-            return std::string_view{celix_bundle_getSymbolicName(cBnd.get())};
+        [[nodiscard]] std::string getSymbolicName() const {
+            return std::string{celix_bundle_getSymbolicName(cBnd.get())};
         }
 
         /**
          * @brief The name of the bundle.
          */
-        [[nodiscard]] std::string_view getName() const {
-            return std::string_view{celix_bundle_getName(cBnd.get())};
+        [[nodiscard]] std::string getName() const {
+            return std::string{celix_bundle_getName(cBnd.get())};
         }
 
         /**
          * @brief The group of the bundle.
          */
-        [[nodiscard]] std::string_view getGroup() const {
-            return std::string_view{celix_bundle_getGroup(cBnd.get())};
+        [[nodiscard]] std::string getGroup() const {
+            return std::string{celix_bundle_getGroup(cBnd.get())};
         }
 
         /**
          * @brief The description of the bundle.
          */
-        [[nodiscard]] std::string_view getDescription() const {
-            return std::string_view{celix_bundle_getDescription(cBnd.get())};
+        [[nodiscard]] std::string getDescription() const {
+            return std::string{celix_bundle_getDescription(cBnd.get())};
         }
 
         /**

--- a/libs/framework/include/celix/ServiceRegistration.h
+++ b/libs/framework/include/celix/ServiceRegistration.h
@@ -128,14 +128,14 @@ namespace celix {
         /**
          * @brief The service name for this service registration.
          */
-        std::string_view getServiceName() const { return name; }
+        const std::string& getServiceName() const { return name; }
 
         /**
          * @brief The service version for this service registration.
          *
          * Empty string if there is no service version.
          */
-        std::string_view getServiceVersion() const { return version; }
+        const std::string& getServiceVersion() const { return version; }
 
         /**
          * @brief The service properties for this service registration.

--- a/libs/framework/include/celix/ServiceRegistration.h
+++ b/libs/framework/include/celix/ServiceRegistration.h
@@ -69,8 +69,8 @@ namespace celix {
          */
         static std::shared_ptr<ServiceRegistration> create(std::shared_ptr<celix_bundle_context_t> cCtx,
                                                            std::shared_ptr<void> svc,
-                                                           std::string name,
-                                                           std::string version,
+                                                           std::string_view name,
+                                                           std::string_view version,
                                                            celix::Properties properties,
                                                            bool registerAsync,
                                                            bool unregisterAsync,
@@ -111,8 +111,8 @@ namespace celix {
                 new ServiceRegistration{
                     std::move(cCtx),
                     std::move(svc),
-                    std::move(name),
-                    std::move(version),
+                    name,
+                    version,
                     std::move(properties),
                     registerAsync,
                     unregisterAsync,
@@ -128,14 +128,14 @@ namespace celix {
         /**
          * @brief The service name for this service registration.
          */
-        const std::string& getServiceName() const { return name; }
+        std::string_view getServiceName() const { return name; }
 
         /**
          * @brief The service version for this service registration.
          *
          * Empty string if there is no service version.
          */
-        const std::string& getServiceVersion() const { return version; }
+        std::string_view getServiceVersion() const { return version; }
 
         /**
          * @brief The service properties for this service registration.
@@ -256,16 +256,16 @@ namespace celix {
         ServiceRegistration(
                 std::shared_ptr<celix_bundle_context_t> _cCtx,
                 std::shared_ptr<void> _svc,
-                std::string _name,
-                std::string _version,
+                std::string_view _name,
+                std::string_view _version,
                 celix::Properties _properties,
                 bool _registerAsync,
                 bool _unregisterAsync,
                 std::vector<std::function<void(ServiceRegistration&)>> _onRegisteredCallbacks,
                 std::vector<std::function<void(ServiceRegistration&)>> _onUnregisteredCallbacks) :
                 cCtx{std::move(_cCtx)},
-                name{std::move(_name)},
-                version{std::move(_version)},
+                name{_name},
+                version{_version},
                 properties{std::move(_properties)},
                 registerAsync{_registerAsync},
                 unregisterAsync{_unregisterAsync},

--- a/libs/framework/include/celix/ServiceRegistrationBuilder.h
+++ b/libs/framework/include/celix/ServiceRegistrationBuilder.h
@@ -45,12 +45,12 @@ namespace celix {
         ServiceRegistrationBuilder(
                 std::shared_ptr<celix_bundle_context_t> _cCtx,
                 std::shared_ptr<I> _svc,
-                std::string _name,
+                std::string_view _name,
                 bool _registerAsync = true,
                 bool _unregisterAsync = true) :
                 cCtx{std::move(_cCtx)},
                 svc{std::move(_svc)},
-                name{std::move(_name)},
+                name{_name},
                 version{celix::typeVersion<I>()},
                 registerAsync{_registerAsync},
                 unregisterAsync{_unregisterAsync}{}
@@ -64,21 +64,7 @@ namespace celix {
          *
          * This will lead to a 'service.version' service property.
          */
-        ServiceRegistrationBuilder& setVersion(std::string v) { version = std::move(v); return *this; }
-
-        /**
-         * @brief Add a property to the service properties.
-         *
-         * If a key is already present the value will be overridden.
-         */
-        ServiceRegistrationBuilder& addProperty(const std::string& key, const std::string& value) { properties.set(key, value); return *this; }
-
-        /**
-         * @brief Add a property to the service properties.
-         *
-         * If a key is already present the value will be overridden.
-         */
-        ServiceRegistrationBuilder& addProperty(const std::string& key, const char* value) { properties.set(key, std::string{value}); return *this; }
+        ServiceRegistrationBuilder& setVersion(std::string_view v) { version = v; return *this; }
 
         /**
          * @brief Add a property to the service properties.
@@ -86,12 +72,12 @@ namespace celix {
          * If a key is already present the value will be overridden.
          */
         template<typename T>
-        ServiceRegistrationBuilder& addProperty(const std::string& key, T value) { properties.set(key, std::to_string(std::move(value))); return *this; }
+        ServiceRegistrationBuilder& addProperty(std::string_view key, T&& value) { properties.template set(key, std::forward<T>(value)); return *this; }
 
         /**
          * @brief Set the service properties.
          *
-         * Note this call will clear any already set properties.
+         * Note this call will clear already set properties.
          */
         ServiceRegistrationBuilder& setProperties(celix::Properties p) { properties = std::move(p); return *this; }
 

--- a/libs/framework/include/celix/TrackerBuilders.h
+++ b/libs/framework/include/celix/TrackerBuilders.h
@@ -42,9 +42,9 @@ namespace celix {
         //NOTE private to prevent move so that a build() call cannot be forgotten
         ServiceTrackerBuilder(ServiceTrackerBuilder&&) noexcept = default;
     public:
-        explicit ServiceTrackerBuilder(std::shared_ptr<celix_bundle_context_t> _cCtx, std::string _name) :
+        explicit ServiceTrackerBuilder(std::shared_ptr<celix_bundle_context_t> _cCtx, std::string_view _name) :
                 cCtx{std::move(_cCtx)},
-                name{std::move(_name)} {}
+                name{_name} {}
 
         ServiceTrackerBuilder& operator=(ServiceTrackerBuilder&&) = delete;
         ServiceTrackerBuilder(const ServiceTrackerBuilder&) = delete;
@@ -57,7 +57,7 @@ namespace celix {
          * Example:
          *      "(property_key=value)"
          */
-        ServiceTrackerBuilder& setFilter(const std::string& f) { filter = celix::Filter{f}; return *this; }
+        ServiceTrackerBuilder& setFilter(std::string_view f) { filter = celix::Filter{f}; return *this; }
 
         /**
          * @brief Set filter to be used to matching services.
@@ -310,9 +310,9 @@ namespace celix {
         //NOTE private to prevent move so that a build() call cannot be forgotten
         MetaTrackerBuilder(MetaTrackerBuilder &&) = default;
     public:
-        explicit MetaTrackerBuilder(std::shared_ptr<celix_bundle_context_t> _cCtx, std::string _serviceName) :
+        explicit MetaTrackerBuilder(std::shared_ptr<celix_bundle_context_t> _cCtx, std::string_view _serviceName) :
                 cCtx{std::move(_cCtx)},
-                serviceName{std::move(_serviceName)}
+                serviceName{_serviceName}
         {}
 
         MetaTrackerBuilder &operator=(MetaTrackerBuilder &&) = delete;

--- a/libs/framework/include/celix/Trackers.h
+++ b/libs/framework/include/celix/Trackers.h
@@ -250,12 +250,12 @@ namespace celix {
         /**
          * @brief The service name tracked by this service tracker.
          */
-        std::string_view getServiceName() const { return svcName; }
+        const std::string& getServiceName() const { return svcName; }
 
         /**
          * @brief The service version range tracked by this service tracker.
          */
-        std::string_view getServiceRange() const { return svcVersionRange; }
+        const std::string& getServiceRange() const { return svcVersionRange; }
 
         /**
          * @brief The additional filter for services tracked by this service tracker.

--- a/libs/framework/include/celix/Trackers.h
+++ b/libs/framework/include/celix/Trackers.h
@@ -216,9 +216,9 @@ namespace celix {
      */
     class GenericServiceTracker : public AbstractTracker {
     public:
-        GenericServiceTracker(std::shared_ptr<celix_bundle_context_t> _cCtx, std::string _svcName,
-                              std::string _svcVersionRange, celix::Filter _filter) : AbstractTracker{std::move(_cCtx)}, svcName{std::move(_svcName)},
-                                                                                   svcVersionRange{std::move(_svcVersionRange)}, filter{std::move(_filter)} {
+        GenericServiceTracker(std::shared_ptr<celix_bundle_context_t> _cCtx, std::string_view _svcName,
+                              std::string_view _svcVersionRange, celix::Filter _filter) : AbstractTracker{std::move(_cCtx)}, svcName{_svcName},
+                                                                                   svcVersionRange{_svcVersionRange}, filter{std::move(_filter)} {
             opts.trackerCreatedCallbackData = this;
             opts.trackerCreatedCallback = [](void *data) {
                 auto* trk = static_cast<GenericServiceTracker*>(data);
@@ -250,12 +250,12 @@ namespace celix {
         /**
          * @brief The service name tracked by this service tracker.
          */
-        const std::string& getServiceName() const { return svcName; }
+        std::string_view getServiceName() const { return svcName; }
 
         /**
          * @brief The service version range tracked by this service tracker.
          */
-        const std::string& getServiceRange() const { return svcVersionRange; }
+        std::string_view getServiceRange() const { return svcVersionRange; }
 
         /**
          * @brief The additional filter for services tracked by this service tracker.
@@ -308,8 +308,8 @@ namespace celix {
          */
         static std::shared_ptr<ServiceTracker<I>> create(
                 std::shared_ptr<celix_bundle_context_t> cCtx,
-                std::string svcName,
-                std::string svcVersionRange,
+                std::string_view svcName,
+                std::string_view svcVersionRange,
                 celix::Filter filter,
                 std::vector<std::function<void(const std::shared_ptr<I>&, const std::shared_ptr<const celix::Properties>&, const std::shared_ptr<const celix::Bundle>&)>> setCallbacks,
                 std::vector<std::function<void(const std::shared_ptr<I>&, const std::shared_ptr<const celix::Properties>&, const std::shared_ptr<const celix::Bundle>&)>> addCallbacks,
@@ -318,8 +318,8 @@ namespace celix {
             auto tracker = std::shared_ptr<ServiceTracker<I>>{
                 new ServiceTracker<I>{
                     std::move(cCtx),
-                    std::move(svcName),
-                    std::move(svcVersionRange),
+                    svcName,
+                    svcVersionRange,
                     std::move(filter),
                     std::move(setCallbacks),
                     std::move(addCallbacks),
@@ -381,12 +381,12 @@ namespace celix {
             std::shared_ptr<const celix::Bundle> owner;
         };
 
-        ServiceTracker(std::shared_ptr<celix_bundle_context_t> _cCtx, std::string _svcName,
-                       std::string _svcVersionRange, celix::Filter _filter,
+        ServiceTracker(std::shared_ptr<celix_bundle_context_t> _cCtx, std::string_view _svcName,
+                       std::string_view _svcVersionRange, celix::Filter _filter,
                        std::vector<std::function<void(const std::shared_ptr<I>&, const std::shared_ptr<const celix::Properties>&, const std::shared_ptr<const celix::Bundle>&)>> _setCallbacks,
                        std::vector<std::function<void(const std::shared_ptr<I>&, const std::shared_ptr<const celix::Properties>&, const std::shared_ptr<const celix::Bundle>&)>> _addCallbacks,
                        std::vector<std::function<void(const std::shared_ptr<I>&, const std::shared_ptr<const celix::Properties>&, const std::shared_ptr<const celix::Bundle>&)>> _remCallbacks) :
-                GenericServiceTracker{std::move(_cCtx), std::move(_svcName), std::move(_svcVersionRange), std::move(_filter)},
+                GenericServiceTracker{std::move(_cCtx), _svcName, _svcVersionRange, std::move(_filter)},
                 setCallbacks{std::move(_setCallbacks)},
                 addCallbacks{std::move(_addCallbacks)},
                 remCallbacks{std::move(_remCallbacks)} {
@@ -696,14 +696,14 @@ namespace celix {
          */
         static std::shared_ptr<MetaTracker> create(
                 std::shared_ptr<celix_bundle_context_t> cCtx,
-                std::string serviceName,
+                std::string_view serviceName,
                 std::vector<std::function<void(const ServiceTrackerInfo&)>> onTrackerCreated,
                 std::vector<std::function<void(const ServiceTrackerInfo&)>> onTrackerDestroyed) {
 
             auto tracker = std::shared_ptr<MetaTracker>{
                     new MetaTracker{
                             std::move(cCtx),
-                            std::move(serviceName),
+                            serviceName,
                             std::move(onTrackerCreated),
                             std::move(onTrackerDestroyed)},
                     AbstractTracker::delCallback<MetaTracker>()};
@@ -753,11 +753,11 @@ namespace celix {
     private:
         MetaTracker(
                 std::shared_ptr<celix_bundle_context_t> _cCtx,
-                std::string _serviceName,
+                std::string_view _serviceName,
                 std::vector<std::function<void(const ServiceTrackerInfo&)>> _onTrackerCreated,
                 std::vector<std::function<void(const ServiceTrackerInfo&)>> _onTrackerDestroyed) :
                 AbstractTracker{std::move(_cCtx)},
-                serviceName{std::move(_serviceName)},
+                serviceName{_serviceName},
                 onTrackerCreated{std::move(_onTrackerCreated)},
                 onTrackerDestroyed{std::move(_onTrackerDestroyed)} {}
 

--- a/libs/framework/include/celix/UseServiceBuilder.h
+++ b/libs/framework/include/celix/UseServiceBuilder.h
@@ -54,9 +54,9 @@ namespace celix {
         //NOTE private to prevent move so that a build() call cannot be forgotten
         UseServiceBuilder(UseServiceBuilder&&) noexcept = default;
     public:
-        explicit UseServiceBuilder(std::shared_ptr<celix_bundle_context_t> _cCtx, std::string _name, bool _useSingleService = true) :
+        explicit UseServiceBuilder(std::shared_ptr<celix_bundle_context_t> _cCtx, std::string_view _name, bool _useSingleService = true) :
                 cCtx{std::move(_cCtx)},
-                name{std::move(_name)},
+                name{_name},
                 useSingleService{_useSingleService} {
         }
 
@@ -71,7 +71,7 @@ namespace celix {
          * Example:
          *      "(property_key=value)"
          */
-        UseServiceBuilder& setFilter(const std::string& f) { filter = celix::Filter{f}; return *this; }
+        UseServiceBuilder& setFilter(std::string_view f) { filter = celix::Filter{f}; return *this; }
 
         /**
          * @brief Set filter to be used to matching services.

--- a/libs/utils/gtest/CMakeLists.txt
+++ b/libs/utils/gtest/CMakeLists.txt
@@ -54,7 +54,7 @@ target_compile_definitions(test_utils PRIVATE -DTEST_ZIP_LOCATION=\"${TEST_ZIP_F
 target_compile_definitions(test_utils PRIVATE -DTEST_A_FILE_LOCATION=\"${CMAKE_CURRENT_SOURCE_DIR}/CMakeLists.txt\")
 target_compile_definitions(test_utils PRIVATE -DTEST_A_DIR_LOCATION=\"${CMAKE_CURRENT_SOURCE_DIR}\")
 
-####### linkig zip against test executable to text extract zip from data ###############################################
+####### linking zip against test executable to text extract zip from data ###############################################
 if (UNIX AND NOT APPLE)
     target_link_libraries(test_utils PRIVATE -Wl,--format=binary -Wl,"test.zip" -Wl,--format=default)
 else ()
@@ -63,4 +63,15 @@ endif ()
 
 add_test(NAME test_utils COMMAND test_utils)
 setup_target_for_coverage(test_utils SCAN_DIR ..)
+
+
+#Setting standard to C++11 and testing C++ Properties to ensure that this still support C++11.
+#Note that celix Properties are used in the C++11 dependency manager and this be backwards compatible with Celix 2.2.1
+set(CMAKE_CXX_STANDARD 11)
+add_executable(test_properties_with_cxx11
+        src/CxxPropertiesTestSuite.cc
+)
+target_link_libraries(test_properties_with_cxx11 PRIVATE Celix::utils GTest::gtest GTest::gtest_main)
+add_test(NAME test_properties_with_cxx11 COMMAND test_properties_with_cxx11)
+setup_target_for_coverage(test_properties_with_cxx11 SCAN_DIR ..)
 

--- a/libs/utils/gtest/src/CxxPropertiesTestSuite.cc
+++ b/libs/utils/gtest/src/CxxPropertiesTestSuite.cc
@@ -88,3 +88,60 @@ TEST_F(CxxPropertiesTestSuite, testWrap) {
 
     celix_properties_destroy(props);
 }
+
+#if __cplusplus >= 201703L //C++17 or higher
+TEST_F(CxxPropertiesTestSuite, testStringView) {
+    constexpr std::string_view stringViewKey = "KEY1";
+    constexpr std::string_view stringViewValue = "VALUE1";
+    std::string stringKey{"KEY2"};
+    std::string stringValue{"VALUE2"};
+    const char* charKey = "KEY3";
+    const char* charValue = "VALUE3";
+
+    {
+        //rule: I can create properties with initializer_list using std::string, const char* and string_view
+        celix::Properties props {
+                {charKey, charValue},
+                {stringKey, stringValue},
+                {stringViewKey, stringViewValue}
+        };
+        EXPECT_EQ(props.size(), 3);
+
+        //rule: I can use the subscript operator using string_view objects
+        constexpr std::string_view k = "KEY2";
+        constexpr std::string_view v = "VALUE_NEW";
+        std::string check = props[k];
+        EXPECT_EQ(check, "VALUE2");
+        props[k] = v;
+        check = props[k];
+        EXPECT_EQ(check, v);
+    }
+
+    {
+        //rule: I can use set/get with string_view
+        constexpr std::string_view key = "TEST_KEY";
+        constexpr std::string_view value = "TEST_VALUE";
+
+        celix::Properties props{};
+
+        props.set(key, value);
+        EXPECT_EQ(value, props.get(key));
+        props[key] = value;
+        EXPECT_EQ(value, props.get(key));
+        EXPECT_EQ(1, props.size());
+
+        props.set(key,  std::string{"string value"});
+        EXPECT_EQ("string value", props.get(key));
+        props.set(key,  "string value");
+        EXPECT_EQ("string value", props.get(key));
+        EXPECT_EQ(1, props.size());
+
+        props.set(key, 1L); //long
+        EXPECT_EQ(1L, props.getAsLong(key, -1));
+        props.set(key, 1.0); //double
+        EXPECT_EQ(1.0, props.getAsDouble(key, -1));
+        props.set(key, true); //bool
+        EXPECT_EQ(true, props.getAsBool(key, false));
+    }
+}
+#endif

--- a/libs/utils/gtest/src/CxxPropertiesTestSuite.cc
+++ b/libs/utils/gtest/src/CxxPropertiesTestSuite.cc
@@ -144,4 +144,22 @@ TEST_F(CxxPropertiesTestSuite, testStringView) {
         EXPECT_EQ(true, props.getAsBool(key, false));
     }
 }
+
+TEST_F(CxxPropertiesTestSuite, testUseOfConstexprInSetMethod) {
+    celix::Properties props{};
+
+    //Test if different bool "types" are correctly handled
+    props.set("key1", true);
+    props.set<const bool>("key2", false);
+    props.set<const bool&>("key3", 1);
+    props.set<bool&&>("key4", 0);
+    props.set<volatile bool&&>("key5", true);
+    EXPECT_EQ(5, props.size());
+
+    EXPECT_EQ(props.getAsBool("key1", false), true);
+    EXPECT_EQ(props.get("key2"), "false");
+    EXPECT_EQ(props.get("key3"), "true");
+    EXPECT_EQ(props.get("key4"), "false");
+    EXPECT_EQ(props.get("key5"), "true");
+}
 #endif

--- a/libs/utils/gtest/src/CxxUtilsTestSuite.cc
+++ b/libs/utils/gtest/src/CxxUtilsTestSuite.cc
@@ -103,11 +103,19 @@ TEST_F(CxxUtilsTestSuite, testSplit) {
     EXPECT_EQ(tokens[1], "item2");
     EXPECT_EQ(tokens[2], "item3");
 
-    tokens = celix::split("  item1 , item2  ,  item3  ");
-    ASSERT_EQ(tokens.size(), 3);
+    tokens = celix::split("  item1 , item2  ,  item3,item4  ");
+    ASSERT_EQ(tokens.size(), 4);
     EXPECT_EQ(tokens[0], "item1");
     EXPECT_EQ(tokens[1], "item2");
     EXPECT_EQ(tokens[2], "item3");
+    EXPECT_EQ(tokens[3], "item4");
+
+    tokens = celix::split("  item1 ; item2  ;  item3;item4  ", ";");
+    ASSERT_EQ(tokens.size(), 4);
+    EXPECT_EQ(tokens[0], "item1");
+    EXPECT_EQ(tokens[1], "item2");
+    EXPECT_EQ(tokens[2], "item3");
+    EXPECT_EQ(tokens[3], "item4");
 
     tokens = celix::split("  item1 , ");
     ASSERT_EQ(tokens.size(), 1);

--- a/libs/utils/include/celix/Filter.h
+++ b/libs/utils/include/celix/Filter.h
@@ -84,9 +84,9 @@ namespace celix {
         /**
          * @brief Gets the filter string
          */
-        [[nodiscard]] std::string_view getFilterString() const {
+        [[nodiscard]] std::string getFilterString() const {
             auto cStr = getFilterCString();
-            return cStr == nullptr ? std::string_view{} : std::string_view{cStr};
+            return cStr == nullptr ? std::string{} : std::string{cStr};
         }
 
         /**
@@ -107,9 +107,9 @@ namespace celix {
          * @brief Find the attribute based on the provided key.
          * @return The found attribute value or an empty string if the attribute was not found.
          */
-        [[nodiscard]] std::string_view findAttribute(std::string_view attributeKey) const {
+        [[nodiscard]] std::string findAttribute(std::string_view attributeKey) const {
             auto* cValue = celix_filter_findAttribute(cFilter.get(), attributeKey.data());
-            return cValue == nullptr ? std::string_view{} : std::string_view{cValue};
+            return cValue == nullptr ? std::string{} : std::string{cValue};
         }
 
         /**

--- a/libs/utils/include/celix/Utils.h
+++ b/libs/utils/include/celix/Utils.h
@@ -150,9 +150,9 @@ namespace celix {
      * celix::impl::typeName uses the macro __PRETTY_FUNCTION__ to extract a type name.
      */
     template<typename I>
-    std::string typeName(const std::string& providedTypeName = "") {
+    std::string typeName(std::string_view providedTypeName = "") {
         if (!providedTypeName.empty()) {
-            return providedTypeName;
+            return std::string{providedTypeName};
         } else if constexpr (celix::impl::hasStaticMemberName<I>) {
             return std::string{I::NAME};
         } else {
@@ -169,9 +169,9 @@ namespace celix {
      * Otherwise a empty string will be returned.
      */
     template<typename I>
-    std::string typeVersion(const std::string& providedVersion = "") {
+    std::string typeVersion(std::string_view providedVersion = "") {
         if (!providedVersion.empty()) {
-            return providedVersion;
+            return std::string{providedVersion};
         } else if constexpr (celix::impl::hasStaticMemberVersion<I>) {
             return std::string{I::VERSION};
         } else {
@@ -186,13 +186,13 @@ namespace celix {
      * @param str The string to split
      * @param delimiter The delimiter to use (default ",")
      */
-     inline std::vector<std::string> split(const std::string& str, const std::string& delimiter = ",") {
+     inline std::vector<std::string> split(std::string_view str, std::string_view delimiter = ",") {
         std::vector<std::string> result{};
-        std::string delimiters = delimiter + " \t";
+        std::string delimiters = std::string{delimiter} + " \t";
         size_t found;
         size_t pos = 0;
         while ((found = str.find_first_not_of(delimiters, pos)) != std::string::npos) {
-            pos = str.find_first_of(", ", found);
+            pos = str.find_first_of(delimiters, found);
             result.emplace_back(str.substr(found, pos - found));
         }
         return result;


### PR DESCRIPTION
This PR updates the std::string arguments in the (C++17) methods to std::string_view and if applicable also update the 
std::string return types to std::string_view.

This make it possible to use std::string_view objects as input and as result use constructions like:
`constexpr std::string_view MY_CONSTANT = "value";` for constants. 

Currently string_view arguments are assumed to refer to null-terminated strings. This is essential the same as with handling `const char*` arguments. 

Technically string_view objects can refer to not null-terminated strings and this is also detectable (using string_view::size() and looking for the '\0'), but expensive. IMO this is not really necessary. Mainly, because we also assume `const char*` arguments are null-terminated.

