### PR TITLE
Fix hash when sizeof(long) == 4.

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -37,8 +37,6 @@ class CelixConan(ConanFile):
                   "It is a framework to develop (dynamic) modular software applications " \
                   "using component and/or service-oriented programming."
 
-    tool_requires = "cmake/3.17.5"
-
     options = {
         "enable_testing": [True, False],
         "enable_code_coverage": [True, False],

--- a/libs/utils/src/celix_hash_map.c
+++ b/libs/utils/src/celix_hash_map.c
@@ -91,7 +91,7 @@ static unsigned int celix_stringHashMap_hash(const celix_hash_map_key_t* key) {
 }
 
 static unsigned int celix_longHashMap_hash(const celix_hash_map_key_t* key) {
-    return key->longKey ^ (key->longKey >> 32);
+    return __builtin_choose_expr(sizeof(long) == 4, key->longKey ^ (key->longKey >> 16), key->longKey ^ (key->longKey >> 32));
 }
 
 static bool celix_stringHashMap_equals(const celix_hash_map_key_t* key1, const celix_hash_map_key_t* key2) {

--- a/libs/utils/src/celix_hash_map.c
+++ b/libs/utils/src/celix_hash_map.c
@@ -91,7 +91,7 @@ static unsigned int celix_stringHashMap_hash(const celix_hash_map_key_t* key) {
 }
 
 static unsigned int celix_longHashMap_hash(const celix_hash_map_key_t* key) {
-    return __builtin_choose_expr(sizeof(long) == 4, key->longKey ^ (key->longKey >> 16), key->longKey ^ (key->longKey >> 32));
+    return key->longKey ^ (key->longKey >> (sizeof(key->longKey)*8/2));
 }
 
 static bool celix_stringHashMap_equals(const celix_hash_map_key_t* key1, const celix_hash_map_key_t* key2) {


### PR DESCRIPTION
`key->longKey ^ (key->longKey >> 32)` generates GCC warning ("right shift count >= width of type") on ARM32, which turns out to be a bug.

IIRC, this kind of bug has hurt us before in `celix_array_list`. 
ARM32 CI may catch such errors in future. Another option is to use intxx_t(8/16/32/64) instead of long/int/char.