### PR TITLE
Hotfix/printf format fix

### DIFF
--- a/bundles/logging/log_helper/include/celix_log_helper.h
+++ b/bundles/logging/log_helper/include/celix_log_helper.h
@@ -38,39 +38,39 @@ void celix_logHelper_destroy(celix_log_helper_t* logHelper);
 /**
  * @brief Logs to celix_logHelper_log using the CELIX_LOG_LEVEL_TRACE level, printf style
  */
-void celix_logHelper_trace(celix_log_helper_t* logHelper, const char *format, ...);
+void celix_logHelper_trace(celix_log_helper_t* logHelper, const char *format, ...) __attribute__((format(printf,2,3)));
 
 /**
  * @brief Logs to celix_logHelper_log using the CELIX_LOG_LEVEL_DEBUG level, printf style
  */
-void celix_logHelper_debug(celix_log_helper_t* logHelper, const char *format, ...);
+void celix_logHelper_debug(celix_log_helper_t* logHelper, const char *format, ...) __attribute__((format(printf,2,3)));
 
 /**
  * @brief Logs to celix_logHelper_log using the CELIX_LOG_LEVEL_INFO level, printf style
  */
-void celix_logHelper_info(celix_log_helper_t* logHelper, const char *format, ...);
+void celix_logHelper_info(celix_log_helper_t* logHelper, const char *format, ...) __attribute__((format(printf,2,3)));
 
 /**
  * @brief Logs to celix_logHelper_log using the CELIX_LOG_LEVEL_WARNING level, printf style
  */
-void celix_logHelper_warning(celix_log_helper_t* logHelper, const char *format, ...);
+void celix_logHelper_warning(celix_log_helper_t* logHelper, const char *format, ...) __attribute__((format(printf,2,3)));
 
 /**
  * @brief Logs to celix_logHelper_log using the CELIX_LOG_LEVEL_ERROR level, printf style
  */
-void celix_logHelper_error(celix_log_helper_t* logHelper, const char *format, ...);
+void celix_logHelper_error(celix_log_helper_t* logHelper, const char *format, ...) __attribute__((format(printf,2,3)));
 
 /**
  * @brief Logs to celix_logHelper_log using the CELIX_LOG_LEVEL_FATAL level, printf style
  */
-void celix_logHelper_fatal(celix_log_helper_t* logHelper, const char *format, ...);
+void celix_logHelper_fatal(celix_log_helper_t* logHelper, const char *format, ...) __attribute__((format(printf,2,3)));
 
 /**
  * @brief Logs a message using the provided celix log level to the log_helper, printf style.
  *
  * Silently ignores log level CELIX_LOG_LEVEL_DISABLED.
  */
-void celix_logHelper_log(celix_log_helper_t* logHelper, celix_log_level_e level, const char *format, ...);
+void celix_logHelper_log(celix_log_helper_t* logHelper, celix_log_level_e level, const char *format, ...) __attribute__((format(printf,3,4)));
 
 /**
  * @brief Logs a detailed message using the provided celix log level to the log_helper, printf style.
@@ -83,14 +83,22 @@ void celix_logHelper_log(celix_log_helper_t* logHelper, celix_log_level_e level,
  * If the argument file or function is NULL, the arguments file, function and line are not used.
  *
  */
-void celix_logHelper_logDetails(celix_log_helper_t* logHelper, celix_log_level_e level, const char* file, const char* function, int line, const char *format, ...);
+void celix_logHelper_logDetails(celix_log_helper_t* logHelper,
+                                celix_log_level_e level,
+                                const char* file,
+                                const char* function,
+                                int line,
+                                const char *format, ...) __attribute__((format(printf,6,7)));
 
 /**
  * @brief Logs a message to the log_helper using a format string and a va_list argument (vprintf style).
  *
  * Silently ignores log level CELIX_LOG_LEVEL_DISABLED.
  */
