### PR TITLE
Add .asf.yaml for Celix repo

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,0 +1,45 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# https://cwiki.apache.org/confluence/display/INFRA/git+-+.asf.yaml+features
+---
+github:
+  description: "Apache Celix - An implementation of the OSGi specification adapted to C and C++"
+  homepage: https://celix.apache.org/
+  labels:
+    - apache
+    - celix
+    - c
+    - cplusplus
+    - osgi
+
+  features:
+    # Enable the 'Issues' tab for the GitHub repo
+    issues: true
+    # Enable the 'Projects' tab for the GitHub repo
+    projects: true
+    # Disable the 'Wiki' tab for the GitHub repo
+    wiki: false
+
+  enabled_merge_buttons:
+    merge: true
+    squash: true
+    rebase: true
+
+  protected_branches:
+    master: {}
+

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -41,5 +41,9 @@ github:
     rebase: true
 
   protected_branches:
-    master: {}
+    master:
+      required_pull_request_reviews:
+        dismiss_stale_reviews: false
+        require_code_owner_reviews: false
+        required_approving_review_count: 0
 


### PR DESCRIPTION
This adds an [.asf.yaml](https://cwiki.apache.org/confluence/display/INFRA/git+-+.asf.yaml+features) file for the Celix repo, mainly to have clear which settings/permissions/features we have enabled.
This contains the current settings for the celix repo, except the description and the labels, which I updated while creating the file.

The branch protection settings allow to have settings specified more extensively (see [the available settings](https://cwiki.apache.org/confluence/display/INFRA/git+-+.asf.yaml+features#Git.asf.yamlfeatures-BranchProtection)). What this pull request contains is what is currently in place for celix: branch protection of the `master` branch to prevent force pushes.

One thing that other repos often have additionally enabled in their branch_protection settings is `required_pull_request_reviews`:
```yaml
protected_branches:
  master:
    # When enabled, all commits must be made to a non-protected branch and submitted
    # via a pull request before they can be merged into a branch that matches this rule.
    required_pull_request_reviews:
      # Additional optional setting:
      #   When enabled, pull requests targeting a matching branch require a number
      #   of approvals and no changes requested before they can be merged. 
      required_approving_review_count: 1
```

I think the `required_pull_request_reviews` might be useful, to at least protect ourselves against not accidentally committing to the `master` branch (I always double check on which branch I am before pushing something, but it is easy to forget).

I don't think the `required_approving_review_count` is necessary for Celix, but i am interested on your opinions as well @pnoltes and @abroekhuis.