### PR TITLE
Add COPY / NO_COPY option in the celix_container_bundles cmake function

### DIFF
--- a/bundles/logging/README.md
+++ b/bundles/logging/README.md
@@ -54,4 +54,4 @@ If the Celix Log Service is installed, 'find_package(Celix)' will set:
  
 Also the following deprecated bundle will be set:
  - The `Celix::log_service` bundle target. The log service bundle. Deprecated, use Celix::log_admin instead.
- - The `Celix::log_writer_stdout` bundle target. Deprecated bundle. Logging to stdout is now an integral part of the log admin.
+ - The `Celix::syslog_writer` bundle target. Deprecated bundle. Logging to stdout is now an integral part of the log admin.

--- a/cmake/cmake_celix/ContainerPackaging.cmake
+++ b/cmake/cmake_celix/ContainerPackaging.cmake
@@ -264,7 +264,7 @@ $<JOIN:$<TARGET_PROPERTY:${CONTAINER_TARGET},CONTAINER_EMBEDDED_PROPERTIES>,\\n\
 "
         )
 
-        #Rerun generate to do a second parsing of generator expression
+        #Rerun generate to do a second parsing of generator expressions
         file(GENERATE OUTPUT "${STAGE2_LAUNCHER_SRC}" INPUT "${STAGE1_LAUNCHER_SRC}")
 
         #To prevent unnecessary build times a custom command is used to ensure that the copy to launcher src is only
@@ -272,7 +272,8 @@ $<JOIN:$<TARGET_PROPERTY:${CONTAINER_TARGET},CONTAINER_EMBEDDED_PROPERTIES>,\\n\
         add_custom_command(
                 OUTPUT "${LAUNCHER_SRC}"
                 COMMAND ${CMAKE_COMMAND} -E copy "${STAGE2_LAUNCHER_SRC}" "${LAUNCHER_SRC}"
-                DEPENDS "${STAGE2_LAUNCHER_SRC}")
+                DEPENDS "${STAGE2_LAUNCHER_SRC}"
+        )
     endif ()
 
     if (LAUNCHER_SRC) #compilation needed

--- a/cmake/cmake_celix/ContainerPackaging.cmake
+++ b/cmake/cmake_celix/ContainerPackaging.cmake
@@ -250,7 +250,6 @@ function(add_celix_container)
             endif ()
         endif()
         set(STAGE1_LAUNCHER_SRC "${CMAKE_BINARY_DIR}/celix/gen/containers/${CONTAINER_TARGET}/main.stage1.c")
-        set(STAGE2_LAUNCHER_SRC "${CMAKE_BINARY_DIR}/celix/gen/containers/${CONTAINER_TARGET}/main.stage2.c")
 
         file(GENERATE
                 OUTPUT "${STAGE1_LAUNCHER_SRC}"
@@ -277,15 +276,7 @@ $<JOIN:$<TARGET_PROPERTY:${CONTAINER_TARGET},CONTAINER_EMBEDDED_PROPERTIES>,\\n\
         )
 
         #Rerun generate to do a second parsing of generator expressions
-        file(GENERATE OUTPUT "${STAGE2_LAUNCHER_SRC}" INPUT "${STAGE1_LAUNCHER_SRC}")
-
-        #To prevent unnecessary build times a custom command is used to ensure that the copy to launcher src is only
-        #done if the stage2 file is different
-        add_custom_command(
-                OUTPUT "${LAUNCHER_SRC}"
-                COMMAND ${CMAKE_COMMAND} -E copy "${STAGE2_LAUNCHER_SRC}" "${LAUNCHER_SRC}"
-                DEPENDS "${STAGE2_LAUNCHER_SRC}"
-        )
+        file(GENERATE OUTPUT "${LAUNCHER_SRC}" INPUT "${STAGE1_LAUNCHER_SRC}")
     endif ()
 
     if (LAUNCHER_SRC) #compilation needed

--- a/documents/cmake_commands/README.md
+++ b/documents/cmake_commands/README.md
@@ -345,14 +345,17 @@ Creating a Celix containers using 'add_celix_container' will lead to a CMake exe
 These targets can be used to run/debug Celix containers from a IDE (if the IDE supports CMake).
 
 Optional Arguments:
