### PR TITLE
Adds print functions for dependency manager

### DIFF
--- a/libs/framework/gtest/src/DependencyManagerTestSuite.cc
+++ b/libs/framework/gtest/src/DependencyManagerTestSuite.cc
@@ -1117,4 +1117,68 @@ TEST_F(DependencyManagerTestSuite, CreateInterfaceWithStaticInfo) {
     EXPECT_EQ(it->second, "1.2.3");
 }
 
+TEST_F(DependencyManagerTestSuite, TestPrintInfo) {
+    celix::dm::DependencyManager dm{ctx};
+    auto& cmp = dm.createComponent<Cmp1>();
+    cmp.addInterface<TestService>();
+    cmp.createServiceDependency<TestInterfaceWithStaticInfo>();
+    cmp.build();
+
+    char* buf = nullptr;
+    size_t bufLen = 0;
+    FILE* testStream = open_memstream(&buf, &bufLen);
+    celix_dependencyManager_printInfo(celix_bundleContext_getDependencyManager(ctx), true, true, testStream);
+    fclose(testStream);
+    std::cout << buf << std::endl;
+    EXPECT_TRUE(strstr(buf, "Cmp1")); //cmp name
+    EXPECT_TRUE(strstr(buf, "TestService")); //provided service name
+    EXPECT_TRUE(strstr(buf, "TestName")); //service dependency name
+    free(buf);
+
+    buf = nullptr;
+    bufLen = 0;
+    testStream = open_memstream(&buf, &bufLen);
+    celix_dependencyManager_printInfo(celix_bundleContext_getDependencyManager(ctx), true, false, testStream);
+    fclose(testStream);
+    EXPECT_TRUE(strstr(buf, "Cmp1")); //cmp name
+    EXPECT_TRUE(strstr(buf, "TestService")); //provided service name
+    EXPECT_TRUE(strstr(buf, "TestName")); //service dependency name
+    free(buf);
+
+    buf = nullptr;
+    bufLen = 0;
+    testStream = open_memstream(&buf, &bufLen);
+    celix_dependencyManager_printInfo(celix_bundleContext_getDependencyManager(ctx), false, true, testStream);
+    fclose(testStream);
+    EXPECT_TRUE(strstr(buf, "Cmp1")); //cmp name
+    free(buf);
+
+    buf = nullptr;
+    bufLen = 0;
+    testStream = open_memstream(&buf, &bufLen);
+    celix_dependencyManager_printInfo(celix_bundleContext_getDependencyManager(ctx), false, false, testStream);
+    fclose(testStream);
+    EXPECT_TRUE(strstr(buf, "Cmp1")); //cmp name
+    free(buf);
+
+    buf = nullptr;
+    bufLen = 0;
+    testStream = open_memstream(&buf, &bufLen);
+    celix_dependencyManager_printInfoForBundle(celix_bundleContext_getDependencyManager(ctx), true, true, 0, testStream);
+    fclose(testStream);
+    EXPECT_TRUE(strstr(buf, "Cmp1")); //cmp name
+    free(buf);
+
+    //bundle does not exist -> empty print
+    celix_dependencyManager_printInfoForBundle(celix_bundleContext_getDependencyManager(ctx), true, true, 1 /*non existing*/, stdout);
+
+    std::stringstream ss{};
+    ss << dm;
+    EXPECT_TRUE(strstr(ss.str().c_str(), "Cmp1"));
+
+    ss = std::stringstream{};
+    ss << cmp;
+    EXPECT_TRUE(strstr(ss.str().c_str(), "Cmp1"));
+}
+
 #endif

--- a/libs/framework/include/celix/dm/Component.h
+++ b/libs/framework/include/celix/dm/Component.h
@@ -28,7 +28,7 @@
 #include <iostream>
 #include <type_traits>
 #include <algorithm>
-
+#include <cstdio>
 
 #include "dm_component.h"
 #include "celix/dm/types.h"
