### PR TITLE
Add conan option for bundle compression.

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -78,6 +78,8 @@ class CelixConan(ConanFile):
         "celix_cxx": [True, False],
         "celix_install_deprecated_api": [True, False],
         "celix_add_deprecated_attributes": [True, False],
+        "celix_jar_command_arguments": ["ANY"],
+        "celix_zip_command_arguments": ["ANY"],
     }
     default_options = { 
         "enable_testing": False,
@@ -120,6 +122,8 @@ class CelixConan(ConanFile):
         "celix_cxx": False,
         "celix_install_deprecated_api": False,
         "celix_add_deprecated_attributes": True,
+        "celix_jar_command_arguments": "-cfm",
+        "celix_zip_command_arguments": "-rq",
     }
     _cmake = None
 


### PR DESCRIPTION
I deliberately choose compression as the default to avoid affecting current downstream conan package consumers, but I really don't mind making it consistent with the CMake default.