+- COPY: With this option the bundles used in the container will be copied in and configured for a bundles directory
+  next to the container executable. Only one of the COPY or NO_COPY options can be provided.
+  Default is COPY.
 - NO_COPY: With this option the bundles used in the container will be configured using absolute paths to the bundles
-  zip files.
-  Default the bundle zip files will be copied in and configured for a bundles directory
-  next to the container executable.
+  zip files. Only one of the COPY or NO_COPY options can be provided.
+  Default is COPY.
 - CXX: With this option the generated Celix launcher (if used) will be a C++ source.
-  This ensures that the Celix launcher is linked against stdlibc++.
+  This ensures that the Celix launcher is linked against stdlibc++. Only one of the C or CXX options can be provided.
   Default is CXX
-- C: With this option the generated Celix launcher (if used) will be a C source.
+- C: With this option the generated Celix launcher (if used) will be a C source. Only one of the C or CXX options can
+  be provided.
   Default is CXX
 - FAT: With this option only embedded bundles are allowed to be added to the container. Ensuring a container executable
   this is not dependent on external bundle zip files.
@@ -381,64 +384,67 @@ Optional Arguments:
 
 ```CMake
 add_celix_container(<celix_container_name>
-        [NO_COPY]
-        [CXX]
-        [C]
-        [FAT]
-        [USE_CONFIG]
-        [GROUP group_name]
-        [NAME celix_container_name]
-        [DIR dir]
-        [BUNDLES <bundle1> <bundle2> ...]
-        [INSTALL_BUNDLES <bundle1> <bundle2> ...]
-        [EMBEDDED_BUNDLES <bundle1> <bundle2> ...]
-        [INSTALL_EMBEDDED_BUNDLES <bundle1> <bundle2> ...]
-        [PROPERTIES "prop1=val1" "prop2=val2" ...]
-        [EMBEDDED_PROPERTIES "prop1=val1" "prop2=val2" ...]
-        [RUNTIME_PROPERTIES "prop1=val1" "prop2=val2" ...]
-        )
+    [COPY]
+    [NO_COPY]
+    [CXX]
+    [C]
+    [FAT]
+    [USE_CONFIG]
+    [GROUP group_name]
+    [NAME celix_container_name]
+    [DIR dir]
+    [BUNDLES <bundle1> <bundle2> ...]
+    [INSTALL_BUNDLES <bundle1> <bundle2> ...]
+    [EMBEDDED_BUNDLES <bundle1> <bundle2> ...]
+    [INSTALL_EMBEDDED_BUNDLES <bundle1> <bundle2> ...]
+    [PROPERTIES "prop1=val1" "prop2=val2" ...]
+    [EMBEDDED_PROPERTIES "prop1=val1" "prop2=val2" ...]
+    [RUNTIME_PROPERTIES "prop1=val1" "prop2=val2" ...]
+)
 ```
 
 ```CMake
 add_celix_container(<celix_container_name>
-        LAUNCHER launcher
-        [NO_COPY]
-        [CXX]
-        [C]
-        [FAT]
-        [USE_CONFIG]
-        [GROUP group_name]
-        [NAME celix_container_name]
-        [DIR dir]
-        [BUNDLES <bundle1> <bundle2> ...]
-        [INSTALL_BUNDLES <bundle1> <bundle2> ...]
-        [EMBEDDED_BUNDLES <bundle1> <bundle2> ...]
-        [INSTALL_EMBEDDED_BUNDLES <bundle1> <bundle2> ...]
-        [PROPERTIES "prop1=val1" "prop2=val2" ...]
-        [EMBEDDED_PROPERTIES "prop1=val1" "prop2=val2" ...]
-        [RUNTIME_PROPERTIES "prop1=val1" "prop2=val2" ...]
-        )
+    LAUNCHER launcher
+    [COPY]
+    [NO_COPY]
+    [CXX]
+    [C]
+    [FAT]
+    [USE_CONFIG]
+    [GROUP group_name]
+    [NAME celix_container_name]
+    [DIR dir]
+    [BUNDLES <bundle1> <bundle2> ...]
+    [INSTALL_BUNDLES <bundle1> <bundle2> ...]
+    [EMBEDDED_BUNDLES <bundle1> <bundle2> ...]
+    [INSTALL_EMBEDDED_BUNDLES <bundle1> <bundle2> ...]
+    [PROPERTIES "prop1=val1" "prop2=val2" ...]
+    [EMBEDDED_PROPERTIES "prop1=val1" "prop2=val2" ...]
+    [RUNTIME_PROPERTIES "prop1=val1" "prop2=val2" ...]
+)
 ```
 
 ```CMake
 add_celix_container(<celix_container_name>
-        LAUNCHER_SRC launcher_src
-        [NO_COPY]
-        [CXX]
-        [C]
-        [FAT]
-        [USE_CONFIG]
-        [GROUP group_name]
-        [NAME celix_container_name]
-        [DIR dir]
-        [BUNDLES <bundle1> <bundle2> ...]
-        [INSTALL_BUNDLES <bundle1> <bundle2> ...]
-        [EMBEDDED_BUNDLES <bundle1> <bundle2> ...]
-        [INSTALL_EMBEDDED_BUNDLES <bundle1> <bundle2> ...]
-        [PROPERTIES "prop1=val1" "prop2=val2" ...]
-        [EMBEDDED_PROPERTIES "prop1=val1" "prop2=val2" ...]
-        [RUNTIME_PROPERTIES "prop1=val1" "prop2=val2" ...]
-        )
+    LAUNCHER_SRC launcher_src
+    [COPY]
+    [NO_COPY]
+    [CXX]
+    [C]
+    [FAT]
+    [USE_CONFIG]
+    [GROUP group_name]
+    [NAME celix_container_name]
+    [DIR dir]
+    [BUNDLES <bundle1> <bundle2> ...]
+    [INSTALL_BUNDLES <bundle1> <bundle2> ...]
+    [EMBEDDED_BUNDLES <bundle1> <bundle2> ...]
+    [INSTALL_EMBEDDED_BUNDLES <bundle1> <bundle2> ...]
+    [PROPERTIES "prop1=val1" "prop2=val2" ...]
+    [EMBEDDED_PROPERTIES "prop1=val1" "prop2=val2" ...]
+    [RUNTIME_PROPERTIES "prop1=val1" "prop2=val2" ...]
+)
 ```
 
 Examples:
