### PR TITLE
Feature/uclibc support

### DIFF
--- a/bundles/logging/log_service_api/include/celix_log_service.h
+++ b/bundles/logging/log_service_api/include/celix_log_service.h
@@ -21,6 +21,7 @@
 #define CELIX_LOG_SERVICE_H
 
 #include "celix_log_level.h"
+#include <stdarg.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/libs/framework/include/celix_bundle_context.h
+++ b/libs/framework/include/celix_bundle_context.h
@@ -22,6 +22,7 @@
 #include "celix_properties.h"
 #include "celix_array_list.h"
 #include "celix_filter.h"
+#include <stdarg.h>
 
 #ifndef CELIX_BUNDLE_CONTEXT_H_
 #define CELIX_BUNDLE_CONTEXT_H_

--- a/libs/framework/include/celix_framework.h
+++ b/libs/framework/include/celix_framework.h
@@ -25,6 +25,7 @@
 #include "celix_properties.h"
 #include "celix_log_level.h"
 #include "celix_array_list.h"
+#include <stdarg.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/libs/framework/include/celix_log.h
+++ b/libs/framework/include/celix_log.h
@@ -25,6 +25,7 @@
 #include "celix_log_level.h"
 #include "celix_errno.h"
 #include "framework_exports.h"
+#include <stdarg.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/libs/framework/src/dm_component_impl.c
+++ b/libs/framework/src/dm_component_impl.c
@@ -168,12 +168,12 @@ void component_destroy(celix_dm_component_t *component) {
 
 void celix_dmComponent_destroy(celix_dm_component_t *component) {
     if (component != NULL) {
-        celix_dmComponent_destroyAsync(component, NULL, NULL);
 
         if (celix_framework_isCurrentThreadTheEventLoop(celix_bundleContext_getFramework(component->context))) {
             celix_bundleContext_log(component->context, CELIX_LOG_LEVEL_ERROR,
                    "Cannot synchronized destroy dm component on Celix event thread. Use celix_dmComponent_destroyAsync instead!");
         } else {
+            celix_dmComponent_destroyAsync(component, NULL, NULL);
             celix_bundleContext_waitForEvents(component->context);
         }
     }

--- a/libs/utils/src/celix_log_utils.c
+++ b/libs/utils/src/celix_log_utils.c
@@ -96,8 +96,8 @@ celix_log_level_e celix_logUtils_logLevelFromStringWithCheck(const char *str, ce
     return level;
 }
 
-static inline void celix_logUtils_inlinePrintBacktrace(FILE *stream) {
 #ifndef __UCLIBC__
+static inline void celix_logUtils_inlinePrintBacktrace(FILE *stream) {
     void *bbuf[64];
     int nrOfTraces = backtrace(bbuf, 64);
     char **lines = backtrace_symbols(bbuf, nrOfTraces);
@@ -107,8 +107,12 @@ static inline void celix_logUtils_inlinePrintBacktrace(FILE *stream) {
     }
     free(lines);
     fflush(stream);
-#endif
 }
+#else /* __UCLIBC__ */
+static inline void celix_logUtils_inlinePrintBacktrace(FILE *stream __attribute__((unused))) {
+    //nop
+}
+#endif /* __UCLIBC__ */
 
 void celix_logUtils_printBacktrace(FILE* stream) {
     celix_logUtils_inlinePrintBacktrace(stream);

--- a/libs/utils/src/celix_log_utils.c
+++ b/libs/utils/src/celix_log_utils.c
@@ -21,7 +21,9 @@
 
 #include <stdbool.h>
 #include <stdarg.h>
+#ifndef __UCLIBC__
 #include <execinfo.h>
+#endif
 #include <stdlib.h>
 #include <stdio.h>
 #include <time.h>
@@ -95,6 +97,7 @@ celix_log_level_e celix_logUtils_logLevelFromStringWithCheck(const char *str, ce
 }
 
 static inline void celix_logUtils_inlinePrintBacktrace(FILE *stream) {
+#ifndef __UCLIBC__
     void *bbuf[64];
     int nrOfTraces = backtrace(bbuf, 64);
     char **lines = backtrace_symbols(bbuf, nrOfTraces);
@@ -104,6 +107,7 @@ static inline void celix_logUtils_inlinePrintBacktrace(FILE *stream) {
     }
     free(lines);
     fflush(stream);
+#endif
 }
 
 void celix_logUtils_printBacktrace(FILE* stream) {

--- a/libs/utils/src/celix_threads.c
+++ b/libs/utils/src/celix_threads.c
@@ -45,7 +45,7 @@ celix_status_t celixThread_create(celix_thread_t *new_thread, celix_thread_attr_
     return status;
 }
 
-#if defined(_GNU_SOURCE) && defined(__linux__)
+#if defined(_GNU_SOURCE) && defined(__linux__) && !defined(__UCLIBC__)
 void celixThread_setName(celix_thread_t *thread, const char *threadName) {
     pthread_setname_np(thread->thread, threadName);
 }


### PR DESCRIPTION
Fix all problems found when compiling against uclibc:

- Lack of `backtrace`. The most plausible way of supporting it is via [libunwind](https://github.com/libunwind/libunwind)
- Lack of `pthread_setname_np`. Indeed, we can use `prctl(PR_SET_NAME)` to set the task name of the calling thread. To set task name of arbitrary `pthread_t`, we have to know the corresponding tid for a given pthread_t. Unfortunately there is no  `pthread_getthreadid_np` in uclibc.

Though uclibc is still used in newest SOCs in my day job, it's not actively maintained any more. And there is no rush to support these features on platforms using uclibc.