### PR TITLE
Update GH notifications format for better mailing list archive readability

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -47,3 +47,15 @@ github:
         require_code_owner_reviews: false
         required_approving_review_count: 0
 
+  # Attempt to make the auto-generated github emails more easily readable in email clients.
+  custom_subjects:
+    new_pr: "[PR] {title} ({repository})"
+    close_pr: "Re: [PR] {title} ({repository})"
+    comment_pr: "Re: [PR] {title} ({repository})"
+    diffcomment: "Re: [PR] {title} ({repository})"
+    merge_pr: "Re: [PR] {title} ({repository})"
+    new_issue: "[I] {title} ({repository})"
+    comment_issue: "Re: [I] {title} ({repository})"
+    close_issue: "Re: [I] {title} ({repository})"
+    catchall: "[GH] {title} ({repository})"
+


### PR DESCRIPTION
Following the instructions here: https://cwiki.apache.org/confluence/display/INFRA/Git+-+.asf.yaml+features#Git.asf.yamlfeatures-CustomsubjectlinesforGitHubevents this was introduced to tweak the format of the GitHub emails sent to our mailing lists.

Try to change it to a more readable format for Celix. I would say if it doesn't work we can always improve on it.

I copied this from the plc4x repo: https://github.com/apache/plc4x/blob/a1c99f2045e01668e1d4b63377e840839b928610/.asf.yaml#L61-L71