### PR TITLE
Updates conanfile.py and jansson linking for macos setup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,6 +57,15 @@ if (NOT TARGET CURL::libcurl)
             )
 endif ()
 
+if (NOT TARGET jansson::jansson)
+    message("Note jansson::jansson target not created by find_package(Jansson). Creating jansson::jansson Target.")
+    add_library(jansson::jansson SHARED IMPORTED)
+    set_target_properties(jansson::jansson PROPERTIES
+            IMPORTED_LOCATION "${JANSSON_LIBRARIES}"
+            INTERFACE_INCLUDE_DIRECTORIES "${JANSSON_INCLUDE_DIRS}"
+            )
+endif ()
+
 # see https://public.kitware.com/Bug/view.php?id=15696
 IF (${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION} EQUAL 3.3 AND ${CMAKE_GENERATOR} STREQUAL "Unix Makefiles")
     message( FATAL_ERROR "Building Celix using CMake 3.3 and makefiles is not supported due to a bug in the Makefile Generator (see Bug 15696). Please change the used CMake version - both, CMake 3.2 and CMake 3.4 are working fine. Or use a different generator (e.g. Ninja)." )

--- a/bundles/pubsub/examples/CMakeLists.txt
+++ b/bundles/pubsub/examples/CMakeLists.txt
@@ -24,7 +24,7 @@ if (PUBSUB_EXAMPLES)
 
     find_package(Jansson REQUIRED)
 
-    set(PUBSUB_CONTAINER_LIBS Jansson Celix::dfi)
+    set(PUBSUB_CONTAINER_LIBS jansson::jansson Celix::dfi)
 
     # UDP Multicast
     if (BUILD_PUBSUB_PSA_UDP_MC)

--- a/bundles/pubsub/integration/CMakeLists.txt
+++ b/bundles/pubsub/integration/CMakeLists.txt
@@ -153,7 +153,7 @@ if (PUBSUB_INTEGRATION)
                 pubsub_sut
                 pubsub_tst
                 )
-        target_link_libraries(pubsub_udpmc_tests PRIVATE Celix::pubsub_api Jansson Celix::dfi GTest::gtest GTest::gtest_main)
+        target_link_libraries(pubsub_udpmc_tests PRIVATE Celix::pubsub_api jansson::jansson Celix::dfi GTest::gtest GTest::gtest_main)
         target_include_directories(pubsub_udpmc_tests SYSTEM PRIVATE gtest)
 
         add_celix_container(pstm_deadlock_udpmc_test
@@ -172,7 +172,7 @@ if (PUBSUB_INTEGRATION)
                 Celix::shell_tui
                 )
         target_compile_definitions(pstm_deadlock_udpmc_test PRIVATE -DDEADLOCK_SUT_BUNDLE_FILE=\"${DEADLOCK_SUT_BUNDLE_FILE}\")
-        target_link_libraries(pstm_deadlock_udpmc_test PRIVATE Celix::pubsub_api Jansson Celix::dfi GTest::gtest GTest::gtest_main)
+        target_link_libraries(pstm_deadlock_udpmc_test PRIVATE Celix::pubsub_api jansson::jansson Celix::dfi GTest::gtest GTest::gtest_main)
         target_include_directories(pstm_deadlock_udpmc_test SYSTEM PRIVATE pstm_deadlock_udpmc_test)
 
         add_celix_bundle_dependencies(pstm_deadlock_udpmc_test pubsub_deadlock_sut)
@@ -339,7 +339,7 @@ if (PUBSUB_INTEGRATION)
                 pubsub_tst
                 pubsub_serializer
                 )
-        target_link_libraries(pubsub_websocket_v2_tests PRIVATE Celix::pubsub_api Jansson civetweb_shared GTest::gtest GTest::gtest_main)
+        target_link_libraries(pubsub_websocket_v2_tests PRIVATE Celix::pubsub_api jansson::jansson civetweb_shared GTest::gtest GTest::gtest_main)
         target_include_directories(pubsub_websocket_v2_tests SYSTEM PRIVATE gtest)
         add_test(NAME pubsub_websocket_v2_tests COMMAND pubsub_websocket_v2_tests WORKING_DIRECTORY $<TARGET_PROPERTY:pubsub_websocket_v2_tests,CONTAINER_LOC>)
         setup_target_for_coverage(pubsub_websocket_v2_tests SCAN_DIR ..)
