### PR TITLE
Refactors the DefaultExecutor of celix::Promises

### DIFF
--- a/libs/promises/api/celix/DefaultExecutor.h
+++ b/libs/promises/api/celix/DefaultExecutor.h
@@ -36,7 +36,10 @@ namespace celix {
 
         void execute(int /*priority*/, std::function<void()> task) override {
             std::lock_guard lck{mutex};
-            futures.emplace_back(std::async(policy, std::move(task)));
+            futures.emplace_back(std::async(policy, [task = std::move(task)]() mutable {
+                task();
+                task = nullptr; //to ensure captures of task go out of scope
+            }));
             removeCompletedFutures();
         }
 

--- a/libs/promises/api/celix/IExecutor.h
+++ b/libs/promises/api/celix/IExecutor.h
@@ -39,6 +39,9 @@ namespace celix {
          * @brief Executes the given command at some time in the future. The command may execute in a new thread,
          * in a pooled thread, or in the calling thread, at the discretion of the Executor implementation.
          *
+         * @note After a task has been executed, the `std::function<void()>` task object must go out of scope to
+         * ensure that the potential capture objects also go out of scope.
+         *
          * @param priority the priority of the task. It depends on the executor implementation whether this is supported.
          * @param command the "runnable" task
          * @throws celix::RejectedExecutionException if this task cannot be accepted for execution.


### PR DESCRIPTION
Small PR that refactors the DefaultExecutor of celix::Promises so that std::function goes out of scope after executing. 
This ensure that captures of task lambda go out of scope as soon as an task is done, ensuring a more predictable RAII behavior.  