@@ -137,6 +137,8 @@ namespace celix { namespace dm {
          * The underlining service registration and service tracker will be registered/created async.
          */
         void runBuild();
+
+        friend std::ostream& operator<<(std::ostream& out, const BaseComponent& cmp);
     protected:
         celix_bundle_context_t* context;
         celix_dependency_manager_t* cDepMan;
@@ -152,6 +154,10 @@ namespace celix { namespace dm {
         std::vector<std::shared_ptr<void>> componentContexts{};
     };
 
+    /**
+     * Stream outputs the full component info.
+     */
+    inline std::ostream& operator<<(std::ostream& out, const BaseComponent& cmp);
 
     template<class T>
     class Component : public BaseComponent {

--- a/libs/framework/include/celix/dm/DependencyManager.h
+++ b/libs/framework/include/celix/dm/DependencyManager.h
@@ -19,6 +19,10 @@
 
 #pragma once
 
+#include <cstdio>
+#include <iostream>
+#include <vector>
+
 #include "celix/dm/types.h"
 #include "celix/dm/Component.h"
 #include "celix/dm/ServiceDependency.h"
@@ -27,8 +31,6 @@
 #include "bundle_context.h"
 #include "celix_bundle_context.h"
 #include "celix_dependency_manager.h"
-
-#include <vector>
 
 namespace celix { namespace dm {
 
@@ -215,6 +217,8 @@ namespace celix { namespace dm {
          * @return A vector of DependencyManagerInfo structs.
          */
         std::vector<celix::dm::DependencyManagerInfo> getInfos() const;
+
+        friend std::ostream& operator<<(std::ostream& out, const DependencyManager& mng);
     private:
         template<class T>
         Component<T>& createComponentInternal(std::string name, std::string uuid);
@@ -225,6 +229,10 @@ namespace celix { namespace dm {
         std::vector<std::shared_ptr<BaseComponent>> components{};
     };
 
+    /**
+     * Stream outputs the full dependency manager info.
+     */
+    inline std::ostream& operator<<(std::ostream& out, const DependencyManager& mng);
 }}
 
 #include "celix/dm/DependencyManager_Impl.h"

--- a/libs/framework/include/celix/dm/DependencyManager_Impl.h
+++ b/libs/framework/include/celix/dm/DependencyManager_Impl.h
@@ -217,3 +217,14 @@ inline std::vector<celix::dm::DependencyManagerInfo> DependencyManager::getInfos
     celix_dependencyManager_destroyInfos(cDependencyManager(), cInfos);
     return result;
 }
+
+std::ostream& celix::dm::operator<<(std::ostream &out, const DependencyManager &mng) {
+    char* buf = nullptr;
+    size_t bufSize = 0;
+    FILE* stream = open_memstream(&buf, &bufSize);
+    celix_dependencyManager_printInfo(mng.cDepMan.get(), true, true, stream);
+    fclose(stream);
+    out << buf;
+    free(buf);
+    return out;
+}

--- a/libs/framework/include/celix_dependency_manager.h
+++ b/libs/framework/include/celix_dependency_manager.h
@@ -103,41 +103,6 @@ celix_status_t celix_dependencyManager_removeAllComponents(celix_dependency_mana
 celix_status_t celix_dependencyManager_removeAllComponentsAsync(celix_dependency_manager_t *manager, void *doneData, void (*doneCallback)(void *data));
 
 /**
- * Create and returns a dependency manager info struct for the specified bundle.
- * The dependency manager info contains information about the state of the dependency manager components
- *
- * Caller has ownership of the return value (use celix_dependencyManager_destroyInfo to free the memory).
- *
- * @param manager The dependency manager
- * @param bndId The bundle id to get the info from.
- * @returns The dependency manager info for the provided bundle id or NULL if the bundle id is invalid.
- */
-celix_dependency_manager_info_t* celix_dependencyManager_createInfo(celix_dependency_manager_t *manager, long bndId);
-
-/**
- * Create and returns a dependency manager info struct for all started bundles.
- * The dependency manager info contains information about the state of the dependency manager components
- *
- * Caller has ownership of the return values (use celix_dependencyManager_destroyInfos to free the memory).
- *
- * @param manager The dependency manager
- * @returns A Celix array of dependency manager infos (celix_dependency_manager_info_t*)
- * for the provided bundle id or NULL if the bundle id is invalid.
- */
-celix_array_list_t * /*celix_dependency_manager_info_t* entries*/ celix_dependencyManager_createInfos(celix_dependency_manager_t *manager);
-
-/**
- * Destroys a DM info struct.
- */
-void celix_dependencyManager_destroyInfo(celix_dependency_manager_t *manager, celix_dependency_manager_info_t *info);
-
-/**
- * Destroys a celix array list of  DM info structs.
- */
-void celix_dependencyManager_destroyInfos(celix_dependency_manager_t *manager, celix_array_list_t * infos /*entries celix_dependency_manager_info_t*/);
-
-
-/**
  * Check if all components for the bundle of the dependency manager are active (all required dependencies resolved).
  */
 bool celix_dependencyManager_areComponentsActive(celix_dependency_manager_t *manager);
@@ -160,6 +125,58 @@ size_t celix_dependencyManager_nrOfComponents(celix_dependency_manager_t *manage
  * and/or service trackers are created).
  */
 void celix_dependencyManager_wait(celix_dependency_manager_t* manager);
+
+/**
+ * Create and returns a dependency manager info struct for the specified bundle.
+ * The dependency manager info contains information about the state of the dependency manager components
+ *
+ * Caller has ownership of the return value (use celix_dependencyManager_destroyInfo to free the memory).
+ *
+ * @param manager The dependency manager
+ * @param bndId The bundle id to get the info from.
+ * @returns The dependency manager info for the provided bundle id or NULL if the bundle id is invalid.
+ */
+celix_dependency_manager_info_t* celix_dependencyManager_createInfo(celix_dependency_manager_t *manager, long bndId);
+
+/**
+ * Create and returns a dependency manager info struct for all started bundles.
+ * The dependency manager info contains information about the state of the dependency manager components
+ *
+ * Caller has ownership of the return values (use celix_dependencyManager_destroyInfos to free the memory).
+ *
+ * @param manager The dependency manager
+ * @returns A Celix array of dependency manager infos (celix_dependency_manager_info_t*)
+ */
+celix_array_list_t * /*celix_dependency_manager_info_t* entries*/ celix_dependencyManager_createInfos(celix_dependency_manager_t *manager);
+
+/**
+ * Destroys a DM info struct.
+ */
+void celix_dependencyManager_destroyInfo(celix_dependency_manager_t *manager, celix_dependency_manager_info_t *info);
+
+/**
+ * Destroys a celix array list of  DM info structs.
+ */
+void celix_dependencyManager_destroyInfos(celix_dependency_manager_t *manager, celix_array_list_t * infos /*entries celix_dependency_manager_info_t*/);
+
+/**
+ * Print the dependency manager info for all bundles to the provided output stream.
+ * @param manager The dependency manager.
+ * @param fullInfo Whether to print the full info or summary.
+ * @param useAnsiColors Whether to use ansi colors when printing info.
+ * @param stream The output stream (e.g. stdout)
+ */
+void celix_dependencyManager_printInfo(celix_dependency_manager_t* manager, bool fullInfo, bool useAnsiColors, FILE* stream);
+
+/**
+ * Print the dependency manager info for the provided bundle id to the provided output stream.
+ * @param manager The dependency manager.
+ * @param fullInfo whether to print the full info or summary.
+ * @param useAnsiColors Whether to use ansi colors when printing info.
+ * @param bundleId The bundle id for which the dependency manager info should be printed.
+ * @param stream The output stream (e.g. stdout)
+ */
+void celix_dependencyManager_printInfoForBundle(celix_dependency_manager_t* manager, bool fullInfo, bool useAnsiColors, long bundleId, FILE* stream);
 
 #ifdef __cplusplus
 }

--- a/libs/framework/include/celix_dm_component.h
+++ b/libs/framework/include/celix_dm_component.h
@@ -172,23 +172,34 @@ celix_status_t celix_dmComponent_setCallbacks(celix_dm_component_t *component, c
         celix_dmComponent_setCallbacks((dmCmp), (celix_dm_cmp_lifecycle_fpt)tmp_init, (celix_dm_cmp_lifecycle_fpt)tmp_start, (celix_dm_cmp_lifecycle_fpt)tmp_stop, (celix_dm_cmp_lifecycle_fpt)tmp_deinit); \
     } while(0)
 
+
+bool celix_dmComponent_isActive(celix_dm_component_t *component);
+
+/**
+ * Returns the string value of a provided state
+ */
+const char* celix_dmComponent_stateToString(celix_dm_component_state_t state);
+
 /**
  * Create a DM Component info struct. Containing information about the component.
  * Caller has ownership.
  */
-celix_status_t celix_dmComponent_getComponentInfo(celix_dm_component_t *component, dm_component_info_pt *info);
+celix_status_t celix_dmComponent_getComponentInfo(celix_dm_component_t *component, celix_dm_component_info_t** infoOut);
 
-bool celix_dmComponent_isActive(celix_dm_component_t *component);
+/**
+ * Print the component info to the provided stream.
+ * @param info The component info to print.
+ * @param printFullInfo Whether to print the full info or summary.
+ * @param useAnsiColors Whether to use ansi colors when printing the component info.
+ * @param stream The stream to print to (e..g stdout).
+ */
+void celix_dmComponent_printComponentInfo(celix_dm_component_info_t* info, bool printFullInfo, bool useAnsiColors, FILE* stream);
 
 /**
  * Destroys a DM Component info struct.
  */
 void celix_dmComponent_destroyComponentInfo(dm_component_info_pt info);
 
-/**
- * Returns the string value of a provided state
- */
-const char* celix_dmComponent_stateToString(celix_dm_component_state_t state);
 
 #ifdef __cplusplus
 }

--- a/libs/framework/include/celix_dm_info.h
+++ b/libs/framework/include/celix_dm_info.h
@@ -52,8 +52,10 @@ typedef struct celix_dm_service_dependency_info_struct dm_service_dependency_inf
 typedef struct celix_dm_service_dependency_info_struct celix_dm_service_dependency_info_t;
 
 struct celix_dm_component_info_struct {
-    char id[64];
-    char name[128];
+    long bundleId;
+    char* bundleSymbolicName;
+    char* id;
+    char* name;
     bool active;
     char* state;
     size_t nrOfTimesStarted;

--- a/libs/framework/src/dm_dependency_manager_impl.c
+++ b/libs/framework/src/dm_dependency_manager_impl.c
@@ -373,7 +373,30 @@ celix_status_t dependencyManager_getInfo(celix_dependency_manager_t *manager, dm
 	return status;
 }
 
-
 void dependencyManager_destroyInfo(celix_dependency_manager_t *manager, celix_dependency_manager_info_t *info) {
     celix_dependencyManager_destroyInfo(manager, info);
+}
+
+static void celix_dependencyManager_printInfoForEntry(bool fullInfo, bool useAnsiColors, FILE* stream, celix_dependency_manager_info_t* mngInfo) {
+	for (int i = 0; i < celix_arrayList_size(mngInfo->components); ++i) {
+		celix_dm_component_info_t *cmpInfo = celix_arrayList_get(mngInfo->components, i);
+        celix_dmComponent_printComponentInfo(cmpInfo, fullInfo, useAnsiColors, stream);
+	}
+}
+
+void celix_dependencyManager_printInfo(celix_dependency_manager_t* manager, bool fullInfo, bool useAnsiColors, FILE* stream) {
+	celix_array_list_t *infos = celix_dependencyManager_createInfos(manager);
+	for (int i = 0; i< celix_arrayList_size(infos); ++i) {
+		celix_dependency_manager_info_t* mngInfo = celix_arrayList_get(infos, i);
+		celix_dependencyManager_printInfoForEntry(fullInfo, useAnsiColors, stream, mngInfo);
+	}
+	celix_dependencyManager_destroyInfos(manager, infos);
+}
+
+void celix_dependencyManager_printInfoForBundle(celix_dependency_manager_t* manager, bool fullInfo, bool useAnsiColors, long bundleId, FILE* stream) {
+	celix_dependency_manager_info_t* mngInfo = celix_dependencyManager_createInfo(manager, bundleId);
+    if (mngInfo != NULL) {
+        celix_dependencyManager_printInfoForEntry(fullInfo, useAnsiColors, stream, mngInfo);
+        celix_dependencyManager_destroyInfo(manager, mngInfo);
+    }
 }

--- a/libs/utils/include/celix/Utils.h
+++ b/libs/utils/include/celix/Utils.h
@@ -161,6 +161,22 @@ namespace celix {
     }
 
     /**
+     * @brief Returns the inferred cmp type name for the template T if the providedCmpTypeName is empty.
+     *
+     * If the a non empty providedCmpTypeName is provided this will be returned.
+     * Otherwise the celix::impl::typeName will be used to infer the type name.
+     * celix::impl::typeName uses the macro __PRETTY_FUNCTION__ to extract a type name.
+     */
+    template<typename T>
+    std::string cmpTypeName(std::string_view providedCmpTypeName = "") {
+        if (!providedCmpTypeName.empty()) {
+            return std::string{providedCmpTypeName};
+        } else {
+            return celix::impl::extractTypeName<T>();
+        }
+    }
+
+    /**
      * @brief Returns the inferred type version for the template I if the providedVersion is empty.
      *
      * If the a non empty providedVersion is provided this will be returned.
@@ -215,6 +231,22 @@ namespace celix {
             return providedTypeName;
         } else {
             return celix::impl::extractTypeName<I>();
+        }
+    }
+
+    /**
+     * @brief Returns the inferred cmp type name for the template T if the providedCmpTypeName is empty.
+     *
+     * If the a non empty providedCmpTypeName is provided this will be returned.
+     * Otherwise the celix::impl::typeName will be used to infer the type name.
+     * celix::impl::typeName uses the macro __PRETTY_FUNCTION__ to extract a type name.
+     */
+    template<typename T>
+    std::string cmpTypeName(const std::string &providedCmpTypeName = "") {
+        if (!providedCmpTypeName.empty()) {
+            return providedCmpTypeName;
+        } else {
+            return celix::impl::extractTypeName<T>();
         }
     }
 


### PR DESCRIPTION
This PR adds print functions for dependency manager and dependency manager component.
Most of the print functionality of the `dm` shell command is reused for this.

Also:
 - Refactors dm shell command to use dm/cmp print functions 
 - Fixes an issue where dm component got name of a interface if the interface has a static NAME field. 
 - Adds overloaded C++ stream operator, so that this can be used in C++ (e.g. with gtest `EXPECT_EQ(...) << cmp`).