### PR TITLE
Feature/update debug optimalization flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,8 +147,8 @@ endif()
 
 # Set build type specific flags
 # Debug
-set(CMAKE_C_FLAGS_DEBUG "-g -DDEBUG ${CMAKE_C_FLAGS}")
-set(CMAKE_CXX_FLAGS_DEBUG "-g -DDEBUG ${CMAKE_CXX_FLAGS}")
+set(CMAKE_C_FLAGS_DEBUG "-g -DDEBUG -Og ${CMAKE_C_FLAGS}")
+set(CMAKE_CXX_FLAGS_DEBUG "-g -DDEBUG -Og ${CMAKE_CXX_FLAGS}")
 set(CMAKE_DEBUG_POSTFIX "d")
 
 if (CMAKE_BUILD_TYPE STREQUAL "Debug")

--- a/libs/dfi/CMakeLists.txt
+++ b/libs/dfi/CMakeLists.txt
@@ -39,7 +39,7 @@ target_include_directories(dfi PUBLIC
 	$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>
 	$<INSTALL_INTERFACE:include/celix/dfi>
 )
-
+target_compile_options(dfi PRIVATE -O0) #Remove optimalization to ensure libdfi / ffi works
 target_link_libraries(dfi PRIVATE libffi::libffi)
 target_link_libraries(dfi PUBLIC jansson::jansson)
 target_link_libraries(dfi PRIVATE Celix::utils)

--- a/libs/dfi/CMakeLists.txt
+++ b/libs/dfi/CMakeLists.txt
@@ -39,7 +39,6 @@ target_include_directories(dfi PUBLIC
 	$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>
 	$<INSTALL_INTERFACE:include/celix/dfi>
 )
-target_compile_options(dfi PRIVATE -O0) #Remove optimalization to ensure libdfi / ffi works
 target_link_libraries(dfi PRIVATE libffi::libffi)
 target_link_libraries(dfi PUBLIC jansson::jansson)
 target_link_libraries(dfi PRIVATE Celix::utils)

--- a/libs/dfi/gtest/CMakeLists.txt
+++ b/libs/dfi/gtest/CMakeLists.txt
@@ -31,7 +31,7 @@ add_executable(test_dfi
 		src/json_rpc_avpr_tests.cpp
 		src/avrobin_serialization_tests.cpp
 )
-
+target_compile_options(test_dfi PRIVATE -O0)
 target_link_libraries(test_dfi PRIVATE Celix::dfi Celix::utils libffi::libffi jansson::jansson GTest::gtest GTest::gtest_main)
 
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/schemas DESTINATION ${CMAKE_CURRENT_BINARY_DIR})

--- a/libs/dfi/gtest/CMakeLists.txt
+++ b/libs/dfi/gtest/CMakeLists.txt
@@ -31,7 +31,14 @@ add_executable(test_dfi
 		src/json_rpc_avpr_tests.cpp
 		src/avrobin_serialization_tests.cpp
 )
-target_compile_options(test_dfi PRIVATE -O0)
+
+#[[
+Note: setting optimize -O0 for the dfi test, because this is needed to get the
+DynFunctionTests.DynFuncTest2 and DynFunctionTests.DynFuncTest3 working.
+See issue #232
+]]
+target_compile_options(test_dfi PRIVATE -O0) #This is needed because
+
 target_link_libraries(test_dfi PRIVATE Celix::dfi Celix::utils libffi::libffi jansson::jansson GTest::gtest GTest::gtest_main)
 
 file(COPY ${CMAKE_CURRENT_LIST_DIR}/schemas DESTINATION ${CMAKE_CURRENT_BINARY_DIR})

--- a/libs/dfi/gtest/src/dyn_function_tests.cpp
+++ b/libs/dfi/gtest/src/dyn_function_tests.cpp
@@ -156,14 +156,9 @@ TEST_F(DynFunctionTests, DynFuncAccTest) {
 }
 
 extern "C" {
-#ifdef __clang__
-[[clang::optnone]]
-#else
-__attribute__((optimize("0")))
-#endif
 static bool func_test3() {
     dyn_function_type *dynFunc = nullptr;
-    void (*fp)(void) = (void(*)(void)) testExample3;
+    void (*fp)(void) = (void (*)(void)) testExample3;
     int rc;
 
     rc = dynFunction_parseWithStr(EXAMPLE3_DESCRIPTOR, nullptr, &dynFunc);
@@ -182,7 +177,7 @@ static bool func_test3() {
 
         rc = dynFunction_call(dynFunc, fp, &rVal, args);
 
-        double *inMemResult = (double *)calloc(1, sizeof(double));
+        double *inMemResult = (double *) calloc(1, sizeof(double));
         a = 2.0;
         ptr = &a;
         args[0] = &ptr;
@@ -201,7 +196,6 @@ static bool func_test3() {
     return rc == 0 && result1 == 4.0 && result2 == 4.0;
 }
 }
-
 
 TEST_F(DynFunctionTests, DynFuncTest3) {
     //NOTE only using libffi with extern C, because combining libffi with EXPECT_*/ASSERT_* call leads to


### PR DESCRIPTION
Add -Og flag when Debug type is used, with exception of libdfi. 

libdfi and the test code for libdfi can result in segfault when using optimization
