### PR TITLE
Fixed typo in bundle packaging checking path CMake

### DIFF
--- a/cmake/cmake_celix/BundlePackaging.cmake
+++ b/cmake/cmake_celix/BundlePackaging.cmake
@@ -367,7 +367,7 @@ function(add_celix_bundle)
         
         if(TARGET ${BUNDLE_ACTIVATOR})
             set_target_properties(${BUNDLE_TARGET_NAME} PROPERTIES "BUNDLE_ACTIVATOR" "$<TARGET_SONAME_FILE_NAME:${BUNDLE_ACTIVATOR}>")
-        elseif(IS_ABSOLUTE ${BUNDLE_ACTIVATOR} AND EXISTS${BUNDLE_ACTIVATOR})
+        elseif(IS_ABSOLUTE ${BUNDLE_ACTIVATOR} AND EXISTS ${BUNDLE_ACTIVATOR})
             get_filename_component(ACT_NAME ${BUNDLE_ACTIVATOR} NAME)
             set_target_properties(${BUNDLE_TARGET_NAME} PROPERTIES "BUNDLE_ACTIVATOR" "${ACT_NAME}>")
         else()


### PR DESCRIPTION
Found a typo, when using `add_celix_bundle` cmake command with an existing library as the activator.
example:
```cmake 
add_celix_bundle(ExampleBundle
        ACTIVATOR /home/user/dir/libexample.so
)
```

Resolved by adding whitespace to [BundlePackaging.cmake](https://github.com/apache/celix/blob/335935c31473311906d62599c62dbd7f2f787ef8/cmake/cmake_celix/BundlePackaging.cmake#L370)


