### PR TITLE
Updates cmake rat configuration so that apache rat is downloaded 

### DIFF
--- a/cmake/celix_project/ApacheRat.cmake
+++ b/cmake/celix_project/ApacheRat.cmake
@@ -15,16 +15,30 @@
 # specific language governing permissions and limitations
 # under the License.
 
-find_package(Java COMPONENTS Runtime)
 
-if(Java_Runtime_FOUND)
-    set(APACHE_RAT "NOT_FOUND" CACHE FILEPATH "Full path to the Apache RAT JAR file")
-    
-    add_custom_target(rat
-        COMMAND ${Java_JAVA_EXECUTABLE} -jar ${APACHE_RAT} -E rat-excludes.txt -d .
-        
-        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
-    )
-else(Java_Runtime_FOUND)
-    MESSAGE(STATUS "Java not found, cannot execute Apache RAT checks")
-endif(Java_Runtime_FOUND)
+#Check if Apache RAT is enabled.
+#Apache RAT can be used to check for missing license text in the project files.
+option(ENABLE_APACHE_RAT "Enables Apache Release Audit tool" FALSE)
+if (ENABLE_APACHE_RAT)
+    find_package(Java COMPONENTS Runtime)
+    if(Java_Runtime_FOUND)
+        include(FetchContent)
+        set(APACHE_RAT_URL "https://dlcdn.apache.org//creadur/apache-rat-0.14/apache-rat-0.14-bin.tar.gz")
+        set(APACHE_RAT_HASH "17119289839dc573dd29039ca09bd86f729f1108308f6681292125418fd7bceeaf7d1a40b83eb01daf7d3dd66fbcc0a68d5431741314e748f7b878e8967459e9") #matching hash for the apache rat download
+
+        FetchContent_Declare(download_apache_rat
+            URL ${APACHE_RAT_URL}
+            URL_HASH SHA512=${APACHE_RAT_HASH}
+        )
+        FetchContent_MakeAvailable(download_apache_rat)
+        set(APACHE_RAT "${download_apache_rat_SOURCE_DIR}/apache-rat-*.jar")
+
+        add_custom_target(rat
+            COMMAND ${Java_JAVA_EXECUTABLE} -jar ${APACHE_RAT} -E rat-excludes.txt -d .
+            WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+        )
+
+    else(Java_Runtime_FOUND)
+        MESSAGE(STATUS "Java not found, cannot execute Apache RAT checks")
+    endif(Java_Runtime_FOUND)
+endif ()


### PR DESCRIPTION
Small update so that apache rat ( release audit tool) can optionally be enabled and if it enabled, the apache rat jar is downloaded using cmake FetchContent