### PR TITLE
Another tracker improvements preliminary

### DIFF
--- a/libs/framework/include/service_registry.h
+++ b/libs/framework/include/service_registry.h
@@ -69,18 +69,7 @@ serviceRegistry_getServiceReferences(service_registry_pt registry, celix_bundle_
                                      filter_pt filter, celix_array_list_t **references);
 
 celix_status_t
-serviceRegistry_retainServiceReference(service_registry_pt registry, celix_bundle_t *bundle, service_reference_pt reference);
-
-celix_status_t
 serviceRegistry_ungetServiceReference(service_registry_pt registry, celix_bundle_t *bundle, service_reference_pt reference);
-
-celix_status_t
-serviceRegistry_getService(service_registry_pt registry, celix_bundle_t *bundle, service_reference_pt reference,
-                           const void **service);
-
-celix_status_t
-serviceRegistry_ungetService(service_registry_pt registry, celix_bundle_t *bundle, service_reference_pt reference,
-                             bool *result);
 
 celix_status_t serviceRegistry_clearReferencesFor(service_registry_pt registry, celix_bundle_t *bundle);
 

--- a/libs/framework/src/framework.c
+++ b/libs/framework/src/framework.c
@@ -1001,10 +1001,6 @@ celix_status_t framework_ungetServiceReference(framework_pt framework, bundle_pt
     return serviceRegistry_ungetServiceReference(framework->registry, bundle, reference);
 }
 
-celix_status_t fw_getService(framework_pt framework, bundle_pt bundle, service_reference_pt reference, const void **service) {
-	return serviceRegistry_getService(framework->registry, bundle, reference, service);
-}
-
 celix_status_t fw_getBundleRegisteredServices(framework_pt framework, bundle_pt bundle, array_list_pt *services) {
 	return serviceRegistry_getRegisteredServices(framework->registry, bundle, services);
 }
