### PR TITLE
Some module layer fixes

### DIFF
--- a/libs/framework/gtest/CMakeLists.txt
+++ b/libs/framework/gtest/CMakeLists.txt
@@ -25,6 +25,8 @@ celix_bundle_description(simple_test_bundle1 "Test Description")
 add_celix_bundle(simple_test_bundle2 NO_ACTIVATOR VERSION 1.0.0)
 add_celix_bundle(simple_test_bundle3 NO_ACTIVATOR VERSION 1.0.0)
 add_celix_bundle(bundle_with_exception SOURCES src/nop_activator.c VERSION 1.0.0)
+add_celix_bundle(bundle_with_bad_export NO_ACTIVATOR VERSION 1.0.0)
+celix_bundle_headers(bundle_with_bad_export "Export-Library: $<SEMICOLON>")
 add_celix_bundle(simple_cxx_bundle SOURCES src/HelloWorldCxxActivator.cc VERSION 1.0.0)
 celix_bundle_libs(simple_cxx_bundle "PRIVATE" TRUE Celix::framework)
 add_celix_bundle(simple_cxx_dep_man_bundle SOURCES src/HelloWorldCxxActivatorWithDepMan.cc VERSION 1.0.0)
@@ -75,7 +77,7 @@ celix_target_bundle_set_definition(test_framework NAME BUNDLE_TEST_SET
 add_celix_bundle_dependencies(test_framework
         simple_test_bundle1
         simple_test_bundle2 simple_test_bundle3 simple_test_bundle4
-        simple_test_bundle5 bundle_with_exception unresolvable_bundle simple_cxx_bundle simple_cxx_dep_man_bundle cmp_test_bundle)
+        simple_test_bundle5 bundle_with_exception bundle_with_bad_export unresolvable_bundle simple_cxx_bundle simple_cxx_dep_man_bundle cmp_test_bundle)
 target_include_directories(test_framework PRIVATE ../src)
 celix_deprecated_utils_headers(test_framework)
 
@@ -88,6 +90,7 @@ celix_get_bundle_filename(simple_test_bundle4 SIMPLE_TEST_BUNDLE4_FILENAME)
 celix_get_bundle_filename(simple_test_bundle5 SIMPLE_TEST_BUNDLE5_FILENAME)
 
 celix_get_bundle_filename(bundle_with_exception BUNDLE_WITH_EXCEPTION)
+celix_get_bundle_file(bundle_with_bad_export BUNDLE_WITH_BAD_EXPORT)
 celix_get_bundle_filename(unresolvable_bundle UNRESOLVABLE_BUNDLE)
 
 celix_get_bundle_file(simple_cxx_bundle SIMPLE_CXX_BUNDLE_LOC)