@@ -361,7 +361,7 @@ if (PUBSUB_INTEGRATION)
                 pubsub_serializer
                 )
         target_compile_definitions(pstm_deadlock_websocket_v2_test PRIVATE -DDEADLOCK_SUT_BUNDLE_FILE=\"${DEADLOCK_SUT_BUNDLE_FILE}\")
-        target_link_libraries(pstm_deadlock_websocket_v2_test PRIVATE Celix::pubsub_api GTest::gtest GTest::gtest_main Jansson Celix::dfi civetweb_shared)
+        target_link_libraries(pstm_deadlock_websocket_v2_test PRIVATE Celix::pubsub_api GTest::gtest GTest::gtest_main jansson::jansson Celix::dfi civetweb_shared)
         target_include_directories(pstm_deadlock_websocket_v2_test SYSTEM PRIVATE pstm_deadlock_websocket_v2_test)
 
         #Note we do not link to bundles, as result (to ensure a bundle zip file is created) an dependency on the bundle is needed.

--- a/bundles/pubsub/pubsub_discovery/CMakeLists.txt
+++ b/bundles/pubsub/pubsub_discovery/CMakeLists.txt
@@ -32,7 +32,7 @@ if (PUBSUB_DISCOVERY_ETCD)
     target_link_libraries(celix_pubsub_discovery_etcd PRIVATE
             Celix::framework Celix::etcdlib_static
             Celix::shell_api Celix::log_helper
-            CURL::libcurl Jansson
+            CURL::libcurl jansson::jansson
             )
     target_link_libraries(celix_pubsub_discovery_etcd PRIVATE Celix::pubsub_spi Celix::pubsub_utils)
 

--- a/bundles/pubsub/pubsub_serializer_json/CMakeLists.txt
+++ b/bundles/pubsub/pubsub_serializer_json/CMakeLists.txt
@@ -31,7 +31,7 @@ target_include_directories(celix_pubsub_serializer_json PRIVATE
     src
 )
 set_target_properties(celix_pubsub_serializer_json PROPERTIES INSTALL_RPATH "$ORIGIN")
-target_link_libraries(celix_pubsub_serializer_json PRIVATE Celix::framework Celix::dfi Jansson Celix::log_helper)
+target_link_libraries(celix_pubsub_serializer_json PRIVATE Celix::framework Celix::dfi jansson::jansson Celix::log_helper)
 target_link_libraries(celix_pubsub_serializer_json PRIVATE Celix::pubsub_spi Celix::pubsub_utils)
 
 install_celix_bundle(celix_pubsub_serializer_json EXPORT celix COMPONENT pubsub)

--- a/bundles/remote_services/discovery_etcd/CMakeLists.txt
+++ b/bundles/remote_services/discovery_etcd/CMakeLists.txt
@@ -42,7 +42,7 @@ if (RSA_DISCOVERY_ETCD)
 			${CURL_INCLUDE_DIR}
 			${LIBXML2_INCLUDE_DIR}
 			)
-	target_link_libraries(rsa_discovery_etcd PRIVATE CURL::libcurl ${LIBXML2_LIBRARIES} Jansson)
+	target_link_libraries(rsa_discovery_etcd PRIVATE CURL::libcurl ${LIBXML2_LIBRARIES} jansson::jansson)
 
 	install_celix_bundle(rsa_discovery_etcd EXPORT celix COMPONENT rsa)
 	#Setup target aliases to match external usage

--- a/bundles/remote_services/remote_service_admin_dfi/CMakeLists.txt
+++ b/bundles/remote_services/remote_service_admin_dfi/CMakeLists.txt
@@ -41,7 +41,7 @@ if (RSA_REMOTE_SERVICE_ADMIN_DFI)
             Celix::log_helper
             Celix::rsa_common
             CURL::libcurl
-            Jansson
+            jansson::jansson
             )
 
     install_celix_bundle(rsa_dfi EXPORT celix COMPONENT rsa)

