### PR TITLE
Fixes an issue where the C++ meta tracker with RSA crashes

### DIFF
--- a/bundles/remote_services/topology_manager/src/activator.c
+++ b/bundles/remote_services/topology_manager/src/activator.c
@@ -150,7 +150,7 @@ static celix_status_t bundleActivator_createExportedServicesTracker(struct activ
     service_tracker_customizer_t *customizer = NULL;
     status = serviceTrackerCustomizer_create(activator->manager, NULL, topologyManager_addExportedService, NULL, topologyManager_removeExportedService, &customizer);
     if (status == CELIX_SUCCESS) {
-        status = serviceTracker_createWithFilter(activator->context, "(service.exported.interfaces=*)", customizer, tracker);
+        status = serviceTracker_createWithFilter(activator->context, "(&(objectClass=*)(service.exported.interfaces=*))", customizer, tracker);
     }
     return status;
 }

--- a/libs/framework/gtest/src/CxxBundleContextTestSuite.cc
+++ b/libs/framework/gtest/src/CxxBundleContextTestSuite.cc
@@ -21,10 +21,11 @@
 
 #include <atomic>
 
+#include "service_tracker.h"
 #include "celix/BundleContext.h"
-
 #include "celix_framework_factory.h"
 #include "celix_framework.h"
+#include "service_tracker_customizer.h"
 
 class CxxBundleContextTestSuite : public ::testing::Test {
 public:
@@ -718,4 +719,24 @@ TEST_F(CxxBundleContextTestSuite, RegisterServiceWithNameAndVersionInfo) {
             .build();
     EXPECT_EQ(reg->getServiceName(), "TestName");
     EXPECT_EQ(reg->getServiceVersion(), "1.2.3");
+}
+
+TEST_F(CxxBundleContextTestSuite, TestOldCStyleTrackerWithCxxMetaTracker) {
+    //rule: A old C style service tracker without an (objectClass=*) filter part, should not crash when combined with a C++ MetaTracker.
+
+    service_tracker_customizer_t *customizer = nullptr;
+    auto status = serviceTrackerCustomizer_create(this, nullptr, nullptr, nullptr, nullptr, &customizer);
+    ASSERT_EQ(status, CELIX_SUCCESS);
+    celix_service_tracker_t* tracker = nullptr;
+    status = serviceTracker_createWithFilter(ctx->getCBundleContext(), "(service.exported.interfaces=*)", customizer, &tracker);
+    ASSERT_EQ(status, CELIX_SUCCESS);
+    status = serviceTracker_open(tracker);
+    ASSERT_EQ(status, CELIX_SUCCESS);
+
+    auto metaTracker = ctx->trackAnyServiceTrackers().build();
+    ctx->waitForEvents();
+    EXPECT_EQ(metaTracker->getState(), celix::TrackerState::OPEN);
+
+    serviceTracker_close(tracker);
+    serviceTracker_destroy(tracker);
 }

--- a/libs/framework/include/celix/Trackers.h
+++ b/libs/framework/include/celix/Trackers.h
@@ -726,14 +726,16 @@ namespace celix {
                         static_cast<void*>(this),
                         [](void *handle, const celix_service_tracker_info_t *cInfo) {
                             auto *trk = static_cast<MetaTracker *>(handle);
-                            ServiceTrackerInfo info{cInfo->serviceName, celix::Filter::wrap(cInfo->filter), cInfo->bundleId};
+                            std::string svcName = cInfo->serviceName == nullptr ? "" : cInfo->serviceName;
+                            ServiceTrackerInfo info{svcName, celix::Filter::wrap(cInfo->filter), cInfo->bundleId};
                             for (const auto& cb : trk->onTrackerCreated) {
                                 cb(info);
                             }
                         },
                         [](void *handle, const celix_service_tracker_info_t *cInfo) {
                             auto *trk = static_cast<MetaTracker *>(handle);
-                            ServiceTrackerInfo info{cInfo->serviceName, celix::Filter::wrap(cInfo->filter), cInfo->bundleId};
+                            std::string svcName = cInfo->serviceName == nullptr ? "" : cInfo->serviceName;
+                            ServiceTrackerInfo info{svcName, celix::Filter::wrap(cInfo->filter), cInfo->bundleId};
                             for (const auto& cb : trk->onTrackerDestroyed) {
                                 cb(info);
                             }


### PR DESCRIPTION
The C++ meta tracker (service tracker tracker) resulted in a logical_error exception when a service tracker was started without a objectClass (service name) filter attribute.