@@ -106,6 +109,7 @@ target_compile_definitions(test_framework PRIVATE
         SIMPLE_TEST_BUNDLE4_LOCATION="${SIMPLE_TEST_BUNDLE4_FILENAME}"
         SIMPLE_TEST_BUNDLE5_LOCATION="${SIMPLE_TEST_BUNDLE5_FILENAME}"
         TEST_BUNDLE_WITH_EXCEPTION_LOCATION="${BUNDLE_WITH_EXCEPTION}"
+        BUNDLE_WITH_BAD_EXPORT_LOCATION="${BUNDLE_WITH_BAD_EXPORT}"
         TEST_BUNDLE_UNRESOLVABLE_LOCATION="${UNRESOLVABLE_BUNDLE}"
         SIMPLE_CXX_BUNDLE_LOC="${SIMPLE_CXX_BUNDLE_LOC}"
         CMP_TEST_BUNDLE_LOC="${CMP_TEST_BUNDLE_LOC}"

--- a/libs/framework/gtest/CMakeLists.txt
+++ b/libs/framework/gtest/CMakeLists.txt
@@ -26,6 +26,7 @@ add_celix_bundle(simple_test_bundle2 NO_ACTIVATOR VERSION 1.0.0)
 add_celix_bundle(simple_test_bundle3 NO_ACTIVATOR VERSION 1.0.0)
 add_celix_bundle(bundle_with_exception SOURCES src/nop_activator.c VERSION 1.0.0)
 add_celix_bundle(simple_cxx_bundle SOURCES src/HelloWorldCxxActivator.cc VERSION 1.0.0)
+celix_bundle_libs(simple_cxx_bundle "PRIVATE" TRUE Celix::framework)
 add_celix_bundle(simple_cxx_dep_man_bundle SOURCES src/HelloWorldCxxActivatorWithDepMan.cc VERSION 1.0.0)
 add_celix_bundle(cmp_test_bundle SOURCES src/CmpTestBundleActivator.cc)
 add_subdirectory(subdir) #simple_test_bundle4, simple_test_bundle5 and sublib
@@ -119,12 +120,14 @@ if (LINKER_WRAP_SUPPORTED)
     add_executable(test_framework_with_ei
             src/BundleArchiveWithErrorInjectionTestSuite.cc
             src/CelixFrameworkUtilsErrorInjectionTestSuite.cc
+            src/CelixBundleContextBundlesWithErrorTestSuite.cc
     )
     target_compile_definitions(test_framework_with_ei PRIVATE
             SIMPLE_TEST_BUNDLE1_LOCATION="${SIMPLE_TEST_BUNDLE1}"
+            SIMPLE_CXX_BUNDLE_LOC="${SIMPLE_CXX_BUNDLE_LOC}"
     )
     target_include_directories(test_framework_with_ei PRIVATE ../src)
-    add_celix_bundle_dependencies(test_framework_with_ei simple_test_bundle1)
+    add_celix_bundle_dependencies(test_framework_with_ei simple_test_bundle1 simple_cxx_bundle)
     celix_target_embedded_bundles(test_framework_with_ei simple_test_bundle1)
     celix_deprecated_utils_headers(test_framework_with_ei)
     target_link_libraries(test_framework_with_ei PRIVATE

--- a/libs/framework/gtest/CMakeLists.txt
+++ b/libs/framework/gtest/CMakeLists.txt
@@ -75,7 +75,7 @@ celix_target_bundle_set_definition(test_framework NAME BUNDLE_TEST_SET
 add_celix_bundle_dependencies(test_framework
         simple_test_bundle1
         simple_test_bundle2 simple_test_bundle3 simple_test_bundle4
-        simple_test_bundle5 bundle_with_exception unresolveable_bundle simple_cxx_bundle simple_cxx_dep_man_bundle cmp_test_bundle)
+        simple_test_bundle5 bundle_with_exception unresolvable_bundle simple_cxx_bundle simple_cxx_dep_man_bundle cmp_test_bundle)
 target_include_directories(test_framework PRIVATE ../src)
 celix_deprecated_utils_headers(test_framework)
 
@@ -175,7 +175,7 @@ if (ENABLE_TESTING_FOR_CXX14)
     add_celix_bundle_dependencies(test_framework_with_cxx14
             simple_test_bundle1
             simple_test_bundle2 simple_test_bundle3 simple_test_bundle4
-            simple_test_bundle5 bundle_with_exception unresolveable_bundle simple_cxx_bundle simple_cxx_dep_man_bundle cmp_test_bundle)
+            simple_test_bundle5 bundle_with_exception unresolvable_bundle simple_cxx_bundle simple_cxx_dep_man_bundle cmp_test_bundle)
     target_include_directories(test_framework_with_cxx14 PRIVATE ../src)
 
     #Also to ensure that CELIX_GEN_CXX_BUNDLE_ACTIVATOR still for C++11.

--- a/libs/framework/gtest/src/CelixBundleContextBundlesTestSuite.cc
+++ b/libs/framework/gtest/src/CelixBundleContextBundlesTestSuite.cc
@@ -72,6 +72,11 @@ TEST_F(CelixBundleContextBundlesTestSuite, InstallABundleTest) {
     ASSERT_TRUE(bndId >= 0);
 }
 
+//TEST_F(CelixBundleContextBundlesTestSuite, InstallBundleWithBadExport) {
+//    long bndId = celix_bundleContext_installBundle(ctx, BUNDLE_WITH_BAD_EXPORT_LOCATION, true);
+//    ASSERT_TRUE(bndId >= 0);
+//}
+
 TEST_F(CelixBundleContextBundlesTestSuite, InstallBundlesTest) {
     long bndId = celix_bundleContext_installBundle(ctx, "non-existing.zip", true);
     ASSERT_TRUE(bndId < 0);

--- a/libs/framework/gtest/src/CelixBundleContextBundlesWithErrorTestSuite.cc
+++ b/libs/framework/gtest/src/CelixBundleContextBundlesWithErrorTestSuite.cc
@@ -1,0 +1,79 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+ */
+
+#include <gtest/gtest.h>
+#include "celix_bundle_context.h"
+#include "celix_framework.h"
+#include "celix_framework_factory.h"
+extern "C" {
+#include "celix_libloader.h"
+}
+#include "celix_properties.h"
+#include "dlfcn_ei.h"
+
+class CelixBundleContextBundlesWithErrorTestSuite : public ::testing::Test {
+public:
+    celix_framework_t* fw = nullptr;
+    celix_bundle_context_t *ctx = nullptr;
+    celix_properties_t *properties = nullptr;
+
+    CelixBundleContextBundlesWithErrorTestSuite() {
+        properties = celix_properties_create();
+        celix_properties_setBool(properties, "LOGHELPER_ENABLE_STDOUT_FALLBACK", true);
+        celix_properties_setBool(properties, "org.osgi.framework.storage.clean", true);
+        celix_properties_set(properties, "org.osgi.framework.storage", ".cacheBundleContextTestFramework");
+
+        fw = celix_frameworkFactory_createFramework(properties);
+        ctx = celix_framework_getFrameworkContext(fw);
+    }
+
+    ~CelixBundleContextBundlesWithErrorTestSuite() override {
+        celix_frameworkFactory_destroyFramework(fw);
+        celix_ei_expect_dlopen(nullptr, 0, nullptr);
+    }
+
+    CelixBundleContextBundlesWithErrorTestSuite(CelixBundleContextBundlesWithErrorTestSuite&&) = delete;
+    CelixBundleContextBundlesWithErrorTestSuite(const CelixBundleContextBundlesWithErrorTestSuite&) = delete;
+    CelixBundleContextBundlesWithErrorTestSuite& operator=(CelixBundleContextBundlesWithErrorTestSuite&&) = delete;
+    CelixBundleContextBundlesWithErrorTestSuite& operator=(const CelixBundleContextBundlesWithErrorTestSuite&) = delete;
+};
+
+TEST_F(CelixBundleContextBundlesWithErrorTestSuite, activatorLoadErrorAbortBundleResolution) {
+    celix_ei_expect_dlopen(CELIX_EI_UNKNOWN_CALLER, 0, nullptr, 1);
+    long bndId = celix_bundleContext_installBundle(ctx, SIMPLE_CXX_BUNDLE_LOC, true);
+    ASSERT_TRUE(bndId > 0); //bundle is installed, but not started
+
+    bool called = celix_bundleContext_useBundle(ctx, bndId, nullptr, [](void */*handle*/, const celix_bundle_t *bnd) {
+        auto state = celix_bundle_getState(bnd);
+        ASSERT_EQ(state, CELIX_BUNDLE_STATE_INSTALLED);
+    });
+    ASSERT_TRUE(called);
+}
+
+TEST_F(CelixBundleContextBundlesWithErrorTestSuite, privateLibraryLoadErrorAbortBundleResolution) {
+    celix_ei_expect_dlopen(CELIX_EI_UNKNOWN_CALLER, 0, nullptr, 2);
+    long bndId = celix_bundleContext_installBundle(ctx, SIMPLE_CXX_BUNDLE_LOC, true);
+    ASSERT_TRUE(bndId > 0); //bundle is installed, but not started
+
+    bool called = celix_bundleContext_useBundle(ctx, bndId, nullptr, [](void */*handle*/, const celix_bundle_t *bnd) {
+        auto state = celix_bundle_getState(bnd);
+        ASSERT_EQ(state, CELIX_BUNDLE_STATE_INSTALLED);
+    });
+    ASSERT_TRUE(called);
+}

--- a/libs/framework/include_deprecated/module.h
+++ b/libs/framework/include_deprecated/module.h
@@ -93,7 +93,7 @@ CELIX_FRAMEWORK_DEPRECATED_EXPORT celix_status_t module_getGroup(module_pt modul
 
 CELIX_FRAMEWORK_DEPRECATED_EXPORT celix_status_t module_getName(module_pt module, const char **name);
 
-CELIX_FRAMEWORK_DEPRECATED_EXPORT celix_status_t module_getDescription(module_pt module, const char **descriptoin);
+CELIX_FRAMEWORK_DEPRECATED_EXPORT celix_status_t module_getDescription(module_pt module, const char **description);
 
 #ifdef __cplusplus
 }

--- a/libs/framework/src/celix_libloader.c
+++ b/libs/framework/src/celix_libloader.c
@@ -29,9 +29,9 @@ celix_library_handle_t* celix_libloader_open(celix_bundle_context_t *ctx, const 
 #endif
     celix_library_handle_t* handle = NULL;
     bool noDelete = celix_bundleContext_getPropertyAsBool(ctx, CELIX_LOAD_BUNDLES_WITH_NODELETE, defaultNoDelete);
-    int flags = RTLD_LAZY|RTLD_LOCAL;
+    int flags = RTLD_NOW|RTLD_LOCAL;
     if (noDelete) {
-        flags = RTLD_LAZY|RTLD_LOCAL|RTLD_NODELETE;
+        flags = RTLD_NOW|RTLD_LOCAL|RTLD_NODELETE;
     }
 
     handle = dlopen(libPath, flags);

--- a/libs/framework/src/framework.c
+++ b/libs/framework/src/framework.c
@@ -2274,7 +2274,7 @@ celix_status_t celix_framework_startBundleEntry(celix_framework_t* framework, ce
                         bundle_setActivator(bndEntry->bnd, NULL);
                         bundleContext_destroy(context);
                         free(activator);
-                        status = bundle_setState(bndEntry->bnd, CELIX_BUNDLE_STATE_RESOLVED);
+                        (void)bundle_setState(bndEntry->bnd, CELIX_BUNDLE_STATE_RESOLVED);
                     }
                 }
             }

--- a/libs/framework/src/framework.c
+++ b/libs/framework/src/framework.c
@@ -164,8 +164,7 @@ static celix_status_t framework_markBundleResolved(framework_pt framework, modul
 
 long framework_getNextBundleId(framework_pt framework);
 
-celix_status_t fw_refreshBundles(framework_pt framework, long bundleIds[], int size);
-celix_status_t fw_refreshBundle(framework_pt framework, long bndId);
+void fw_refreshBundle(framework_pt framework, long bndId);
 
 celix_status_t fw_populateDependentGraph(framework_pt framework, bundle_pt exporter, hash_map_pt *map);
 
@@ -692,11 +691,8 @@ celix_status_t celix_framework_installBundleInternal(celix_framework_t *framewor
   	return status;
 }
 
-celix_status_t fw_refreshBundle(framework_pt framework, long bndId) {
-    celix_status_t status = CELIX_SUCCESS;
+void fw_refreshBundle(framework_pt framework, long bndId) {
     bundle_state_e state;
-
-
     celix_framework_bundle_entry_t *entry = celix_framework_bundleEntry_getBundleEntryAndIncreaseUseCount(framework,
                                                                                                           bndId);
     if (entry != NULL) {
@@ -712,11 +708,8 @@ celix_status_t fw_refreshBundle(framework_pt framework, long bndId) {
 
         celix_framework_bundleEntry_decreaseUseCount(entry);
     } else {
-        framework_logIfError(framework->logger, status, NULL, "Cannot refresh bundle");
+        fw_log(framework->logger, CELIX_LOG_LEVEL_WARNING, "Cannot refresh bundle %ld", bndId);
     }
-
-
-    return status;
 }
 
 bool celix_framework_isBundleAlreadyInstalled(celix_framework_t* fw, const char* bundleSymbolicName) {
@@ -1101,7 +1094,6 @@ static celix_status_t framework_markBundleResolved(framework_pt framework, modul
     celix_status_t status = CELIX_SUCCESS;
     bundle_pt bundle = module_getBundle(module);
     bundle_state_e state;
-    char *error = NULL;
 
     if (bundle != NULL) {
         long bndId = celix_bundle_getId(bundle);
@@ -1109,7 +1101,7 @@ static celix_status_t framework_markBundleResolved(framework_pt framework, modul
 
         bundle_getState(bundle, &state);
         if (state != CELIX_BUNDLE_STATE_INSTALLED) {
-            printf("Trying to resolve a resolved bundle");
+            fw_log(framework->logger, CELIX_LOG_LEVEL_WARNING, "Trying to resolve a resolved bundle");
             status = CELIX_ILLEGAL_STATE;
         } else {
             // Load libraries of this module
@@ -1128,11 +1120,7 @@ static celix_status_t framework_markBundleResolved(framework_pt framework, modul
             long id = 0;
             module_getSymbolicName(module, &symbolicName);
             bundle_getBundleId(bundle, &id);
-            if (error != NULL) {
-                fw_logCode(framework->logger, CELIX_LOG_LEVEL_ERROR, status, "Could not start bundle: %s [%ld]; cause: %s", symbolicName, id, error);
-            } else {
-                fw_logCode(framework->logger, CELIX_LOG_LEVEL_ERROR, status, "Could not start bundle: %s [%ld]", symbolicName, id);
-            }
+            fw_logCode(framework->logger, CELIX_LOG_LEVEL_ERROR, status, "Could not resolve bundle: %s [%ld]", symbolicName, id);
         }
 
 
@@ -1973,23 +1961,14 @@ celix_status_t celix_framework_uninstallBundleEntry(celix_framework_t* framework
             fw_bundleEntry_destroy(removedEntry , true); //wait till use count is 0 -> e.g. not used
 
             if (status == CELIX_SUCCESS) {
-                celix_status_t refreshStatus = fw_refreshBundle(framework, bndId);
-                if (refreshStatus != CELIX_SUCCESS) {
-                    printf("Could not refresh bundle");
-                } else {
-                    celix_framework_waitForEmptyEventQueue(framework); //to ensure that the uninstall event is triggered and handled
-                    bundleArchive_destroy(archive);
-                    status = CELIX_DO_IF(status, bundle_closeModules(bnd));
-                    status = CELIX_DO_IF(status, bundle_destroy(bnd));
-                }
+                fw_refreshBundle(framework, bndId);
+                celix_framework_waitForEmptyEventQueue(framework); //to ensure that the uninstall event is triggered and handled
+                bundleArchive_destroy(archive);
+                status = CELIX_DO_IF(status, bundle_closeModules(bnd));
+                status = CELIX_DO_IF(status, bundle_destroy(bnd));
             }
         }
-
-
-        if (status != CELIX_SUCCESS) {
-            framework_logIfError(framework->logger, status, "", "Cannot uninstall bundle");
-        }
-
+        framework_logIfError(framework->logger, status, "", "Cannot uninstall bundle");
         return status;
 
     } else {

--- a/libs/framework/src/manifest_parser.c
+++ b/libs/framework/src/manifest_parser.c
@@ -389,11 +389,6 @@ static linked_list_pt manifestParser_parseImportHeader(const char * header) {
 
 	linkedList_destroy(clauses);
 
-	if(failure){
-		linkedList_destroy(requirements);
-		requirements = NULL;
-	}
-
 	return requirements;
 }
 
@@ -450,10 +445,6 @@ static linked_list_pt manifestParser_parseExportHeader(module_pt module, const c
 	}
 
 	linkedList_destroy(clauses);
-	if(failure){
-		linkedList_destroy(capabilities);
-		capabilities = NULL;
-	}
 
 	return capabilities;
 }

--- a/libs/framework/src/module.c
+++ b/libs/framework/src/module.c
@@ -251,12 +251,12 @@ celix_status_t module_getGroup(module_pt module, const char **symbolicName) {
     return status;
 }
 
-celix_status_t module_getDescription(module_pt module, const char **symbolicName) {
+celix_status_t module_getDescription(module_pt module, const char **descriptoin) {
     celix_status_t status = CELIX_SUCCESS;
     if (module == NULL) {
         status = CELIX_ILLEGAL_ARGUMENT;
     } else {
-        *symbolicName = module->description;
+        *descriptoin = module->description;
     }
     return status;
 }
@@ -454,10 +454,7 @@ static celix_status_t celix_module_loadLibrariesInManifestEntry(celix_module_t* 
 
         if ( (status == CELIX_SUCCESS) && (activator != NULL) && (strcmp(trimmedLib, activator) == 0) ) {
             *activatorHandle = handle;
-        } else if ((status != CELIX_SUCCESS) && (handle != NULL)) {
-            celix_libloader_close(fwCtx, handle);
         }
-
         token = strtok_r(NULL, ",", &last);
     }
 
@@ -501,8 +498,6 @@ celix_status_t celix_module_loadLibraries(celix_module_t* module) {
             celixThreadMutex_lock(&module->handlesLock);
             module->bundleActivatorHandle = activatorHandle;
             celixThreadMutex_unlock(&module->handlesLock);
-        } else if (activatorHandle != NULL) {
-            celix_libloader_close(fwCtx, activatorHandle);
         }
     }
 

--- a/libs/framework/src/module.c
+++ b/libs/framework/src/module.c
@@ -419,8 +419,6 @@ static celix_status_t celix_module_loadLibraryForManifestEntry(celix_module_t* m
 
 static celix_status_t celix_module_loadLibrariesInManifestEntry(celix_module_t* module, const char *librariesIn, const char *activator, bundle_archive_pt archive, void **activatorHandle) {
     celix_status_t status = CELIX_SUCCESS;
-    celix_bundle_context_t* fwCtx = celix_framework_getFrameworkContext(module->fw);
-
     char* last;
     char* libraries = strndup(librariesIn, 1024*10);
     char* token = strtok_r(libraries, ",", &last);
@@ -464,8 +462,6 @@ static celix_status_t celix_module_loadLibrariesInManifestEntry(celix_module_t* 
 
 celix_status_t celix_module_loadLibraries(celix_module_t* module) {
     celix_status_t status = CELIX_SUCCESS;
-    celix_bundle_context_t* fwCtx = celix_framework_getFrameworkContext(module->fw);
-
     celix_library_handle_t* activatorHandle = NULL;
     bundle_archive_pt archive = NULL;
     bundle_revision_pt revision = NULL;

--- a/libs/framework/src/module.c
+++ b/libs/framework/src/module.c
@@ -422,7 +422,7 @@ static celix_status_t celix_module_loadLibrariesInManifestEntry(celix_module_t* 
     char* last;
     char* libraries = strndup(librariesIn, 1024*10);
     char* token = strtok_r(libraries, ",", &last);
-    while (token != NULL) {
+    while (token != NULL && status == CELIX_SUCCESS) {
         void *handle = NULL;
         char lib[128];
         lib[127] = '\0';

--- a/libs/framework/src/module.c
+++ b/libs/framework/src/module.c
@@ -358,6 +358,7 @@ array_list_pt module_getDependents(module_pt module) {
 celix_status_t celix_module_closeLibraries(celix_module_t* module) {
     celix_status_t status = CELIX_SUCCESS;
     celix_bundle_context_t *fwCtx = celix_framework_getFrameworkContext(module->fw);
+    bundle_setHandle(module->bundle, NULL); //note deprecated
     celixThreadMutex_lock(&module->handlesLock);
     for (int i = 0; i < celix_arrayList_size(module->libraryHandles); i++) {
         void *handle = celix_arrayList_get(module->libraryHandles, i);
@@ -501,6 +502,7 @@ celix_status_t celix_module_loadLibraries(celix_module_t* module) {
     if (status != CELIX_SUCCESS) {
         fw_logCode(module->fw->logger, CELIX_LOG_LEVEL_ERROR, status, "Could not load libraries for bundle %s",
                    celix_bundle_getSymbolicName(module->bundle));
+        (void)celix_module_closeLibraries(module);
     }
 
     return status;

--- a/libs/framework/src/module.c
+++ b/libs/framework/src/module.c
@@ -251,12 +251,12 @@ celix_status_t module_getGroup(module_pt module, const char **symbolicName) {
     return status;
 }
 
-celix_status_t module_getDescription(module_pt module, const char **descriptoin) {
+celix_status_t module_getDescription(module_pt module, const char **description) {
     celix_status_t status = CELIX_SUCCESS;
     if (module == NULL) {
         status = CELIX_ILLEGAL_ARGUMENT;
     } else {
-        *descriptoin = module->description;
+        *description = module->description;
     }
     return status;
 }


### PR DESCRIPTION
This PR aims to address some issues found when reviewing #476.

## Double dlclose

Note that all opened shared object come from `celix_module_loadLibrary`, which will add the handle to `module->libraryHandles`.
Also note that for all installed bundles, `celix_module_closeLibraries` will close all opened shared object in `module->libraryHandles` when `framework_destroy`. Thus call `celix_libloader_close` on any shared object opened by `celix_module_loadLibrary` without removing it from `module->libraryHandles` must be a double-close.

## Crash Staring Bundle Containing Unresolved Symbols

Recorded in #492.

## Silent Bundle Start Failure

Recorded in #501.

## Crash Caused by Loading Bundles with Malformed Export Header 

Check `TEST_F(CelixBundleContextBundlesTestSuite, InstallBundleWithBadExport)` for details. 
Currently the test is commented out due to #531, which should be fixed by #518.