### PR TITLE
Fix rsa use after free

### DIFF
--- a/bundles/remote_services/topology_manager/src/activator.c
+++ b/bundles/remote_services/topology_manager/src/activator.c
@@ -234,12 +234,13 @@ celix_status_t bundleActivator_stop(void * userData, celix_bundle_context_t *con
 	serviceRegistration_unregister(activator->hook);
 	free(activator->hookService);
 
+
+	topologyManager_closeImports(activator->manager);
 	serviceRegistration_unregister(activator->endpointListenerService);
 	free(activator->endpointListener);
 
 	serviceRegistration_unregister(activator->scopeReg);
 
-	topologyManager_closeImports(activator->manager);
 
 	return status;
 }

--- a/bundles/remote_services/topology_manager/src/topology_manager.c
+++ b/bundles/remote_services/topology_manager/src/topology_manager.c
@@ -62,7 +62,7 @@ struct topology_manager {
 	celix_thread_mutex_t importedServicesLock;
 	celix_thread_mutexattr_t importedServicesLockAttr;
 	hash_map_pt importedServices;
-	bool disableImportedService;
+	bool stopAddImportedService;
 
 	scope_pt scope;
 
@@ -96,7 +96,7 @@ celix_status_t topologyManager_create(celix_bundle_context_t *context, celix_log
 	celixThreadMutexAttr_create(&(*manager)->importedServicesLockAttr);
 	celixThreadMutexAttr_settype(&(*manager)->importedServicesLockAttr, CELIX_THREAD_MUTEX_RECURSIVE);
 	celixThreadMutex_create(&(*manager)->importedServicesLock, &(*manager)->importedServicesLockAttr);
-	(*manager)->disableImportedService = false;
+	(*manager)->stopAddImportedService = false;
 
 	celixThreadMutex_create(&(*manager)->exportedServicesLock, NULL);
 	celixThreadMutex_create(&(*manager)->listenerListLock, NULL);
@@ -159,7 +159,7 @@ celix_status_t topologyManager_closeImports(topology_manager_pt manager) {
 
 	status = celixThreadMutex_lock(&manager->importedServicesLock);
 
-	manager->disableImportedService = true;
+	manager->stopAddImportedService = true;
 
 	hash_map_iterator_pt iter = hashMapIterator_create(manager->importedServices);
 
@@ -484,8 +484,8 @@ celix_status_t topologyManager_addImportedService(void *handle, endpoint_descrip
 
 	if (celixThreadMutex_lock(&manager->importedServicesLock) == CELIX_SUCCESS) {
 
-		// bundleActivator is stopping, ignore add imported service
-		if (manager->disableImportedService) {
+		// bundleActivator is stopping, stop add imported service
+		if (manager->stopAddImportedService) {
 			celixThreadMutex_unlock(&manager->importedServicesLock);
 			celix_logHelper_log(manager->loghelper, CELIX_LOG_LEVEL_INFO,"TOPOLOGY_MANAGER: Endpointer listener will close, Ignore imported service (%s; %s).", endpoint->service, endpoint->id);
 			return CELIX_SUCCESS;

--- a/bundles/remote_services/topology_manager/src/topology_manager.c
+++ b/bundles/remote_services/topology_manager/src/topology_manager.c
@@ -62,6 +62,7 @@ struct topology_manager {
 	celix_thread_mutex_t importedServicesLock;
 	celix_thread_mutexattr_t importedServicesLockAttr;
 	hash_map_pt importedServices;
+	bool disableImportedService;
 
 	scope_pt scope;
 
@@ -95,6 +96,7 @@ celix_status_t topologyManager_create(celix_bundle_context_t *context, celix_log
 	celixThreadMutexAttr_create(&(*manager)->importedServicesLockAttr);
 	celixThreadMutexAttr_settype(&(*manager)->importedServicesLockAttr, CELIX_THREAD_MUTEX_RECURSIVE);
 	celixThreadMutex_create(&(*manager)->importedServicesLock, &(*manager)->importedServicesLockAttr);
+	(*manager)->disableImportedService = false;
 
 	celixThreadMutex_create(&(*manager)->exportedServicesLock, NULL);
 	celixThreadMutex_create(&(*manager)->listenerListLock, NULL);
@@ -157,7 +159,10 @@ celix_status_t topologyManager_closeImports(topology_manager_pt manager) {
 
 	status = celixThreadMutex_lock(&manager->importedServicesLock);
 
+	manager->disableImportedService = true;
+
 	hash_map_iterator_pt iter = hashMapIterator_create(manager->importedServices);
+
 	while (hashMapIterator_hasNext(iter)) {
 		hash_map_entry_pt entry = hashMapIterator_nextEntry(iter);
 		endpoint_description_t *ep = hashMapEntry_getKey(entry);
@@ -478,6 +483,13 @@ celix_status_t topologyManager_addImportedService(void *handle, endpoint_descrip
 	celix_logHelper_log(manager->loghelper, CELIX_LOG_LEVEL_INFO, "TOPOLOGY_MANAGER: Add imported service (%s; %s).", endpoint->service, endpoint->id);
 
 	if (celixThreadMutex_lock(&manager->importedServicesLock) == CELIX_SUCCESS) {
+
+		// bundleActivator is stopping, ignore add imported service
+		if (manager->disableImportedService) {
+			celixThreadMutex_unlock(&manager->importedServicesLock);
+			celix_logHelper_log(manager->loghelper, CELIX_LOG_LEVEL_INFO,"TOPOLOGY_MANAGER: Endpointer listener will close, Ignore imported service (%s; %s).", endpoint->service, endpoint->id);
+			return CELIX_SUCCESS;
+		}
 
 		hash_map_pt imports = hashMap_create(NULL, NULL, NULL, NULL);
 		hashMap_put(manager->importedServices, endpoint, imports);


### PR DESCRIPTION
#406 
During the bundleActivator_stop of topology manager,  endpointDescription_destroy in endpointDiscoveryPoller_poll happened between serviceRegistration_unregister(activator->endpointListenerService) and topologyManager_closeImports. Thus use-after-free on endpoint follows.
To ensure that endpoint has been removed from  topology manager before it is destoryed by discovery, I made the following changes.