--- a/bundles/remote_services/topology_manager/tms_tst/CMakeLists.txt
+++ b/bundles/remote_services/topology_manager/tms_tst/CMakeLists.txt
@@ -36,7 +36,7 @@ target_include_directories(test_tm_scoped PRIVATE ../src ../include)
 target_link_libraries(test_tm_scoped PRIVATE
         Celix::framework
         GTest::gtest GTest::gtest_main
-        Jansson
+        jansson::jansson
         calculator_api
         Celix::rsa_common
 )

--- a/cmake/Modules/FindJansson.cmake
+++ b/cmake/Modules/FindJansson.cmake
@@ -41,9 +41,9 @@ find_package_handle_standard_args(Jansson  DEFAULT_MSG
 
 mark_as_advanced(JANSSON_INCLUDE_DIR JANSSON_LIBRARY)
 
-if (JANSSON_FOUND AND NOT TARGET Jansson)
-    add_library(Jansson SHARED IMPORTED)
-    set_target_properties(Jansson PROPERTIES
+if (JANSSON_FOUND AND NOT TARGET jansson::jansson)
+    add_library(jansson::jansson SHARED IMPORTED)
+    set_target_properties(jansson::jansson PROPERTIES
             IMPORTED_LOCATION "${JANSSON_LIBRARY}"
             INTERFACE_INCLUDE_DIRECTORIES "${JANSSON_INCLUDE_DIR}"
     )

--- a/conanfile.py
+++ b/conanfile.py
@@ -193,6 +193,7 @@ class CelixConan(ConanFile):
         self.options['zlib'].shared = True
         self.requires("libuuid/1.0.3")
         self.options['libuuid'].shared = True
+        self.requires("openssl/[>=1.1.1n <2.0.0]")
         self.requires("libzip/[>=1.7.3 <2.0.0]")
         self.options['libzip'].shared = True
         self.options['openssl'].shared = True
@@ -226,10 +227,14 @@ class CelixConan(ConanFile):
             self._cmake.definitions[opt.upper()] = self.options.get_safe(opt, False)
         self._cmake.definitions["CMAKE_PROJECT_Celix_INCLUDE"] = os.path.join(self.build_folder, "conan_paths.cmake")
         # the following is workaround for https://github.com/conan-io/conan/issues/7192
-        self._cmake.definitions["CMAKE_EXE_LINKER_FLAGS"] = "-Wl,--unresolved-symbols=ignore-in-shared-libs"
+        if self.settings.os == "Linux":
+            self._cmake.definitions["CMAKE_EXE_LINKER_FLAGS"] = "-Wl,--unresolved-symbols=ignore-in-shared-libs"
         self.output.info(self._cmake.definitions)
-        v = tools.Version(self.version)
-        self._cmake.configure(defs={'CELIX_MAJOR': v.major, 'CELIX_MINOR': v.minor, 'CELIX_MICRO': v.patch})
+        if self.version is None:
+            self._cmake.configure(defs={'CELIX_MAJOR': 2, 'CELIX_MINOR': 2, 'CELIX_MICRO': 1})
+        else :
+            v = tools.Version(self.version)
+            self._cmake.configure(defs={'CELIX_MAJOR': v.major, 'CELIX_MINOR': v.minor, 'CELIX_MICRO': v.patch})
         return self._cmake
 
     def build(self):

--- a/libs/dfi/CMakeLists.txt
+++ b/libs/dfi/CMakeLists.txt
@@ -41,7 +41,7 @@ target_include_directories(dfi PUBLIC
 )
 
 target_link_libraries(dfi PRIVATE FFI::lib)
-target_link_libraries(dfi PUBLIC Jansson)
+target_link_libraries(dfi PUBLIC jansson::jansson)
 target_link_libraries(dfi PRIVATE Celix::utils)
 set_target_properties(dfi PROPERTIES "SOVERSION" 1)
 

--- a/libs/dfi/gtest/CMakeLists.txt
+++ b/libs/dfi/gtest/CMakeLists.txt
@@ -32,7 +32,7 @@ add_executable(test_dfi
 		src/avrobin_serialization_tests.cpp
 )
 
-target_link_libraries(test_dfi PRIVATE Celix::dfi Celix::utils FFI::lib Jansson GTest::gtest GTest::gtest_main)
+target_link_libraries(test_dfi PRIVATE Celix::dfi Celix::utils FFI::lib jansson::jansson GTest::gtest GTest::gtest_main)
 
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/schemas DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/descriptors DESTINATION ${CMAKE_CURRENT_BINARY_DIR})

--- a/libs/etcdlib/CMakeLists.txt
+++ b/libs/etcdlib/CMakeLists.txt
@@ -65,7 +65,7 @@ if (CELIX_ETCDLIB OR ETCDLIB_STANDALONE)
 
     set_target_properties(etcdlib PROPERTIES SOVERSION 1)
     set_target_properties(etcdlib PROPERTIES VERSION 1.0.0)
-    target_link_libraries(etcdlib PUBLIC CURL::libcurl Jansson ${CELIX_OPTIONAL_EXTRA_LIBS})
+    target_link_libraries(etcdlib PUBLIC CURL::libcurl jansson::jansson ${CELIX_OPTIONAL_EXTRA_LIBS})
 
     add_library(etcdlib_static STATIC
             src/etcd.c
@@ -75,10 +75,10 @@ if (CELIX_ETCDLIB OR ETCDLIB_STANDALONE)
             )
     target_include_directories(etcdlib_static PRIVATE src)
     set_target_properties(etcdlib_static PROPERTIES "SOVERSION" 1)
-    target_link_libraries(etcdlib_static PUBLIC CURL::libcurl Jansson ${CELIX_OPTIONAL_EXTRA_LIBS})
+    target_link_libraries(etcdlib_static PUBLIC CURL::libcurl jansson::jansson ${CELIX_OPTIONAL_EXTRA_LIBS})
 
     add_executable(etcdlib_test ${CMAKE_CURRENT_SOURCE_DIR}/test/etcdlib_test.c)
-    target_link_libraries(etcdlib_test PRIVATE etcdlib_static CURL::libcurl Jansson)
+    target_link_libraries(etcdlib_test PRIVATE etcdlib_static CURL::libcurl jannson::jannson)
 
     install(DIRECTORY api/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/etcdlib COMPONENT ${ETCDLIB_CMP})
     if (NOT COMMAND celix_subproject)

--- a/libs/etcdlib/cmake/FindJansson.cmake
+++ b/libs/etcdlib/cmake/FindJansson.cmake
@@ -41,9 +41,9 @@ find_package_handle_standard_args(Jansson  DEFAULT_MSG
 
 mark_as_advanced(JANSSON_INCLUDE_DIR JANSSON_LIBRARY)
 
-if (JANSSON_FOUND AND NOT TARGET Jansson)
-    add_library(Jansson SHARED IMPORTED)
-    set_target_properties(Jansson PROPERTIES
+if (JANSSON_FOUND AND NOT TARGET jansson::jansson)
+    add_library(jansson::jansson SHARED IMPORTED)
+    set_target_properties(jansson::jansson PROPERTIES
             IMPORTED_LOCATION "${JANSSON_LIBRARY}"
             INTERFACE_INCLUDE_DIRECTORIES "${JANSSON_INCLUDE_DIR}"
     )

--- a/misc/experimental/bundles/pubsub_admin_nanomsg/CMakeLists.txt
+++ b/misc/experimental/bundles/pubsub_admin_nanomsg/CMakeLists.txt
@@ -18,7 +18,6 @@
 if (BUILD_PUBSUB_PSA_NANOMSG)
 
     find_package(NanoMsg REQUIRED)
-    find_package(Jansson REQUIRED)
 
     add_celix_bundle(celix_pubsub_admin_nanomsg
         BUNDLE_SYMBOLICNAME "apache_celix_pubsub_admin_nanomsg"


### PR DESCRIPTION
I started testing the Celix Conan setup on a macOS system and something did not work:

- conan install failed, because both cmake 3.17.5 and libzip 1.7.3 needed an different openssl version (1.1.1m and 1.1.1n). Currently I solved this by explicitly adding a openssl dep, but maybe this can be solved cleaner
- `-Wl,--unresolved-symbols=ignore-in-shared-libs` does not work on macOS, so conanfile now does this behind an `if`
- For me `self.version` was not so, so made this optional
- The conan generated Findjansson creates a `jansson::jansson` imported target and not a `Jansson` imported target which was generated by Celix's FIndJansson.cmake. This has now been updated to `jansson::jansson`


I still have some troubles with running the Celix tests and I will look into this a bit later. 
