### PR TITLE
[WIP] Skip bundle extraction when reloading bundle from cache.

### DIFF
--- a/libs/framework/include/bundle_revision.h
+++ b/libs/framework/include/bundle_revision.h
@@ -31,6 +31,7 @@
 #define BUNDLE_REVISION_H_
 
 #include <stdio.h>
+#include <stdbool.h>
 
 #include "celix_types.h"
 
@@ -56,11 +57,11 @@ extern "C" {
  * The location parameter is used to identify the bundle, in case of an update or download, the inputFile
  *  parameter can be used to point to the actual data. In the OSGi specification this is the inputstream.
  *
- * @param pool The pool on which this revision has to be allocated.
  * @param root The root for this revision in which the bundle is extracted and state is stored.
  * @param location The location associated with the revision
  * @param revisionNr The number of the revision
  * @param inputFile The (optional) location of the file to use as input for this revision
+ * @param cache Whether this revision represents a cache entry, in which case bundle extraction is skipped.
  * @param[out] bundle_revision The output parameter for the created revision.
  *
  * @return Status code indication failure or success:
@@ -68,7 +69,7 @@ extern "C" {
  * 		- CELIX_ENOMEM If allocating memory for <code>bundle_revision</code> failed.
  */
 celix_status_t bundleRevision_create(const char *root, const char *location, long revisionNr, const char *inputFile,
-                                     bundle_revision_pt *bundle_revision);
+                                     bool cache, bundle_revision_pt *bundle_revision);
 
 celix_status_t bundleRevision_destroy(bundle_revision_pt revision);
 

--- a/libs/framework/src/bundle_archive.c
+++ b/libs/framework/src/bundle_archive.c
@@ -51,7 +51,7 @@ static celix_status_t bundleArchive_initialize(bundle_archive_pt archive);
 
 static celix_status_t bundleArchive_deleteTree(bundle_archive_pt archive, const char * directory);
 
-static celix_status_t bundleArchive_createRevisionFromLocation(bundle_archive_pt archive, const char *location, const char *inputFile, long revNr, bundle_revision_pt *bundle_revision);
+static celix_status_t bundleArchive_createRevisionFromLocation(bundle_archive_pt archive, const char *location, const char *inputFile, long revNr, bundle_revision_pt *bundle_revision, bool isReload);
 static celix_status_t bundleArchive_reviseInternal(bundle_archive_pt archive, bool isReload, long revNr, const char * location, const char *inputFile);
 
 static celix_status_t bundleArchive_readLastModified(bundle_archive_pt archive, time_t *time);
@@ -567,7 +567,7 @@ static celix_status_t bundleArchive_reviseInternal(bundle_archive_pt archive, bo
 		location = "inputstream:";
 	}
 
-	status = bundleArchive_createRevisionFromLocation(archive, location, inputFile, revNr, &revision);
+	status = bundleArchive_createRevisionFromLocation(archive, location, inputFile, revNr, &revision, isReload);
 
 	if (status == CELIX_SUCCESS) {
 		if (!isReload) {
@@ -587,7 +587,7 @@ celix_status_t bundleArchive_rollbackRevise(bundle_archive_pt archive, bool *rol
 	return CELIX_SUCCESS;
 }
 
-static celix_status_t bundleArchive_createRevisionFromLocation(bundle_archive_pt archive, const char *location, const char *inputFile, long revNr, bundle_revision_pt *bundle_revision) {
+static celix_status_t bundleArchive_createRevisionFromLocation(bundle_archive_pt archive, const char *location, const char *inputFile, long revNr, bundle_revision_pt *bundle_revision, bool isReload) {
 	celix_status_t status = CELIX_SUCCESS;
 	char root[256];
 	long refreshCount;
@@ -597,7 +597,7 @@ static celix_status_t bundleArchive_createRevisionFromLocation(bundle_archive_pt
 		bundle_revision_pt revision = NULL;
 
 		sprintf(root, "%s/version%ld.%ld", archive->archiveRoot, refreshCount, revNr);
-		status = bundleRevision_create(root, location, revNr, inputFile, &revision);
+		status = bundleRevision_create(root, location, revNr, inputFile, isReload, &revision);
 
 		if (status == CELIX_SUCCESS) {
 			*bundle_revision = revision;

--- a/libs/framework/src/bundle_revision.c
+++ b/libs/framework/src/bundle_revision.c
@@ -27,7 +27,7 @@
 
 #include "bundle_revision_private.h"
 
-celix_status_t bundleRevision_create(const char *root, const char *location, long revisionNr, const char *inputFile, bundle_revision_pt *bundle_revision) {
+celix_status_t bundleRevision_create(const char *root, const char *location, long revisionNr, const char *inputFile, bool cache, bundle_revision_pt *bundle_revision) {
     celix_status_t status = CELIX_SUCCESS;
 	bundle_revision_pt revision = NULL;
 
@@ -40,13 +40,14 @@ celix_status_t bundleRevision_create(const char *root, const char *location, lon
             free(revision);
             status = CELIX_FILE_IO_EXCEPTION;
         } else {
-            if (inputFile != NULL) {
-                status = extractBundle(inputFile, root);
-            } else if (strcmp(location, "inputstream:") != 0) {
-            	// If location != inputstream, extract it, else ignore it and assume this is a cache entry.
-                status = extractBundle(location, root);
+            if (!cache) {
+                if (inputFile != NULL) {
+                    status = extractBundle(inputFile, root);
+                } else if (strcmp(location, "inputstream:") != 0) {
+                    // If location != inputstream, extract it, else ignore it and assume this is a cache entry.
+                    status = extractBundle(location, root);
+                }
             }
-
             status = CELIX_DO_IF(status, arrayList_create(&(revision->libraryHandles)));
             if (status == CELIX_SUCCESS) {
                 revision->revisionNr = revisionNr;


### PR DESCRIPTION
This PR is requesting for comments, and NOT for immediate merge.

The intention is to remove bundle zip files (or truncate to size 0) after they have been installed into cache. This could be very useful for highly storage-constrained embedded device. In my day time job, I keep the zip file but truncate it to size 0 so that when bundles are configured using config.properties, relative path resolution against `CELIX_BUNDLES_PATH`, which involves using 'access' to test for entity existence,  works as before. 

Will this change conflict with OSGi specs or any existing use cases?

Next I will dive into the OSGi modular layer, and try to solve some remaining issues, e.g. #130 #301. Storage optimization and startup speed optimization are both on my list. Guidance will be highly appreciated! 