### PR TITLE
Fix possible use-after-free.

### DIFF
--- a/libs/framework/include/celix_bundle_activator.h
+++ b/libs/framework/include/celix_bundle_activator.h
@@ -149,12 +149,12 @@ celix_status_t celix_bundleActivator_start(void *userData, celix_bundle_context_
                                                                                                                        \
 celix_status_t celix_bundleActivator_stop(void *userData, celix_bundle_context_t *ctx) {                               \
     celix_status_t status = CELIX_SUCCESS;                                                                             \
+    celix_dependency_manager_t* mng = celix_bundleContext_getDependencyManager(ctx);                                   \
+    celix_dependencyManager_removeAllComponents(mng);                                                                  \
     celix_status_t (*fn)(actType*, celix_bundle_context_t*) = (actStop);                                               \
     if (fn != NULL) {                                                                                                  \
         status = fn((actType*)userData, ctx);                                                                          \
     }                                                                                                                  \
-    celix_dependency_manager_t* mng = celix_bundleContext_getDependencyManager(ctx);                                   \
-    celix_dependencyManager_removeAllComponents(mng);                                                                  \
     return status;                                                                                                     \
 }                                                                                                                      \
                                                                                                                        \


### PR DESCRIPTION
Suppose that we allocate memory in actStart to implement a service, which is managed by dm, and that in actStop we deallocate it, we must first stop the dm from using the service before deallocation happens.

Related logic in `framework.c` is also dubious:

                status = CELIX_DO_IF(status, activator->stop(activator->userData, context));
                if (status == CELIX_SUCCESS) {
                    celix_dependency_manager_t *mng = celix_bundleContext_getDependencyManager(context);
                    celix_dependencyManager_removeAllComponents(mng);
                }

An issue should be more appropriate, since I just want to have some discussion about this. Any one cautious can follow the original dm_exmaple:

```C
static celix_status_t activator_stop(struct phase1_activator_struct *act, celix_bundle_context_t *ctx) {
    printf("PHASE1: stop\n");
    celix_dependency_manager_t *mng = celix_bundleContext_getDependencyManager(ctx);
    celix_dependencyManager_removeAllComponents(mng);
    if (act->phase1Cmp != NULL) {
        phase1_destroy(act->phase1Cmp); //Considering we can destroy some resource not managed but used by dm
    }

    return CELIX_SUCCESS;
}
```
