### PR TITLE
Fix RSA CMake error

### DIFF
--- a/bundles/remote_services/CMakeLists.txt
+++ b/bundles/remote_services/CMakeLists.txt
@@ -42,6 +42,39 @@ if (REMOTE_SERVICE_ADMIN)
         #add_subdirectory(remote_service_admin_shm)
     endif ()
 
+    if (BUILD_RSA_DISCOVERY_ETCD AND BUILD_RSA_REMOTE_SERVICE_ADMIN_DFI)
+        add_celix_container(remote-services-dfi
+                NAME "server"
+                GROUP "remote-services/remote-services-dfi"
+                BUNDLES
+                Celix::rsa_discovery_etcd
+                Celix::rsa_topology_manager
+                Celix::rsa_dfi
+                Celix::shell
+                Celix::shell_tui
+                Celix::log_admin
+
+                celix_remote_interceptors_example
+                calculator
+                PROPERTIES
+                RSA_PORT=18888
+                )
+
+        add_celix_container(remote-services-dfi-client
+                NAME "client"
+                GROUP "remote-services/remote-services-dfi"
+                BUNDLES
+                Celix::rsa_topology_manager
+                Celix::rsa_dfi Celix::shell
+                Celix::shell_tui
+                Celix::log_admin
+                Celix::rsa_discovery_etcd
+                celix_remote_interceptors_example
+                calculator_shell
+                PROPERTIES
+                RSA_PORT=28888
+                )
+    endif()
 endif (REMOTE_SERVICE_ADMIN)
 
 

--- a/bundles/remote_services/examples/CMakeLists.txt
+++ b/bundles/remote_services/examples/CMakeLists.txt
@@ -46,38 +46,3 @@ add_subdirectory(interceptors)
 #            BUNDLES org.apache.celix.calc.api.Calculator_proxy
 #        )
 #    endif ()
-
-
-if (BUILD_RSA_DISCOVERY_ETCD AND BUILD_RSA_REMOTE_SERVICE_ADMIN_DFI)
-    add_celix_container(remote-services-dfi
-        NAME "server"
-        GROUP "remote-services/remote-services-dfi"
-        BUNDLES
-            Celix::rsa_discovery_etcd
-            Celix::rsa_topology_manager
-            Celix::rsa_dfi
-            Celix::shell
-            Celix::shell_tui
-            Celix::log_admin
-
-            celix_remote_interceptors_example
-            calculator
-        PROPERTIES
-            RSA_PORT=18888
-    )
-
-    add_celix_container(remote-services-dfi-client
-        NAME "client"
-        GROUP "remote-services/remote-services-dfi"
-        BUNDLES
-            Celix::rsa_topology_manager
-            Celix::rsa_dfi Celix::shell
-            Celix::shell_tui
-            Celix::log_admin
-            Celix::rsa_discovery_etcd
-            celix_remote_interceptors_example
-            calculator_shell
-        PROPERTIES
-            RSA_PORT=28888
-    )
-endif ()


### PR DESCRIPTION
Break cyclic dependency between examples and other RSA tests.

It fixes #383 