-void celix_logHelper_vlog(celix_log_helper_t* logHelper, celix_log_level_e level, const char *format, va_list formatArgs);
+void celix_logHelper_vlog(celix_log_helper_t* logHelper,
+                          celix_log_level_e level,
+                          const char *format,
+                          va_list formatArgs) __attribute__((format(printf,3,0)));
 
 /**
  * @brief Logs a detailed message to log_helper using a format string and a va_list argument (vprintf style).
@@ -103,7 +111,13 @@ void celix_logHelper_vlog(celix_log_helper_t* logHelper, celix_log_level_e level
  * If the argument file or function is NULL, the arguments file, function and line are not used.
  *
  */
-void celix_logHelper_vlogDetails(celix_log_helper_t* logHelper, celix_log_level_e level, const char* file, const char* function, int line, const char *format, va_list formatArgs);
+void celix_logHelper_vlogDetails(celix_log_helper_t* logHelper,
+                                 celix_log_level_e level,
+                                 const char* file,
+                                 const char* function,
+                                 int line,
+                                 const char *format,
+                                 va_list formatArgs) __attribute__((format(printf,6,0)));
 
 /**
  * @brief nr of times a helper log function has been called.

--- a/bundles/pubsub/pubsub_admin_tcp/src/pubsub_tcp_handler.c
+++ b/bundles/pubsub/pubsub_admin_tcp/src/pubsub_tcp_handler.c
@@ -337,7 +337,7 @@ pubsub_tcpHandler_createEntry(pubsub_tcpHandler_t *handle, int fd, char *url, ch
         entry->connected = false;
         unsigned minimalMsgSize = entry->writeHeaderBufferSize + entry->writeFooterBufferSize;
         if ((minimalMsgSize > handle->maxMsgSize) && (handle->maxMsgSize)) {
-            L_ERROR("[TCP Socket] maxMsgSize (%d) < headerSize + FooterSize (%d): %s\n", handle->maxMsgSize, minimalMsgSize);
+            L_ERROR("[TCP Socket] maxMsgSize (%d) < headerSize + FooterSize (%d)\n", handle->maxMsgSize, minimalMsgSize);
         } else {
             entry->maxMsgSize = (handle->maxMsgSize) ? handle->maxMsgSize : LONG_MAX;
         }
@@ -1192,7 +1192,7 @@ int pubsub_tcpHandler_write(pubsub_tcpHandler_t *handle, pubsub_protocol_message
                 } else if (msgPartSize) {
                     entry->retryCount = 0;
                     if (nbytes != msgPartSize) {
-                        L_ERROR("[TCP Socket] seq: %d MsgSize not correct: %d != %d (%s)\n", message->header.seqNr, msgPartSize, nbytes, strerror(errno));
+                        L_ERROR("[TCP Socket] seq: %d MsgSize not correct: %zu != %ld (%s)\n", message->header.seqNr, msgPartSize, nbytes, strerror(errno));
                     }
                 }
                 // Note: serialized Payload is deleted by serializer

--- a/bundles/pubsub/pubsub_admin_udp_mc/src/pubsub_udpmc_admin.c
+++ b/bundles/pubsub/pubsub_admin_udp_mc/src/pubsub_udpmc_admin.c
@@ -324,7 +324,7 @@ celix_status_t pubsub_udpmcAdmin_setupTopicSender(void *handle, const char *scop
             hashMap_put(psa->topicSenders.map, key, sender);
         } else {
             free(key);
-            L_ERROR("[PSA UDPMC] Error creating a valid TopicSender. Endpoints are not valid %i", serializerSvcId);
+            L_ERROR("[PSA UDPMC] Error creating a valid TopicSender. Endpoints are not valid %ld", serializerSvcId);
         }
     } else {
         free(key);
@@ -605,7 +605,7 @@ void pubsub_udpmcAdmin_addSerializerSvc(void *handle, void *svc, const celix_pro
         L_INFO("[PSA_UDPMC] Ignoring serializer service without %s property", PUBSUB_SERIALIZER_TYPE_KEY);
         return;
     }
-    L_WARN("[PSA_UDPM] adding serializer %s %i", serType, svcId);
+    L_WARN("[PSA_UDPM] adding serializer %s %ld", serType, svcId);
 
     celixThreadMutex_lock(&psa->serializers.mutex);
     psa_udpmc_serializer_entry_t *entry = hashMap_get(psa->serializers.map, (void*)svcId);

--- a/bundles/pubsub/pubsub_admin_websocket/src/pubsub_websocket_topic_receiver.c
+++ b/bundles/pubsub/pubsub_admin_websocket/src/pubsub_websocket_topic_receiver.c
@@ -344,7 +344,7 @@ void pubsub_websocketTopicReceiver_listConnections(pubsub_websocket_topic_receiv
 
 
 void pubsub_websocketTopicReceiver_connectTo(pubsub_websocket_topic_receiver_t *receiver, const char *socketAddress, long socketPort) {
-    L_DEBUG("[PSA_WEBSOCKET] TopicReceiver %s/%s ('%s') connecting to websocket address %s:li", receiver->scope == NULL ? "(null)" : receiver->scope, receiver->topic, receiver->uri, socketAddress, socketPort);
+    L_DEBUG("[PSA_WEBSOCKET] TopicReceiver %s/%s ('%s') connecting to websocket address %s:%ld", receiver->scope == NULL ? "(null)" : receiver->scope, receiver->topic, receiver->uri, socketAddress, socketPort);
 
     char *key = NULL;
     asprintf(&key, "%s:%li", socketAddress, socketPort);
@@ -539,7 +539,7 @@ static void processMsg(pubsub_websocket_topic_receiver_t *receiver, const char *
             free(payload);
         } else {
             L_WARN("[PSA_WEBSOCKET_TR] Received unsupported message: "
-                   "ID = %s, major = %d, minor = %d, seqNr = %d, data valid? %s",
+                   "ID = %s, major = %"JSON_INTEGER_FORMAT", minor = %"JSON_INTEGER_FORMAT", seqNr = %"JSON_INTEGER_FORMAT", data valid? %s",
                    (jsId ? json_string_value(jsId) : "ERROR"),
                    json_integer_value(jsMajor), json_integer_value(jsMinor),
                    json_integer_value(jsSeqNr), (jsData ? "TRUE" : "FALSE"));

--- a/bundles/pubsub/pubsub_admin_zmq/src/pubsub_zmq_admin.c
+++ b/bundles/pubsub/pubsub_admin_zmq/src/pubsub_zmq_admin.c
@@ -160,7 +160,7 @@ pubsub_zmq_admin_t* pubsub_zmqAdmin_create(celix_bundle_context_t *ctx, celix_lo
     long nrThreads = celix_bundleContext_getPropertyAsLong(ctx, PUBSUB_ZMQ_NR_THREADS_KEY, 0);
     if (nrThreads > 0) {
         zsys_set_io_threads((size_t)nrThreads);
-        L_INFO("[PSA_ZMQ] Using %d threads for ZMQ", (size_t)nrThreads);
+        L_INFO("[PSA_ZMQ] Using %ld threads for ZMQ", nrThreads);
     }
 
 

--- a/bundles/pubsub/pubsub_utils/src/pubsub_serialization_provider.c
+++ b/bundles/pubsub/pubsub_utils/src/pubsub_serialization_provider.c
@@ -454,7 +454,7 @@ static void pubsub_serializationProvider_parseDescriptors(pubsub_serialization_p
 
         bool unique = pubsub_serializationProvider_validateEntry(provider, serEntry);
         if (unique && serEntry->valid) { //note only register if unique and valid
-            L_DEBUG("Adding message serialization entry for msg %s with id %d and version %s", serEntry->msgFqn, serEntry->msgId, serEntry->msgVersion);
+            L_DEBUG("Adding message serialization entry for msg %s with id %d and version %s", serEntry->msgFqn, serEntry->msgId, serEntry->msgVersionStr);
             pubsub_serializationProvider_registerSerializationEntry(provider, serEntry);
         }
 

--- a/bundles/pubsub/pubsub_utils/src/pubsub_serializer_handler.c
+++ b/bundles/pubsub/pubsub_utils/src/pubsub_serializer_handler.c
@@ -219,7 +219,7 @@ void pubsub_serializerHandler_addSerializationService(pubsub_serializer_handler_
 
     celix_version_t* msgVersion = celix_version_createVersionFromString(version);
     if (msgVersion == NULL) {
-        L_ERROR("%s service has an invalid %s property. value is '%s'", PUBSUB_MESSAGE_SERIALIZATION_SERVICE_NAME, PUBSUB_MESSAGE_SERIALIZATION_SERVICE_MSG_VERSION_PROPERTY, msgVersion);
+        L_ERROR("%s service has an invalid %s property. value is '%s'", PUBSUB_MESSAGE_SERIALIZATION_SERVICE_NAME, PUBSUB_MESSAGE_SERIALIZATION_SERVICE_MSG_VERSION_PROPERTY, version);
         return;
     }
 

--- a/bundles/remote_services/remote_service_admin_shm_v2/rsa_shm/src/rsa_shm_client.c
+++ b/bundles/remote_services/remote_service_admin_shm_v2/rsa_shm/src/rsa_shm_client.c
@@ -739,7 +739,7 @@ static bool rsaShmClient_shouldBreakInvocation(rsa_shm_client_t *client, long se
         }
 
         if (svcDiagInfo->concurrentInvocations > clientManager->maxConcurrentNum) {
-            celix_logHelper_error(clientManager->logHelper,"RsaShmClient:The number of concurrent invocation for service id %ld is greater than %d.",
+            celix_logHelper_error(clientManager->logHelper,"RsaShmClient:The number of concurrent invocation for service id %ld is greater than %ld.",
                     serviceId, clientManager->maxConcurrentNum);
             breaked = true;
             break;

--- a/bundles/remote_services/remote_service_admin_shm_v2/rsa_shm/src/rsa_shm_export_registration.c
+++ b/bundles/remote_services/remote_service_admin_shm_v2/rsa_shm/src/rsa_shm_export_registration.c
@@ -258,7 +258,7 @@ static void exportRegistration_addRpcFac(void *handle, void *svc) {
     opts.remove = exportRegistration_removeRequestHandlerSvc;
     export->reqHandlerSvcTrkId = celix_bundleContext_trackServicesWithOptionsAsync(export->context, &opts);
     if (export->reqHandlerSvcTrkId < 0) {
-        celix_logHelper_error(export->logHelper,"RSA export reg: Error Tracking service for %s(%d)", RSA_REQUEST_HANDLER_SERVICE_NAME, export->reqHandlerSvcId);
+        celix_logHelper_error(export->logHelper,"RSA export reg: Error Tracking service for %s(%ld)", RSA_REQUEST_HANDLER_SERVICE_NAME, export->reqHandlerSvcId);
         goto err_tracking_endpoint_svc;
     }
     export->reqHandlerSvcId = reqHandlerSvcId;

--- a/bundles/remote_services/rsa_rpc_json/src/rsa_json_rpc_endpoint_impl.c
+++ b/bundles/remote_services/rsa_rpc_json/src/rsa_json_rpc_endpoint_impl.c
@@ -227,7 +227,7 @@ static celix_status_t rsaJsonRpcEndpoint_handleRequest(void *handle, celix_prope
 
     long serialProtoId  = celix_properties_getAsLong(metadata, "SerialProtocolId", 0);
     if (serialProtoId != endpoint->serialProtoId) {
-        celix_logHelper_error(endpoint->logHelper, "Serialization protocol ID mismatch. expect:%ld actual:%ld.", serialProtoId, endpoint->serialProtoId);
+        celix_logHelper_error(endpoint->logHelper, "Serialization protocol ID mismatch. expect:%ld actual:%u.", serialProtoId, endpoint->serialProtoId);
         return CELIX_ILLEGAL_ARGUMENT;
     }
 


### PR DESCRIPTION
Add __attribute__((format(printf))) to log helper and fix all gcc warnings.