@@ -446,13 +452,13 @@ Examples:
 #Creates a Celix container in ${CMAKE_BINARY_DIR}/deploy/simple_container which starts 3 bundles located at
 #${CMAKE_BINARY_DIR}/deploy/simple_container/bundles.
 add_celix_container(simple_container
-        BUNDLES
+    BUNDLES
         Celix::shell
         Celix::shell_tui
         Celix::log_admin
-        PROPERTIES
+    PROPERTIES
         CELIX_LOGGING_DEFAULT_ACTIVE_LOG_LEVEL=debug
-        )
+)
 ```
 
 ```CMake

--- a/documents/cmake_commands/README.md
+++ b/documents/cmake_commands/README.md
@@ -504,7 +504,7 @@ Optional Arguments:
 - COPY: If this option is present, the bundles will be copied to the container build dir. This option overrides the
   NO_COPY option used in the add_celix_container call.
 - NO_COPY: If this option is present, the install/start bundles will be configured using a absolute path to the
-  bundle. This option overrides optional NO_COPY option used in the add_celix_container call.
+  bundle. This option overrides optional COPY option used in the add_celix_container call.
 
 ## celix_container_embedded_bundles
 Embed a selection of bundles to the Celix container.

--- a/documents/cmake_commands/README.md
+++ b/documents/cmake_commands/README.md
@@ -474,11 +474,13 @@ Add a selection of bundles to the Celix container.
 
 ```CMake
 celix_container_bundles(<celix_container_target_name>
-    [LEVEL (0..6)]
-    [INSTALL]
-    bundle1
-    bundle2
-    ...
+      [COPY]
+      [NO_COPY]
+      [LEVEL (0..6)]
+      [INSTALL]
+      bundle1
+      bundle2
+      ...
 )
 ```
 
