### PR TITLE
Fix a first-check-then-do race condition during framework shutdown.

### DIFF
--- a/libs/framework/src/framework.c
+++ b/libs/framework/src/framework.c
@@ -1591,7 +1591,7 @@ static inline bool fw_removeTopEventFromQueue(celix_framework_t* fw) {
 static inline void fw_handleEvents(celix_framework_t* framework) {
     celixThreadMutex_lock(&framework->dispatcher.mutex);
     int size = framework->dispatcher.eventQueueSize + celix_arrayList_size(framework->dispatcher.dynamicEventQueue);
-    if (size == 0) {
+    if (size == 0 && framework->dispatcher.active) {
         celixThreadCondition_timedwaitRelative(&framework->dispatcher.cond, &framework->dispatcher.mutex, 1, 0);
     }
     size = framework->dispatcher.eventQueueSize + celix_arrayList_size(framework->dispatcher.dynamicEventQueue);


### PR DESCRIPTION
```C
static void *fw_eventDispatcher(void *fw) {
    framework_pt framework = (framework_pt) fw;

    celixThreadMutex_lock(&framework->dispatcher.mutex);
    bool active = framework->dispatcher.active;
    celixThreadMutex_unlock(&framework->dispatcher.mutex);

    while (active) { //first check active then handle events
        fw_handleEvents(framework);
        celixThreadMutex_lock(&framework->dispatcher.mutex);
        active = framework->dispatcher.active;
        celixThreadMutex_unlock(&framework->dispatcher.mutex);
    }
    //omitted
}
```

If shell_cmd happens to shutdown the framework during this first-check-then-do race window, unnecessary 1 second delay follows. 