@@ -1013,10 +1009,6 @@ celix_status_t fw_getBundleServicesInUse(framework_pt framework, bundle_pt bundl
 	celix_status_t status = CELIX_SUCCESS;
 	status = serviceRegistry_getServicesInUse(framework->registry, bundle, services);
 	return status;
-}
-
-celix_status_t framework_ungetService(framework_pt framework, bundle_pt bundle, service_reference_pt reference, bool *result) {
-	return serviceRegistry_ungetService(framework->registry, bundle, reference, result);
 }
 
 void fw_addServiceListener(framework_pt framework, bundle_pt bundle, celix_service_listener_t *listener, const char* sfilter) {

--- a/libs/framework/src/framework_private.h
+++ b/libs/framework/src/framework_private.h
@@ -188,8 +188,6 @@ FRAMEWORK_EXPORT void fw_unregisterService(service_registration_pt registration)
 
 FRAMEWORK_EXPORT celix_status_t fw_getServiceReferences(framework_pt framework, array_list_pt *references, bundle_pt bundle, const char* serviceName, const char* filter);
 FRAMEWORK_EXPORT celix_status_t framework_ungetServiceReference(framework_pt framework, bundle_pt bundle, service_reference_pt reference);
-FRAMEWORK_EXPORT celix_status_t fw_getService(framework_pt framework, bundle_pt bundle, service_reference_pt reference, const void** service);
-FRAMEWORK_EXPORT celix_status_t framework_ungetService(framework_pt framework, bundle_pt bundle, service_reference_pt reference, bool *result);
 FRAMEWORK_EXPORT celix_status_t fw_getBundleRegisteredServices(framework_pt framework, bundle_pt bundle, array_list_pt *services);
 FRAMEWORK_EXPORT celix_status_t fw_getBundleServicesInUse(framework_pt framework, bundle_pt bundle, array_list_pt *services);
 

--- a/libs/framework/src/service_reference.c
+++ b/libs/framework/src/service_reference.c
@@ -39,7 +39,6 @@
 
 static void serviceReference_doRelease(struct celix_ref *);
 static void serviceReference_destroy(service_reference_pt);
-static void serviceReference_logWarningUsageCountBelowZero(service_reference_pt ref);
 
 celix_status_t serviceReference_create(registry_callback_t callback, bundle_pt referenceOwner, service_registration_pt registration,  service_reference_pt *out) {
 	celix_status_t status = CELIX_SUCCESS;
@@ -52,7 +51,7 @@ celix_status_t serviceReference_create(registry_callback_t callback, bundle_pt r
         ref->callback = callback;
 		ref->referenceOwner = referenceOwner;
 		ref->registration = registration;
-        ref->service = NULL;
+        ref->serviceCache = NULL;
         serviceRegistration_getBundle(registration, &ref->registrationBundle);
 		celixThreadRwlock_create(&ref->lock, NULL);
         ref->usageCount = 0;
@@ -85,48 +84,10 @@ celix_status_t serviceReference_release(service_reference_pt ref, bool *out) {
 static void serviceReference_doRelease(struct celix_ref *refCount) {
     service_reference_pt ref = (service_reference_pt)refCount;
     CELIX_BUILD_ASSERT(offsetof(struct serviceReference, refCount) == 0);
-    if(ref->registration != NULL) {
-        serviceRegistration_release(ref->registration);
-    }
+    serviceReference_invalidateCache(ref);
+    serviceRegistration_release(ref->registration);
     serviceReference_destroy(ref);
 }
-
-celix_status_t serviceReference_increaseUsage(service_reference_pt ref, size_t *out) {
-    //fw_log(logger, CELIX_LOG_LEVEL_DEBUG, "Destroying service reference %p\n", ref);
-    size_t local = 0;
-    celixThreadRwlock_writeLock(&ref->lock);
-    ref->usageCount += 1;
-    local = ref->usageCount;
-    celixThreadRwlock_unlock(&ref->lock);
-    if (out) {
-        *out = local;
-    }
-    return CELIX_SUCCESS;
-}
-
-celix_status_t serviceReference_decreaseUsage(service_reference_pt ref, size_t *out) {
-    celix_status_t status = CELIX_SUCCESS;
-    size_t localCount = 0;
-    celixThreadRwlock_writeLock(&ref->lock);
-    if (ref->usageCount == 0) {
-        serviceReference_logWarningUsageCountBelowZero(ref);
-        status = CELIX_BUNDLE_EXCEPTION;
-    } else {
-        ref->usageCount -= 1;
-    }
-    localCount = ref->usageCount;
-    celixThreadRwlock_unlock(&ref->lock);
-
-    if (out) {
-        *out = localCount;
-    }
-    return status;
-}
-
-static void serviceReference_logWarningUsageCountBelowZero(service_reference_pt ref __attribute__((unused))) {
-    fw_log(celix_frameworkLogger_globalLogger(), CELIX_LOG_LEVEL_WARNING, "Cannot decrease service usage count below 0\n");
-}
-
 
 celix_status_t serviceReference_getUsageCount(service_reference_pt ref, size_t *count) {
     celix_status_t status = CELIX_SUCCESS;
@@ -141,19 +102,39 @@ celix_status_t serviceReference_getReferenceCount(service_reference_pt ref, size
     return CELIX_SUCCESS;
 }
 
-celix_status_t serviceReference_getService(service_reference_pt ref, const void **service) {
+celix_status_t serviceReference_getService(service_reference_pt ref, const void **service)
+{
     celix_status_t status = CELIX_SUCCESS;
-    celixThreadRwlock_readLock(&ref->lock);
-    *service = ref->service;
+    celixThreadRwlock_writeLock(&ref->lock);
+    if(ref->usageCount == 0) {
+        assert(ref->serviceCache == NULL);
+        status  = serviceRegistration_getService(ref->registration, ref->referenceOwner, &ref->serviceCache);
+    }
+    if(status == CELIX_SUCCESS) {
+        ref->usageCount += 1;
+    }
+    *service = ref->serviceCache;
     celixThreadRwlock_unlock(&ref->lock);
     return status;
 }
 
-celix_status_t serviceReference_setService(service_reference_pt ref, const void *service) {
+celix_status_t serviceReference_ungetService(service_reference_pt ref, bool *result)
+{
     celix_status_t status = CELIX_SUCCESS;
     celixThreadRwlock_writeLock(&ref->lock);
-    ref->service = service;
+    if (ref->usageCount == 0) {
+        assert(ref->serviceCache == NULL);
+        fw_log(celix_frameworkLogger_globalLogger(), CELIX_LOG_LEVEL_WARNING, "Cannot decrease service usage count below 0\n");
+    } else {
+        ref->usageCount -= 1;
+    }
+    if(ref->usageCount == 0 && ref->serviceCache != NULL) {
+        status = serviceRegistration_ungetService(ref->registration, ref->referenceOwner, &ref->serviceCache);
+    }
     celixThreadRwlock_unlock(&ref->lock);
+    if(result != NULL) {
+        *result = (status == CELIX_SUCCESS);
+    }
     return status;
 }
 
@@ -210,13 +191,9 @@ serviceReference_getPropertyWithDefault(service_reference_pt ref, const char *ke
     celix_status_t status = CELIX_SUCCESS;
     properties_pt props = NULL;
     celixThreadRwlock_readLock(&ref->lock);
-    if (ref->registration != NULL) {
-        status = serviceRegistration_getProperties(ref->registration, &props);
-        if (status == CELIX_SUCCESS) {
-            *value = (char*) properties_getWithDefault(props, key, def);
-        }
-    } else {
-        *value = NULL;
+    status = serviceRegistration_getProperties(ref->registration, &props);
+    if (status == CELIX_SUCCESS) {
+        *value = (char*) properties_getWithDefault(props, key, def);
     }
     celixThreadRwlock_unlock(&ref->lock);
     return status;
@@ -247,26 +224,15 @@ FRAMEWORK_EXPORT celix_status_t serviceReference_getPropertyKeys(service_referen
     return status;
 }
 
-celix_status_t serviceReference_invalidate(service_reference_pt ref) {
-    assert(ref != NULL);
+celix_status_t serviceReference_invalidateCache(service_reference_pt reference) {
+    assert(reference != NULL);
     celix_status_t status = CELIX_SUCCESS;
-    service_registration_pt reg = NULL;
-    celixThreadRwlock_writeLock(&ref->lock);
-    reg = ref->registration;
-    ref->registration = NULL;
-    celixThreadRwlock_unlock(&ref->lock);
-
-    if (reg != NULL) {
-        serviceRegistration_release(reg);
+    celixThreadRwlock_writeLock(&reference->lock);
+    if(reference->serviceCache != NULL) {
+        status = serviceRegistration_ungetService(reference->registration, reference->referenceOwner, &reference->serviceCache);
     }
+    celixThreadRwlock_unlock(&reference->lock);
 	return status;
-}
-
-celix_status_t serviceReference_isValid(service_reference_pt ref, bool *result) {
-    celixThreadRwlock_readLock(&ref->lock);
-    (*result) = ref->registration != NULL;
-    celixThreadRwlock_unlock(&ref->lock);
-    return CELIX_SUCCESS;
 }
 
 bool serviceReference_isAssignableTo(service_reference_pt reference __attribute__((unused)), bundle_pt requester __attribute__((unused)), const char* serviceName __attribute__((unused))) {
@@ -363,21 +329,15 @@ celix_status_t serviceReference_getUsingBundles(service_reference_pt ref, array_
 
     celixThreadRwlock_readLock(&ref->lock);
     reg = ref->registration;
-    if (reg != NULL) {
-        serviceRegistration_retain(reg);
-        callback.handle = ref->callback.handle;
-        callback.getUsingBundles = ref->callback.getUsingBundles;
-    }
+    callback.handle = ref->callback.handle;
+    callback.getUsingBundles = ref->callback.getUsingBundles;
     celixThreadRwlock_unlock(&ref->lock);
 
-    if (reg != NULL) {
-        if (callback.getUsingBundles != NULL) {
-            status = callback.getUsingBundles(callback.handle, reg, out);
-        } else {
-            fw_log(celix_frameworkLogger_globalLogger(), CELIX_LOG_LEVEL_ERROR, "getUsingBundles callback not set");
-            status = CELIX_BUNDLE_EXCEPTION;
-        }
-        serviceRegistration_release(reg);
+    if (callback.getUsingBundles != NULL) {
+        status = callback.getUsingBundles(callback.handle, reg, out);
+    } else {
+        fw_log(celix_frameworkLogger_globalLogger(), CELIX_LOG_LEVEL_ERROR, "getUsingBundles callback not set");
+        status = CELIX_BUNDLE_EXCEPTION;
     }
 
     return status;

--- a/libs/framework/src/service_reference_private.h
+++ b/libs/framework/src/service_reference_private.h
@@ -36,9 +36,9 @@ struct serviceReference {
     struct celix_ref refCount;
     registry_callback_t callback;
 	bundle_pt referenceOwner;
-	struct serviceRegistration * registration;
+	struct serviceRegistration * registration; // this registration is always accessible within the reference, though the service embedded might be unregistered by its provider
     bundle_pt registrationBundle;
-    const void* service;
+    const void* serviceCache; // service instance cached by this reference
     size_t usageCount;
 
     celix_thread_rwlock_t lock;
@@ -49,17 +49,13 @@ celix_status_t serviceReference_create(registry_callback_t callback, bundle_pt r
 celix_status_t serviceReference_retain(service_reference_pt ref);
 celix_status_t serviceReference_release(service_reference_pt ref, bool *destroyed);
 
-celix_status_t serviceReference_increaseUsage(service_reference_pt ref, size_t *updatedCount);
-celix_status_t serviceReference_decreaseUsage(service_reference_pt ref, size_t *updatedCount);
-
-celix_status_t serviceReference_invalidate(service_reference_pt reference);
-celix_status_t serviceReference_isValid(service_reference_pt reference, bool *result);
+celix_status_t serviceReference_invalidateCache(service_reference_pt reference);
 
 celix_status_t serviceReference_getUsageCount(service_reference_pt reference, size_t *count);
 celix_status_t serviceReference_getReferenceCount(service_reference_pt reference, size_t *count);
 
-celix_status_t serviceReference_setService(service_reference_pt ref, const void *service);
-celix_status_t serviceReference_getService(service_reference_pt reference, const void **service);
+celix_status_t serviceReference_getService(service_reference_pt ref, const void **service);
+celix_status_t serviceReference_ungetService(service_reference_pt ref, bool *result);
 
 celix_status_t serviceReference_getOwner(service_reference_pt reference, bundle_pt *owner);
 

--- a/libs/framework/src/service_registry.c
+++ b/libs/framework/src/service_registry.c
@@ -82,7 +82,7 @@ celix_status_t serviceRegistry_create(framework_pt framework, service_registry_p
 	if (status == CELIX_SUCCESS) {
 		*out = reg;
 	} else {
-		framework_logIfError(reg->framework->logger, status, NULL, "Cannot create service registry");
+		framework_logIfError(framework->logger, status, NULL, "Cannot create service registry");
 	}
 
 	return status;
@@ -277,13 +277,12 @@ celix_status_t serviceRegistry_unregisterService(service_registry_pt registry, b
         service_reference_pt ref = refsMap != NULL ?
                                    hashMap_get(refsMap, (void*)registration->serviceId) : NULL;
         if (ref != NULL) {
-            serviceReference_invalidate(ref);
+            serviceReference_invalidateCache(ref);
         }
     }
     hashMapIterator_destroy(iter);
+    serviceRegistration_invalidate(registration);
 	celixThreadRwlock_unlock(&registry->lock);
-
-	serviceRegistration_invalidate(registration);
     serviceRegistration_release(registration);
 
 	return CELIX_SUCCESS;
@@ -305,7 +304,6 @@ static celix_status_t serviceRegistry_getServiceReference_internal(service_regis
                                                    service_registration_pt registration, service_reference_pt *out) {
 	//only call after locked registry RWlock
 	celix_status_t status = CELIX_SUCCESS;
-	bundle_pt bundle = NULL;
     service_reference_pt ref = NULL;
     hash_map_pt references = NULL;
 
@@ -318,10 +316,7 @@ static celix_status_t serviceRegistry_getServiceReference_internal(service_regis
     ref = hashMap_get(references, (void*)registration->serviceId);
 
     if (ref == NULL) {
-        status = serviceRegistration_getBundle(registration, &bundle);
-        if (status == CELIX_SUCCESS) {
-            status = serviceReference_create(registry->callback, owner, registration, &ref);
-        }
+        status = serviceReference_create(registry->callback, owner, registration, &ref);
         if (status == CELIX_SUCCESS) {
             hashMap_put(references, (void*)registration->serviceId, ref);
         }
@@ -422,33 +417,15 @@ celix_status_t serviceRegistry_getServiceReferences(service_registry_pt registry
 	return status;
 }
 
-celix_status_t serviceRegistry_retainServiceReference(service_registry_pt registry, bundle_pt bundle, service_reference_pt reference) {
-    celix_status_t status = CELIX_SUCCESS;
-    bundle_pt refBundle = NULL;
-    
-    celixThreadRwlock_writeLock(&registry->lock);
-    serviceReference_getOwner(reference, &refBundle);
-    if (refBundle == bundle) {
-        serviceReference_retain(reference);
-    } else {
-        status = CELIX_ILLEGAL_ARGUMENT;
-        fw_log(registry->framework->logger, CELIX_LOG_LEVEL_ERROR, "cannot retain a service reference from an other bundle (in ref %p) (provided %p).", refBundle, bundle);
-    }
-    celixThreadRwlock_unlock(&registry->lock);
-
-    return status;
-}
-
-
 celix_status_t serviceRegistry_ungetServiceReference(service_registry_pt registry, bundle_pt bundle, service_reference_pt reference) {
     celix_status_t status = CELIX_SUCCESS;
     bool destroyed = false;
     size_t count = 0;
 
-    celixThreadRwlock_writeLock(&registry->lock);
     serviceReference_getUsageCount(reference, &count);
     serviceReference_release(reference, &destroyed);
     if (destroyed) {
+        celixThreadRwlock_writeLock(&registry->lock);
 
         if (count > 0) {
             serviceRegistry_logWarningServiceReferenceUsageCount(registry, bundle, reference, count, 0);
@@ -486,8 +463,8 @@ celix_status_t serviceRegistry_ungetServiceReference(service_registry_pt registr
             fw_log(registry->framework->logger, CELIX_LOG_LEVEL_FATAL, "Cannot find reference %p in serviceReferences map",
                    reference);
         }
+        celixThreadRwlock_unlock(&registry->lock);
     }
-    celixThreadRwlock_unlock(&registry->lock);
 
     return status;
 }
@@ -539,10 +516,6 @@ celix_status_t serviceRegistry_clearReferencesFor(service_registry_pt registry, 
             serviceReference_getReferenceCount(ref, &refCount);
             serviceRegistry_logWarningServiceReferenceUsageCount(registry, bundle, ref, usageCount, refCount);
 
-            while (usageCount > 0) {
-                serviceReference_decreaseUsage(ref, &usageCount);
-            }
-
             bool destroyed = false;
             while (!destroyed) {
                 serviceReference_release(ref, &destroyed);
@@ -583,58 +556,6 @@ celix_status_t serviceRegistry_getServicesInUse(service_registry_pt registry, bu
     *out = result;
 
 	return CELIX_SUCCESS;
-}
-
-celix_status_t serviceRegistry_getService(service_registry_pt registry, bundle_pt bundle, service_reference_pt reference, const void **out) {
-	celix_status_t status = CELIX_SUCCESS;
-	service_registration_pt registration = NULL;
-    size_t count = 0;
-    const void *service = NULL;
-    bool valid = false;
-
-
-    celixThreadRwlock_readLock(&registry->lock);
-    serviceReference_getServiceRegistration(reference, &registration);
-    valid = serviceRegistration_isValid(registration);
-    if (valid) {
-        serviceRegistration_retain(registration);
-        serviceReference_increaseUsage(reference, &count);
-        if (count == 1) {
-            serviceRegistration_getService(registration, bundle, &service);
-            serviceReference_setService(reference, service);
-        }
-    }
-    celixThreadRwlock_unlock(&registry->lock);
-    if(!valid) {
-        *out = NULL;
-        return status;
-    }
-
-    serviceRegistration_release(registration);
-
-    serviceReference_getService(reference, out);
-
-	return status;
-}
-
-celix_status_t serviceRegistry_ungetService(service_registry_pt registry, bundle_pt bundle, service_reference_pt reference, bool *result) {
-    service_registration_pt reg = NULL;
-    const void *service = NULL;
-    size_t count = 0;
-
-    celixThreadRwlock_readLock(&registry->lock);
-    celixThreadRwlock_unlock(&registry->lock);
-
-    celix_status_t status = serviceReference_decreaseUsage(reference, &count);
-    if (count == 0) {
-        serviceReference_getService(reference, &service);
-        serviceReference_getServiceRegistration(reference, &reg);
-        if (reg != NULL) {
-            serviceRegistration_ungetService(reg, bundle, &service);
-        }
-    }
-
-	return status;
 }
 
 static celix_status_t serviceRegistry_addHooks(service_registry_pt registry, const char* serviceName, const void* serviceObject, service_registration_pt registration) {
@@ -1100,7 +1021,6 @@ celix_status_t celix_serviceRegistry_addServiceListener(celix_service_registry_t
             properties_pt props = NULL;
             serviceRegistration_getProperties(registration, &props);
             if (celix_filter_match(filter, props)) {
-                serviceRegistration_retain(registration);
                 long svcId = serviceRegistration_getServiceId(registration);
                 service_reference_pt ref = NULL;
                 serviceRegistry_getServiceReference_internal(registry, bundle, registration, &ref);
@@ -1124,12 +1044,7 @@ celix_status_t celix_serviceRegistry_addServiceListener(celix_service_registry_t
         event.reference = ref;
         event.type = OSGI_FRAMEWORK_SERVICE_EVENT_REGISTERED;
         listener->serviceChanged(listener->handle, &event);
-        serviceReference_release(ref, NULL);
-
-        service_registration_t* reg = NULL;
-        serviceReference_getServiceRegistration(ref, &reg);
-        serviceRegistration_release(reg);
-
+        serviceRegistry_ungetServiceReference(registry, bundle, ref);
         //update pending register event count
         celix_decreasePendingRegisteredEvent(registry, svcId);
     }

--- a/libs/framework/src/service_tracker.c
+++ b/libs/framework/src/service_tracker.c
@@ -418,7 +418,9 @@ static celix_status_t serviceTracker_track(service_tracker_t* tracker, service_r
                                                               serviceTracker_checkAndInvokeSetService);
             }
             serviceTracker_invokeAddService(tracker, tracked);
-        } //FIXME: bundleContext_ungetServiceReference for error condition(if any)
+        } else {
+            bundleContext_ungetServiceReference(tracker->context, reference);
+        }
     } else {
         bundleContext_ungetServiceReference(tracker->context, reference);
     }


### PR DESCRIPTION
1. Simplify  implementation of serviceReference by establishing a new class invariant for serviceReference: the registration is always accessible during the containing reference's lifetime, though the service object within the registration might be unregistered.
2. Emphasize that serviceReference is only valid within its owner's Bundle Context.
3. Fix bugs in corner cases (see inline comments, to be added later).

