### PR TITLE
Remove buffer mechanism from websocket pubsub admin, make similar to tcp admin

### DIFF
--- a/bundles/pubsub/pubsub_admin_websocket/src/pubsub_psa_websocket_constants.h
+++ b/bundles/pubsub/pubsub_admin_websocket/src/pubsub_psa_websocket_constants.h
@@ -39,6 +39,11 @@
 #define PUBSUB_WEBSOCKET_ADDRESS_KEY                  "websocket.socket_address"
 #define PUBSUB_WEBSOCKET_PORT_KEY                     "websocket.socket_port"
 
+
+/* With this interval new connections and receivers are polled and registred. Similar to the TCP admin */
+#define PSA_WEBSOCKET_SUBSCRIBER_CONNECTION_TIMEOUT   "PSA_WEBSOCKET_SUBSCRIBER_CONNECTION_TIMEOUT"
+#define PSA_WEBSOCKET_SUBSCRIBER_CONNECTION_DEFAULT_TIMEOUT 250 // 250 ms
+
 /**
  * The static url which a subscriber should try to connect to.
  * The urls are space separated

--- a/bundles/pubsub/pubsub_admin_websocket/src/pubsub_psa_websocket_constants.h
+++ b/bundles/pubsub/pubsub_admin_websocket/src/pubsub_psa_websocket_constants.h
@@ -43,6 +43,8 @@
 /* With this interval new connections and receivers are polled and registred. Similar to the TCP admin */
 #define PSA_WEBSOCKET_SUBSCRIBER_CONNECTION_TIMEOUT   "PSA_WEBSOCKET_SUBSCRIBER_CONNECTION_TIMEOUT"
 #define PSA_WEBSOCKET_SUBSCRIBER_CONNECTION_DEFAULT_TIMEOUT 250 // 250 ms
+#define PSA_WEBSOCKET_SUBSCRIBER_CONNECTION_MIN_TIMEOUT     0
+#define PSA_WEBSOCKET_SUBSCRIBER_CONNECTION_MAX_TIMEOUT     (UINT_MAX / 1000)
 
 /**
  * The static url which a subscriber should try to connect to.

--- a/bundles/pubsub/pubsub_admin_websocket/src/pubsub_websocket_topic_receiver.c
+++ b/bundles/pubsub/pubsub_admin_websocket/src/pubsub_websocket_topic_receiver.c
@@ -150,7 +150,10 @@ pubsub_websocket_topic_receiver_t* pubsub_websocketTopicReceiver_create(celix_bu
     long timeoutMs = celix_bundleContext_getPropertyAsLong(ctx, PSA_WEBSOCKET_SUBSCRIBER_CONNECTION_TIMEOUT,
                                                                 PSA_WEBSOCKET_SUBSCRIBER_CONNECTION_DEFAULT_TIMEOUT);
     receiver->timeoutUs = (useconds_t)((
-            ((timeoutMs < 0) || (timeoutMs > INT_MAX))            // Protect against under and overflow
+            (
+                (timeoutMs < PSA_WEBSOCKET_SUBSCRIBER_CONNECTION_MIN_TIMEOUT) 
+                || (timeoutMs > PSA_WEBSOCKET_SUBSCRIBER_CONNECTION_MAX_TIMEOUT)
+            )  // Protect against under and overflow
             ? PSA_WEBSOCKET_SUBSCRIBER_CONNECTION_DEFAULT_TIMEOUT // Use default for excessive values
             : timeoutMs)
          * 1000);


### PR DESCRIPTION
In the websocket pubsub admin, effectively there was a busy loop with polling for new connections/subscribers AND for receiving data. In the TCP admin, the receiving data is handled in another thread, so the polling can be done on a lower frequency.

In this pull request, I've removed the buffer mechanism. Note that if the callback takes long civetweb (and/or the tcp stack) is assumed to have enough buffers to cope with that. In practice, the behaviour is now the same as with the tcp admin.

I've tested this at the project at work, the webpage of the webserver (web shell) is still responsive. No spinning threads are observed anymore, which was my goal.

PS. note that this is my first PR on Celix, if I make a mistake in the etiquette, my apologies and please tell me.
