### PR TITLE
Add conan option for bundle compression.

### DIFF
--- a/cmake/cmake_celix/BundlePackaging.cmake
+++ b/cmake/cmake_celix/BundlePackaging.cmake
@@ -18,8 +18,15 @@
 
 
 set(CELIX_NO_POSTFIX_BUILD_TYPES RelWithDebInfo Release CACHE STRING "The build type used for creating bundle without a build type postfix.")
-set(CELIX_JAR_COMMAND_ARGUMENTS -cfm0 CACHE STRING "Default no compression is applied")
-set(CELIX_ZIP_COMMAND_ARGUMENTS -rq0 CACHE STRING "Default no compression is applied")
+option(CELIX_USE_COMPRESSION_FOR_BUNDLE_ZIPS "Enables bundle compression" TRUE)
+
+if (CELIX_USE_COMPRESSION_FOR_BUNDLE_ZIPS)
+    set(CELIX_JAR_COMMAND_ARGUMENTS -cfm)
+    set(CELIX_ZIP_COMMAND_ARGUMENTS -rq)
+else()
+    set(CELIX_JAR_COMMAND_ARGUMENTS -cfm0)
+    set(CELIX_ZIP_COMMAND_ARGUMENTS -rq0)
+endif ()
 
 
 find_program(JAR_COMMAND jar NO_CMAKE_FIND_ROOT_PATH)

--- a/conanfile.py
+++ b/conanfile.py
@@ -78,8 +78,7 @@ class CelixConan(ConanFile):
         "celix_cxx": [True, False],
         "celix_install_deprecated_api": [True, False],
         "celix_add_deprecated_attributes": [True, False],
-        "celix_jar_command_arguments": ["ANY"],
-        "celix_zip_command_arguments": ["ANY"],
+        "celix_use_compression_for_bundle_zips": [True, False],
     }
     default_options = { 
         "enable_testing": False,
@@ -122,8 +121,7 @@ class CelixConan(ConanFile):
         "celix_cxx": False,
         "celix_install_deprecated_api": False,
         "celix_add_deprecated_attributes": True,
-        "celix_jar_command_arguments": "-cfm",
-        "celix_zip_command_arguments": "-rq",
+        "celix_use_compression_for_bundle_zips": True,
     }
     _cmake = None
 


### PR DESCRIPTION
Fix issues raised in #439.

I inclined to make compression as the default, since embedded device is very sensitive to disk usage.