@@ -499,6 +501,10 @@ Optional Arguments:
 - LEVEL: The run level for the added bundles. Default is 3.
 - INSTALL: If this option is present, the bundles will only be installed instead of the default install and start.
   The bundles will be installed after all bundle in LEVEL 0..6 are installed and started.
+- COPY: If this option is present, the bundles will be copied to the container build dir. This option overrides the
+  NO_COPY option used in the add_celix_container call.
+- NO_COPY: If this option is present, the install/start bundles will be configured using a absolute path to the
+  bundle. This option overrides optional NO_COPY option used in the add_celix_container call.
 
 ## celix_container_embedded_bundles
 Embed a selection of bundles to the Celix container.

--- a/examples/celix-examples/CMakeLists.txt
+++ b/examples/celix-examples/CMakeLists.txt
@@ -44,7 +44,7 @@ if (EXAMPLES)
     add_subdirectory(embedding)
     add_subdirectory(track_tracker_example)
     add_subdirectory(log_service_example)
-
     add_subdirectory(bundle_with_private_lib)
+    add_subdirectory(bundles_copy_example)
 
 endif(EXAMPLES)

--- a/examples/celix-examples/bundles_copy_example/CMakeLists.txt
+++ b/examples/celix-examples/bundles_copy_example/CMakeLists.txt
@@ -19,7 +19,7 @@
 
 if (TARGET Celix::log_admin AND TARGET Celix::shell AND TARGET Celix::shell_tui AND TARGET Celix::syslog_writer)
     #By default bundles in a container will be copied to the bundles dir in the container dir
-    add_celix_container(copy_bundles_example1 BUNDLES Celix::log_admin)
+    add_celix_container(copy_bundles_example1 COPY BUNDLES Celix::log_admin)
     #The shell bundle will also be copied, because of the container copy config
     celix_container_bundles(copy_bundles_example1 LEVEL 1 Celix::shell)
     #The shell_tui bundle will not be copied, because of the NO_COPY option

--- a/examples/celix-examples/bundles_copy_example/CMakeLists.txt
+++ b/examples/celix-examples/bundles_copy_example/CMakeLists.txt
@@ -17,21 +17,23 @@
 
 ######################## Examples for the COPY / NO_COPY option in celix_container_bundles work #######################
 
-#By default bundles in a container will be copied to the bundles dir in the container dir
-add_celix_container(copy_bundles_example1 BUNDLES Celix::log_admin)
-#The shell bundle will also be copied, because of the container copy config
-celix_container_bundles(copy_bundles_example1 LEVEL 1 Celix::shell)
-#The shell_tui bundle will not be copied, because of the NO_COPY option
-celix_container_bundles(copy_bundles_example1 NO_COPY LEVEL 1 Celix::shell_tui)
-#The log_writer_syslog bundle will be copied, because of the COPY option
-celix_container_bundles(copy_bundles_example1 LEVEL 2 COPY Celix::syslog_writer)
+if (TARGET Celix::log_admin AND TARGET Celix::shell AND TARGET Celix::shell_tui AND TARGET Celix::syslog_writer)
+    #By default bundles in a container will be copied to the bundles dir in the container dir
+    add_celix_container(copy_bundles_example1 BUNDLES Celix::log_admin)
+    #The shell bundle will also be copied, because of the container copy config
+    celix_container_bundles(copy_bundles_example1 LEVEL 1 Celix::shell)
+    #The shell_tui bundle will not be copied, because of the NO_COPY option
+    celix_container_bundles(copy_bundles_example1 NO_COPY LEVEL 1 Celix::shell_tui)
+    #The log_writer_syslog bundle will be copied, because of the COPY option
+    celix_container_bundles(copy_bundles_example1 LEVEL 2 COPY Celix::syslog_writer)
 
 
-#Bundles in this container will not be copied to the bundles dir in the container dir, because of the NO_COPY option
-add_celix_container(copy_bundles_example2 NO_COPY BUNDLES Celix::log_admin)
-#The shell bundle will also mpt be copied, because of the container copy config
-celix_container_bundles(copy_bundles_example2 LEVEL 1 Celix::shell)
-#The shell_tui bundle will not be copied, because of the NO_COPY option
-celix_container_bundles(copy_bundles_example2 LEVEL 1 NO_COPY Celix::shell_tui)
-#The log_writer_syslog bundle will be copied, because of the COPY option
-celix_container_bundles(copy_bundles_example2 COPY LEVEL 2 Celix::syslog_writer)
+    #Bundles in this container will not be copied to the bundles dir in the container dir, because of the NO_COPY option
+    add_celix_container(copy_bundles_example2 NO_COPY BUNDLES Celix::log_admin)
+    #The shell bundle will also mpt be copied, because of the container copy config
+    celix_container_bundles(copy_bundles_example2 LEVEL 1 Celix::shell)
+    #The shell_tui bundle will not be copied, because of the NO_COPY option
+    celix_container_bundles(copy_bundles_example2 LEVEL 1 NO_COPY Celix::shell_tui)
+    #The log_writer_syslog bundle will be copied, because of the COPY option
+    celix_container_bundles(copy_bundles_example2 COPY LEVEL 2 Celix::syslog_writer)
+endif ()

