### PR TITLE
Fixes an issue when building and not using cmake type DEBUG

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -27,9 +27,11 @@
 # - cmake <loc_to_celix_src>/examples
 # - make -j all
 
-cmake_minimum_required (VERSION 3.4)
+cmake_minimum_required (VERSION 3.14)
+cmake_policy(SET CMP0068 NEW)
 project (CelixUse C CXX)
 set(CMAKE_C_FLAGS "-D_GNU_SOURCE -std=gnu99 ${CMAKE_C_FLAGS}")
 set(CMAKE_CXX_STANDARD 17)
+set(CELIX_CXX ON CACHE BOOL "C++ on")
 find_package(Celix REQUIRED)
 add_subdirectory(celix-examples examples)

--- a/libs/framework/src/celix_libloader.c
+++ b/libs/framework/src/celix_libloader.c
@@ -26,7 +26,7 @@
 celix_library_handle_t* celix_libloader_open(celix_bundle_context_t *ctx, const char *libPath) {
     bool defaultNoDelete = true;
 #if defined(NDEBUG)
-    bool defaultNoDelete = false;
+    defaultNoDelete = false;
 #endif
     celix_library_handle_t* handle = NULL;
     bool noDelete = celix_bundleContext_getPropertyAsBool(ctx, CELIX_LOAD_BUNDLES_WITH_NODELETE, defaultNoDelete);


### PR DESCRIPTION
Fixes an issue when building with a CMAKE_BUILD_TYPE Release or RelWithDebInfo.

The issue was that if NDEBUG is defined a variable was declared multiple times. 