### PR TITLE
Tracker improvements preliminary

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ endif ()
 set(ENABLE_MORE_WARNINGS OFF)
 
 # Set C specific flags
-set(CMAKE_C_FLAGS "-D_GNU_SOURCE -std=gnu99 -fPIC ${CMAKE_C_FLAGS}")
+set(CMAKE_C_FLAGS "-D_GNU_SOURCE -std=gnu11 -fPIC ${CMAKE_C_FLAGS}")
 set(CMAKE_C_FLAGS "-Wall -Werror ${CMAKE_C_FLAGS}")
 
 # Set C++ specific flags

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ endif ()
 set(ENABLE_MORE_WARNINGS OFF)
 
 # Set C specific flags
-set(CMAKE_C_FLAGS "-D_GNU_SOURCE -std=gnu11 -fPIC ${CMAKE_C_FLAGS}")
+set(CMAKE_C_FLAGS "-D_GNU_SOURCE -std=gnu99 -fPIC ${CMAKE_C_FLAGS}")
 set(CMAKE_C_FLAGS "-Wall -Werror ${CMAKE_C_FLAGS}")
 
 # Set C++ specific flags

--- a/bundles/remote_services/discovery_common/src/discovery.c
+++ b/bundles/remote_services/discovery_common/src/discovery.c
@@ -176,6 +176,7 @@ celix_status_t discovery_informEndpointListeners(discovery_t *discovery, endpoin
 
                         listener->endpointRemoved(listener->handle, endpoint, (char*)scope);
                     }
+                    bundleContext_ungetService(discovery->context, reference, NULL);
                 }
 
                 celix_filter_destroy(filter);

--- a/bundles/remote_services/rsa_common/src/export_registration_impl.c
+++ b/bundles/remote_services/rsa_common/src/export_registration_impl.c
@@ -154,6 +154,7 @@ celix_status_t exportRegistration_endpointAdded(void * handle, service_reference
 		status = bundleContext_getService(registration->context, registration->reference, &service);
 		if (status == CELIX_SUCCESS) {
 			endpoint->setService(endpoint->endpoint, service);
+            bundleContext_ungetService(registration->context, registration->reference, NULL);
 		}
 	}
 

--- a/libs/framework/gtest/CMakeLists.txt
+++ b/libs/framework/gtest/CMakeLists.txt
@@ -52,7 +52,7 @@ target_link_libraries(test_framework PRIVATE Celix::framework CURL::libcurl GTes
 add_celix_bundle_dependencies(test_framework
         simple_test_bundle1
         simple_test_bundle2 simple_test_bundle3 simple_test_bundle4
-        simple_test_bundle5 bundle_with_exception unresolveable_bundle simple_cxx)
+        simple_test_bundle5 bundle_with_exception unresolveable_bundle simple_cxx_bundle simple_cxx_dep_man_bundle cmp_test_bundle)
 target_include_directories(test_framework PRIVATE ../src)
 
 celix_get_bundle_file(simple_cxx_bundle SIMPLE_CXX_BUNDLE_LOC)

--- a/libs/framework/src/bundle_context.c
+++ b/libs/framework/src/bundle_context.c
@@ -76,7 +76,7 @@ celix_status_t bundleContext_create(framework_pt framework, celix_framework_logg
 
         }
 	}
-
+    //FIXME: context == NULL?
 	framework_logIfError(context->framework->logger, status, NULL, "Failed to create context");
 
 	return status;
@@ -108,7 +108,7 @@ celix_status_t bundleContext_destroy(bundle_context_pt context) {
 	} else {
 		status = CELIX_ILLEGAL_ARGUMENT;
 	}
-
+    //FIXME: context == NULL?
 	framework_logIfError(context->framework->logger, status, NULL, "Failed to destroy context");
 
 	return status;