--- a/examples/celix-examples/bundles_copy_example/CMakeLists.txt
+++ b/examples/celix-examples/bundles_copy_example/CMakeLists.txt
@@ -1,0 +1,37 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+######################## Examples for the COPY / NO_COPY option in celix_container_bundles work #######################
+
+#By default bundles in a container will be copied to the bundles dir in the container dir
+add_celix_container(copy_bundles_example1 BUNDLES Celix::log_admin)
+#The shell bundle will also be copied, because of the container copy config
+celix_container_bundles(copy_bundles_example1 LEVEL 1 Celix::shell)
+#The shell_tui bundle will not be copied, because of the NO_COPY option
+celix_container_bundles(copy_bundles_example1 NO_COPY LEVEL 1 Celix::shell_tui)
+#The log_writer_syslog bundle will be copied, because of the COPY option
+celix_container_bundles(copy_bundles_example1 LEVEL 2 COPY Celix::syslog_writer)
+
+
+#Bundles in this container will not be copied to the bundles dir in the container dir, because of the NO_COPY option
+add_celix_container(copy_bundles_example2 NO_COPY BUNDLES Celix::log_admin)
+#The shell bundle will also mpt be copied, because of the container copy config
+celix_container_bundles(copy_bundles_example2 LEVEL 1 Celix::shell)
+#The shell_tui bundle will not be copied, because of the NO_COPY option
+celix_container_bundles(copy_bundles_example2 LEVEL 1 NO_COPY Celix::shell_tui)
+#The log_writer_syslog bundle will be copied, because of the COPY option
+celix_container_bundles(copy_bundles_example2 COPY LEVEL 2 Celix::syslog_writer)

--- a/examples/celix-examples/bundles_copy_example/CMakeLists.txt
+++ b/examples/celix-examples/bundles_copy_example/CMakeLists.txt
@@ -30,7 +30,7 @@ if (TARGET Celix::log_admin AND TARGET Celix::shell AND TARGET Celix::shell_tui 
 
     #Bundles in this container will not be copied to the bundles dir in the container dir, because of the NO_COPY option
     add_celix_container(copy_bundles_example2 NO_COPY BUNDLES Celix::log_admin)
-    #The shell bundle will also mpt be copied, because of the container copy config
+    #The shell bundle will also not be copied, because of the container copy config
     celix_container_bundles(copy_bundles_example2 LEVEL 1 Celix::shell)
     #The shell_tui bundle will not be copied, because of the NO_COPY option
     celix_container_bundles(copy_bundles_example2 LEVEL 1 NO_COPY Celix::shell_tui)


### PR DESCRIPTION
When using container images it is useful to be able to selective copy or not copy bundles in a celix container (deploy) dir.

This PR add support for a COPY and NO_COPY option in the celix_bundles_container cmake function.

Also updates the add_celix_container cmake function, so that the generated main c/cc file will only be a newer file if the content is changed. 