### PR TITLE
make the  listening ip of RSA  configurable

### DIFF
--- a/bundles/remote_services/discovery_common/include/discovery.h
+++ b/bundles/remote_services/discovery_common/include/discovery.h
@@ -46,6 +46,20 @@
 #define DISCOVERY_POLL_ENDPOINTS    "DISCOVERY_CFG_POLL_ENDPOINTS"
 #define DISCOVERY_SERVER_MAX_EP     "DISCOVERY_CFG_SERVER_MAX_EP"
 
+/**
+ * @brief It indicate that is discovery server reach-able from all network interfaces.
+ * @details If set false, discovery server bind to the IP address configured by the user.
+ * If set true, discovery server bind to 0.0.0.0.
+ * The property is of the type boolean and the default is true
+ */
+#define CELIX_DISCOVERY_BIND_ON_ALL_INTERFACES "CELIX_DISCOVERY_BIND_ON_ALL_INTERFACES"
+
+/**
+ * @brief Default value for the property CELIX_DISCOVERY_BIND_ON_ALL_INTERFACES
+ */
+#define CELIX_DISCOVERY_BIND_ON_ALL_INTERFACES_DEFAULT true
+
+
 struct discovery {
     celix_bundle_context_t *context;
 

--- a/bundles/remote_services/discovery_common/src/endpoint_discovery_server.c
+++ b/bundles/remote_services/discovery_common/src/endpoint_discovery_server.c
@@ -163,11 +163,13 @@ celix_status_t endpointDiscoveryServer_create(discovery_t *discovery,
     char newPort[10];
 
     do {
+        char listeningPorts[50]={0};
         const char *options[] = {
-                "listening_ports", port,
+                "listening_ports", listeningPorts,
                 "num_threads", DEFAULT_SERVER_THREADS,
                 NULL
         };
+        snprintf(listeningPorts,sizeof(listeningPorts),"%s:%s",(*server)->ip, port);
 
         (*server)->ctx = mg_start(&callbacks, (*server), options);
 

--- a/bundles/remote_services/discovery_etcd/src/etcd_watcher.c
+++ b/bundles/remote_services/discovery_etcd/src/etcd_watcher.c
@@ -134,7 +134,7 @@ static celix_status_t etcdWatcher_addAlreadyExistingWatchpoints(etcd_watcher_t *
 static celix_status_t etcdWatcher_addOwnFramework(etcd_watcher_t *watcher)
 {
     char localNodePath[MAX_LOCALNODE_LENGTH];
-    char *value=NULL;
+    char *value = NULL;
  	char url[MAX_VALUE_LENGTH];
     int modIndex;
     char* endpoints = NULL;

--- a/bundles/remote_services/discovery_etcd/src/etcd_watcher.c
+++ b/bundles/remote_services/discovery_etcd/src/etcd_watcher.c
@@ -134,7 +134,7 @@ static celix_status_t etcdWatcher_addAlreadyExistingWatchpoints(etcd_watcher_t *
 static celix_status_t etcdWatcher_addOwnFramework(etcd_watcher_t *watcher)
 {
     char localNodePath[MAX_LOCALNODE_LENGTH];
-    char *value;
+    char *value=NULL;
  	char url[MAX_VALUE_LENGTH];
     int modIndex;
     char* endpoints = NULL;

--- a/bundles/remote_services/remote_service_admin_dfi/src/remote_service_admin_dfi.c
+++ b/bundles/remote_services/remote_service_admin_dfi/src/remote_service_admin_dfi.c
@@ -256,21 +256,30 @@ celix_status_t remoteServiceAdmin_create(celix_bundle_context_t *context, remote
         snprintf(newPort, 10, "%li", port);
 
         unsigned int port_counter = 0;
+        bool bindToAllInterfaces = celix_bundleContext_getPropertyAsBool(context, CELIX_RSA_BIND_ON_ALL_INTERFACES, CELIX_RSA_BIND_ON_ALL_INTERFACES_DEFAULT);
         do {
-            char listeningPorts[50]={0};
+            char *listeningPorts = NULL;
+            if (bindToAllInterfaces) {
+                asprintf(&listeningPorts,"0.0.0.0:%s", newPort);
+            } else {
+                asprintf(&listeningPorts,"%s:%s", (*admin)->ip, newPort);
+            }
+
             const char *options[] = { "listening_ports", listeningPorts, "num_threads", "5", NULL};
-            snprintf(listeningPorts,sizeof(listeningPorts),"%s:%s",(*admin)->ip, newPort);
 
             (*admin)->ctx = mg_start(&callbacks, (*admin), options);
 
             if ((*admin)->ctx != NULL) {
-                celix_logHelper_log((*admin)->loghelper, CELIX_LOG_LEVEL_INFO, "RSA: Start webserver: %s", newPort);
+                celix_logHelper_log((*admin)->loghelper, CELIX_LOG_LEVEL_INFO, "RSA: Start webserver: %s", listeningPorts);
                 (*admin)->port = strdup(newPort);
 
             } else {
                 celix_logHelper_log((*admin)->loghelper, CELIX_LOG_LEVEL_ERROR, "Error while starting rsa server on port %s - retrying on port %li...", newPort, port + port_counter);
                 snprintf(newPort, 10,  "%li", port + port_counter++);
             }
+
+            free(listeningPorts);
+
         } while (((*admin)->ctx == NULL) && (port_counter < MAX_NUMBER_OF_RESTARTS));
 
     }

--- a/bundles/remote_services/remote_service_admin_dfi/src/remote_service_admin_dfi.c
+++ b/bundles/remote_services/remote_service_admin_dfi/src/remote_service_admin_dfi.c
@@ -257,8 +257,9 @@ celix_status_t remoteServiceAdmin_create(celix_bundle_context_t *context, remote
 
         unsigned int port_counter = 0;
         do {
-
-            const char *options[] = { "listening_ports", newPort, "num_threads", "5", NULL};
+            char listeningPorts[50]={0};
+            const char *options[] = { "listening_ports", listeningPorts, "num_threads", "5", NULL};
+            snprintf(listeningPorts,sizeof(listeningPorts),"%s:%s",(*admin)->ip, newPort);
 
             (*admin)->ctx = mg_start(&callbacks, (*admin), options);
 

--- a/bundles/remote_services/remote_service_admin_dfi/src/remote_service_admin_dfi_constants.h
+++ b/bundles/remote_services/remote_service_admin_dfi/src/remote_service_admin_dfi_constants.h
@@ -52,4 +52,18 @@
  */
 #define RSA_DFI_USE_CURL_SHARE_HANDLE_DEFAULT   false
 
+/**
+ * @brief It indicate that is RSA server reach-able from all network interfaces.
+ * @details If set false, RSA server bind to the IP address configured by the user.
+ * If set true, RSA server bind to 0.0.0.0.
+ * The property is of the type boolean and the default is true
+ */
+#define CELIX_RSA_BIND_ON_ALL_INTERFACES "CELIX_RSA_BIND_ON_ALL_INTERFACES"
+
+/**
+ * @brief Default value for the property CELIX_RSA_BIND_ON_ALL_INTERFACES
+ */
+#define CELIX_RSA_BIND_ON_ALL_INTERFACES_DEFAULT true
+
+
 #endif //CELIX_REMOTE_SERVICE_ADMIN_DFI_CONSTANTS_H


### PR DESCRIPTION
Currently, the default LISTENING IP  of RSA is 0.0.0.0. Could I start the server based on the configured IP.