@@ -233,6 +233,7 @@ celix_status_t bundleContext_getServiceReference(bundle_context_pt context, cons
     if (serviceName != NULL) {
         if (bundleContext_getServiceReferences(context, serviceName, NULL, &services) == CELIX_SUCCESS) {
             reference = (arrayList_size(services) > 0) ? arrayList_get(services, 0) : NULL;
+            //FIXME: unget service reference
             arrayList_destroy(services);
             *service_reference = reference;
         } else {

--- a/libs/framework/src/bundle_context_private.h
+++ b/libs/framework/src/bundle_context_private.h
@@ -79,7 +79,7 @@ struct celix_bundle_context {
 	celix_dependency_manager_t *mng;
 	long nextTrackerId;
 	hash_map_t *bundleTrackers; //key = trackerId, value = celix_bundle_context_bundle_tracker_entry_t*
-	hash_map_t *serviceTrackers; //key = trackerId, value = celix_service_tracker_t*
+	hash_map_t *serviceTrackers; //key = trackerId, value = celix_bundle_context_service_tracker_entry_t*
 	hash_map_t *metaTrackers; //key = trackerId, value = celix_bundle_context_service_tracker_tracker_entry_t*
     hash_map_t *stoppingTrackerEventIds; //key = trackerId, value = eventId for stopping the tracker. Note id are only present if the stop tracking is queued.
 };

--- a/libs/framework/src/framework.c
+++ b/libs/framework/src/framework.c
@@ -968,6 +968,7 @@ celix_status_t fw_getServiceReferences(framework_pt framework, array_list_pt *re
             if (status == CELIX_SUCCESS) {
                 serviceNameObjectClass = properties_get(props, OSGI_FRAMEWORK_OBJECTCLASS);
                 if (!serviceReference_isAssignableTo(ref, bundle, serviceNameObjectClass)) {
+                    //FIXME: unget service reference
                     arrayList_remove(*references, refIdx);
                     refIdx--;
                 }

--- a/libs/framework/src/service_reference.c
+++ b/libs/framework/src/service_reference.c
@@ -84,7 +84,7 @@ celix_status_t serviceReference_release(service_reference_pt ref, bool *out) {
 
 static void serviceReference_doRelease(struct celix_ref *refCount) {
     service_reference_pt ref = (service_reference_pt)refCount;
-    BUILD_ASSERT(offsetof(struct serviceReference, refCount) == 0);
+    CELIX_BUILD_ASSERT(offsetof(struct serviceReference, refCount) == 0);
     if(ref->registration != NULL) {
         serviceRegistration_release(ref->registration);
     }
@@ -137,11 +137,8 @@ celix_status_t serviceReference_getUsageCount(service_reference_pt ref, size_t *
 }
 
 celix_status_t serviceReference_getReferenceCount(service_reference_pt ref, size_t *count) {
-    celix_status_t status = CELIX_SUCCESS;
-    celixThreadRwlock_readLock(&ref->lock);
-    *count = ref->refCount.count;
-    celixThreadRwlock_unlock(&ref->lock);
-    return status;
+    *count = celix_ref_read(&ref->refCount);
+    return CELIX_SUCCESS;
 }
 
 celix_status_t serviceReference_getService(service_reference_pt ref, const void **service) {

--- a/libs/framework/src/service_reference_private.h
+++ b/libs/framework/src/service_reference_private.h
@@ -29,16 +29,16 @@
 
 #include "registry_callback_private.h"
 #include "service_reference.h"
+#include "celix_ref.h"
 
 
 struct serviceReference {
+    struct celix_ref refCount;
     registry_callback_t callback;
 	bundle_pt referenceOwner;
 	struct serviceRegistration * registration;
     bundle_pt registrationBundle;
     const void* service;
-
-	size_t refCount;
     size_t usageCount;
 
     celix_thread_rwlock_t lock;
@@ -59,7 +59,7 @@ celix_status_t serviceReference_getUsageCount(service_reference_pt reference, si
 celix_status_t serviceReference_getReferenceCount(service_reference_pt reference, size_t *count);
 
 celix_status_t serviceReference_setService(service_reference_pt ref, const void *service);
-celix_status_t serviceReference_getService(service_reference_pt reference, void **service);
+celix_status_t serviceReference_getService(service_reference_pt reference, const void **service);
 
 celix_status_t serviceReference_getOwner(service_reference_pt reference, bundle_pt *owner);
 

--- a/libs/framework/src/service_registration.c
+++ b/libs/framework/src/service_registration.c
@@ -24,11 +24,12 @@
 
 #include "service_registration_private.h"
 #include "celix_constants.h"
+#include "celix_build_assert.h"
 
+static void serviceRegistration_destroy(struct celix_ref *);
 static celix_status_t serviceRegistration_initializeProperties(service_registration_pt registration, properties_pt properties);
 static celix_status_t serviceRegistration_createInternal(registry_callback_t callback, bundle_pt bundle, const char* serviceName, unsigned long serviceId,
         const void * serviceObject, properties_pt dictionary, enum celix_service_type svcType, service_registration_pt *registration);
-static celix_status_t serviceRegistration_destroy(service_registration_pt registration);
 
 service_registration_pt serviceRegistration_create(registry_callback_t callback, bundle_pt bundle, const char* serviceName, unsigned long serviceId, const void * serviceObject, properties_pt dictionary) {
     service_registration_pt registration = NULL;
@@ -48,22 +49,13 @@ static celix_status_t serviceRegistration_createInternal(registry_callback_t cal
     celix_status_t status = CELIX_SUCCESS;
 	service_registration_pt  reg = calloc(1, sizeof(*reg));
     if (reg) {
+        celix_ref_init(&reg->refCount);
         reg->callback = callback;
-        reg->services = NULL;
-        reg->nrOfServices = 0;
 		reg->svcType = svcType;
 		reg->className = strndup(serviceName, 1024*10);
 		reg->bundle = bundle;
-		reg->refCount = 1;
 		reg->serviceId = serviceId;
 	    reg->svcObj = serviceObject;
-
-		if (svcType == CELIX_DEPRECATED_FACTORY_SERVICE) {
-			reg->deprecatedFactory = (service_factory_pt) reg->svcObj;
-		} else if (svcType == CELIX_FACTORY_SERVICE) {
-			reg->factory = (celix_service_factory_t*) reg->svcObj;
-		}
-
 		reg->isUnregistering = false;
 		celixThreadRwlock_create(&reg->lock, NULL);
 
@@ -83,35 +75,24 @@ static celix_status_t serviceRegistration_createInternal(registry_callback_t cal
 }
 
 void serviceRegistration_retain(service_registration_pt registration) {
-	celixThreadRwlock_writeLock(&registration->lock);
-	registration->refCount += 1;
-    celixThreadRwlock_unlock(&registration->lock);
+    celix_ref_get(&registration->refCount);
 }
 
 void serviceRegistration_release(service_registration_pt registration) {
-    celixThreadRwlock_writeLock(&registration->lock);
-    assert(registration->refCount > 0);
-	registration->refCount -= 1;
-	if (registration->refCount == 0) {
-		serviceRegistration_destroy(registration);
-	} else {
-        celixThreadRwlock_unlock(&registration->lock);
-	}
+    celix_ref_put(&registration->refCount, serviceRegistration_destroy);
 }
 
-static celix_status_t serviceRegistration_destroy(service_registration_pt registration) {
-	//fw_log(logger, CELIX_LOG_LEVEL_DEBUG, "Destroying service registration %p\n", registration);
+static void serviceRegistration_destroy(struct celix_ref *refCount) {
+    service_registration_pt registration = (service_registration_pt )refCount;
+    BUILD_ASSERT(offsetof(service_registration_t, refCount) == 0);
+
+    //fw_log(logger, CELIX_LOG_LEVEL_DEBUG, "Destroying service registration %p\n", registration);
     free(registration->className);
-	registration->className = NULL;
-
+    registration->className = NULL;
     registration->callback.unregister = NULL;
-
-	properties_destroy(registration->properties);
-	celixThreadRwlock_unlock(&registration->lock);
+    properties_destroy(registration->properties);
     celixThreadRwlock_destroy(&registration->lock);
-	free(registration);
-
-	return CELIX_SUCCESS;
+    free(registration);
 }
 
 static celix_status_t serviceRegistration_initializeProperties(service_registration_pt registration, properties_pt dictionary) {

--- a/libs/framework/src/service_registration.c
+++ b/libs/framework/src/service_registration.c
@@ -84,7 +84,7 @@ void serviceRegistration_release(service_registration_pt registration) {
 
 static void serviceRegistration_destroy(struct celix_ref *refCount) {
     service_registration_pt registration = (service_registration_pt )refCount;
-    BUILD_ASSERT(offsetof(service_registration_t, refCount) == 0);
+    CELIX_BUILD_ASSERT(offsetof(service_registration_t, refCount) == 0);
 
     //fw_log(logger, CELIX_LOG_LEVEL_DEBUG, "Destroying service registration %p\n", registration);
     free(registration->className);

--- a/libs/framework/src/service_registration_private.h
+++ b/libs/framework/src/service_registration_private.h
@@ -23,6 +23,7 @@
 
 #include "registry_callback_private.h"
 #include "service_registration.h"
+#include "celix_ref.h"
 
 enum celix_service_type {
 	CELIX_PLAIN_SERVICE,
@@ -31,6 +32,7 @@ enum celix_service_type {
 };
 
 struct serviceRegistration {
+    struct celix_ref refCount;
     registry_callback_t callback;
 
 	char * className;
@@ -41,14 +43,12 @@ struct serviceRegistration {
 	bool isUnregistering;
 
 	enum celix_service_type svcType;
-	const void * svcObj;
-	service_factory_pt deprecatedFactory;
-	celix_service_factory_t *factory;
+    union {
+        const void * svcObj;
+        service_factory_pt deprecatedFactory;
+        celix_service_factory_t *factory;
+    };
 
-	struct service *services;
-	int nrOfServices;
-
-	size_t refCount; //protected by mutex
 
 	celix_thread_rwlock_t lock;
 };

--- a/libs/framework/src/service_registry.c
+++ b/libs/framework/src/service_registry.c
@@ -492,7 +492,7 @@ celix_status_t serviceRegistry_ungetServiceReference(service_registry_pt registr
     return status;
 }
 
-static void serviceRegistry_logWarningServiceReferenceUsageCount(service_registry_pt registry __attribute__((unused)), bundle_pt bundle, service_reference_pt ref, size_t usageCount, size_t refCount) {
+static void serviceRegistry_logWarningServiceReferenceUsageCount(service_registry_pt registry, bundle_pt bundle, service_reference_pt ref, size_t usageCount, size_t refCount) {
     if (usageCount > 0) {
         fw_log(registry->framework->logger, CELIX_LOG_LEVEL_WARNING, "Service Reference destroyed with usage count is %zu, expected 0. Look for missing bundleContext_ungetService calls.", usageCount);
     }
@@ -612,10 +612,7 @@ celix_status_t serviceRegistry_getService(service_registry_pt registry, bundle_p
 
     serviceRegistration_release(registration);
 
-    /* NOTE the out argument of sr_getService should be 'const void**'
-       To ensure backwards compatibility a cast is made instead.
-    */
-    serviceReference_getService(reference, (void **)out);
+    serviceReference_getService(reference, out);
 
 	return status;
 }
@@ -630,10 +627,7 @@ celix_status_t serviceRegistry_ungetService(service_registry_pt registry, bundle
 
     celix_status_t status = serviceReference_decreaseUsage(reference, &count);
     if (count == 0) {
-        /*NOTE the argument service of sr_getService should be 'const void**'
-          To ensure backwards compatibility a cast is made instead.
-          */
-        serviceReference_getService(reference, (void**)&service);
+        serviceReference_getService(reference, &service);
         serviceReference_getServiceRegistration(reference, &reg);
         if (reg != NULL) {
             serviceRegistration_ungetService(reg, bundle, &service);

--- a/libs/framework/src/service_tracker.c
+++ b/libs/framework/src/service_tracker.c
@@ -94,9 +94,10 @@ celix_status_t serviceTracker_create(bundle_context_pt context, const char * ser
 	if (service == NULL || *tracker != NULL) {
 		status = CELIX_ILLEGAL_ARGUMENT;
 	} else {
-        char filter[512];
-        snprintf(filter, sizeof(filter), "(%s=%s)", OSGI_FRAMEWORK_OBJECTCLASS, service);
+        char *filter = NULL;
+        asprintf(&filter, "(%s=%s)", OSGI_FRAMEWORK_OBJECTCLASS, service);
         serviceTracker_createWithFilter(context, filter, customizer, tracker);
+        free(filter);
 	}
 
 	framework_logIfError(context->framework->logger, status, NULL, "Cannot create service tracker");
@@ -340,8 +341,9 @@ static void serviceTracker_serviceChanged(void *handle, celix_service_event_t *e
     switch (event->type) {
         case OSGI_FRAMEWORK_SERVICE_EVENT_REGISTERED:
         case OSGI_FRAMEWORK_SERVICE_EVENT_MODIFIED:
-            if(!closing)
+            if(!closing) {
                 serviceTracker_track(tracker, event->reference, event);
+            }
             break;
         case OSGI_FRAMEWORK_SERVICE_EVENT_UNREGISTERING:
             //after this call the registration can be gone, to prevent that happens before the tracker finishing its cleanup job with the corresponding service,

--- a/libs/utils/include/celix_build_assert.h
+++ b/libs/utils/include/celix_build_assert.h
@@ -17,10 +17,10 @@
  * under the License.
  */
 
-#ifndef CELIX_CELIX_BUILD_ASSERT_H
-#define CELIX_CELIX_BUILD_ASSERT_H
+#ifndef CELIX_BUILD_ASSERT_H
+#define CELIX_BUILD_ASSERT_H
 
-#define BUILD_ASSERT(cond) \
+#define CELIX_BUILD_ASSERT(cond) \
     do { (void) sizeof(char [1 - 2*!(cond)]); } while(0)
 
-#endif //CELIX_CELIX_BUILD_ASSERT_H
+#endif //CELIX_BUILD_ASSERT_H

--- a/libs/utils/include/celix_build_assert.h
+++ b/libs/utils/include/celix_build_assert.h
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef CELIX_CELIX_BUILD_ASSERT_H
+#define CELIX_CELIX_BUILD_ASSERT_H
+
+#define BUILD_ASSERT(cond) \
+    do { (void) sizeof(char [1 - 2*!(cond)]); } while(0)
+
+#endif //CELIX_CELIX_BUILD_ASSERT_H

--- a/libs/utils/include/celix_ref.h
+++ b/libs/utils/include/celix_ref.h
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef CELIX_CELIX_REF_H
+#define CELIX_CELIX_REF_H
+
+#include <stdatomic.h>
+#include <limits.h>
+#include <assert.h>
+
+struct celix_ref {
+    atomic_int count;
+};
+
+static inline void celix_ref_init(struct celix_ref *ref) {
+    ref->count = 1;
+}
+
+static inline void celix_ref_get(struct celix_ref *ref) {
+    int val;
+    val = atomic_fetch_add_explicit(&(ref->count), 1, memory_order_relaxed);
+    assert(val < INT_MAX && val > 0);
+    (void)val;
+}
+
+static inline int celix_ref_put(struct celix_ref *ref, void (*release)(struct celix_ref *ref)) {
+    int val;
+    val = atomic_fetch_sub_explicit(&(ref->count), 1, memory_order_release);
+    if(val == 1) {
+        atomic_thread_fence(memory_order_acquire);
+        release(ref);
+        return 1;
+    }
+    assert(val > 0);
+    return 0;
+}
+
+#endif //CELIX_CELIX_REF_H

--- a/libs/utils/include/celix_ref.h
+++ b/libs/utils/include/celix_ref.h
@@ -20,30 +20,57 @@
 #ifndef CELIX_CELIX_REF_H
 #define CELIX_CELIX_REF_H
 
-#include <stdatomic.h>
 #include <limits.h>
 #include <assert.h>
 
 struct celix_ref {
-    atomic_int count;
+    int count;
 };
 
+/**
+ * @brief Initialize object.
+ * @param ref object in question.
+ */
 static inline void celix_ref_init(struct celix_ref *ref) {
     ref->count = 1;
 }
 
+/**
+ * @brief Read reference count for object.
+ * @param ref object.
+ * @return the current reference count.
+ */
+static inline int celix_ref_read(const struct celix_ref *ref)
+{
+    return __atomic_load_n(&ref->count, __ATOMIC_RELAXED);
+}
+
+/**
+ * @brief Increase reference count for object.
+ * @param ref object.
+ */
 static inline void celix_ref_get(struct celix_ref *ref) {
     int val;
-    val = atomic_fetch_add_explicit(&(ref->count), 1, memory_order_relaxed);
+    val = __atomic_fetch_add(&(ref->count), 1, __ATOMIC_RELAXED);
     assert(val < INT_MAX && val > 0);
     (void)val;
 }
 
+ /**
+  * @brief Decrease reference count for object.
+  *
+  * Decrement the reference count, and if 0, call release().
+  *
+  * @param ref object.
+  * @param release pointer to the function that will clean up the object when the
+  * last reference to the object is released.
+  * @return 1 if the object was removed, otherwise return 0.
+  */
 static inline int celix_ref_put(struct celix_ref *ref, void (*release)(struct celix_ref *ref)) {
     int val;
-    val = atomic_fetch_sub_explicit(&(ref->count), 1, memory_order_release);
+    val = __atomic_fetch_sub(&(ref->count), 1, __ATOMIC_RELEASE);
     if(val == 1) {
-        atomic_thread_fence(memory_order_acquire);
+        __atomic_thread_fence(__ATOMIC_ACQUIRE);
         release(ref);
         return 1;
     }

--- a/libs/utils/src/array_list.c
+++ b/libs/utils/src/array_list.c
@@ -31,6 +31,7 @@
 #include "array_list.h"
 #include "celix_array_list.h"
 #include "array_list_private.h"
+#include "celix_build_assert.h"
 
 static celix_status_t arrayList_elementEquals(const void *a, const void *b, bool *equals);
 static bool celix_arrayList_defaultEquals(const celix_array_list_entry_t a, const celix_array_list_entry_t b);
@@ -60,7 +61,8 @@ static celix_status_t arrayList_elementEquals(const void *a, const void *b, bool
 }
 
 static bool celix_arrayList_defaultEquals(celix_array_list_entry_t a, celix_array_list_entry_t b) {
-    return a.longVal == b.longVal; //just compare as long int
+    BUILD_ASSERT(sizeof(a.voidPtrVal) == sizeof(a));
+    return a.voidPtrVal== b.voidPtrVal;
 }
 
 static bool celix_arrayList_equalsForElement(celix_array_list_t *list, celix_array_list_entry_t a, celix_array_list_entry_t b) {
@@ -495,7 +497,7 @@ void celix_arrayList_removeEntry(celix_array_list_t *list, celix_array_list_entr
 
 void celix_arrayList_remove(celix_array_list_t *list, void *ptr) {
     celix_array_list_entry_t entry;
-        memset(&entry, 0, sizeof(entry));
+    memset(&entry, 0, sizeof(entry));
     entry.voidPtrVal = ptr;
     celix_arrayList_removeEntry(list, entry);
 }

--- a/libs/utils/src/array_list.c
+++ b/libs/utils/src/array_list.c
@@ -61,7 +61,7 @@ static celix_status_t arrayList_elementEquals(const void *a, const void *b, bool
 }
 
 static bool celix_arrayList_defaultEquals(celix_array_list_entry_t a, celix_array_list_entry_t b) {
-    BUILD_ASSERT(sizeof(a.voidPtrVal) == sizeof(a));
+    CELIX_BUILD_ASSERT(sizeof(a.voidPtrVal) == sizeof(a));
     return a.voidPtrVal== b.voidPtrVal;
 }
 


### PR DESCRIPTION
As mentioned in https://github.com/apache/celix/pull/376#issuecomment-965961677, I'm trying to improve the performance of ServiceTracker.  Before the real work done, I must familiarize myself of the code base. Along the way, I do some code cleanup and bug fixes.  Some worth noting:

- buggy default array_list equality implementation. To avoid this kind of bugs forever, I add compile time assert (static assert in modern C++).
- wrong bundle ID in service tracker callbacks.
- #390 