### PR TITLE
Fix wrong compare function in lb_command.c

### DIFF
--- a/bundles/shell/shell/src/lb_command.c
+++ b/bundles/shell/shell/src/lb_command.c
@@ -20,6 +20,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "celix_constants.h"
 #include "celix_utils.h"
 #include "celix_bundle_context.h"
 #include "celix_bundle.h"
@@ -57,7 +58,15 @@ typedef struct lb_command_bundle_info {
 } lb_command_bundle_info_t;
 
 static int lbCommand_bundleInfoCmp(celix_array_list_entry_t a, celix_array_list_entry_t b) {
-    return (int)(a.intVal - b.intVal);
+    lb_command_bundle_info_t* infoA = a.voidPtrVal;
+    lb_command_bundle_info_t* infoB = b.voidPtrVal;
+    if (infoA->id < infoB->id) {
+        return -1;
+    } else if (infoA->id > infoB->id) {
+        return 1;
+    } else {
+        return 0;
+    }
 }
 
 static void lbCommand_collectBundleInfo_callback(void* data, const celix_bundle_t* bnd) {
@@ -91,6 +100,7 @@ static celix_array_list_t* lbCommand_collectBundleInfo(celix_bundle_context_t *c
     celix_array_list_t* infoEntries = celix_arrayList_createWithOptions(&opts);
     if (infoEntries != NULL) {
         celix_bundleContext_useBundles(ctx, (void*)infoEntries, lbCommand_collectBundleInfo_callback);
+        celix_bundleContext_useBundle(ctx, CELIX_FRAMEWORK_BUNDLE_ID, (void*)infoEntries, lbCommand_collectBundleInfo_callback);
         celix_arrayList_sortEntries(infoEntries, lbCommand_bundleInfoCmp);
     }
     return infoEntries;

--- a/libs/utils/include/celix_array_list.h
+++ b/libs/utils/include/celix_array_list.h
@@ -57,7 +57,12 @@ typedef bool (*celix_arrayList_equals_fp)(celix_array_list_entry_t, celix_array_
 
 typedef int (*celix_arrayList_sort_fp)(const void *, const void *);
 
-typedef int (*celix_array_list_sort_entries_fp)(celix_array_list_entry_t a, celix_array_list_entry_t b);
+/**
+ * @brief Compare function for array list entries, which can be used to sort a array list.
+ */
+typedef int (*celix_array_list_compare_entries_fp)(celix_array_list_entry_t a, celix_array_list_entry_t b);
+
+typedef celix_array_list_compare_entries_fp celix_array_list_sort_entries_fp __attribute__((deprecated("Use celix_arrayList_compare_entries_fp instead")));
 
 
 /**
@@ -448,13 +453,13 @@ void celix_arrayList_removeSize(celix_array_list_t *list, size_t value);
  * @brief Sort the array list using the provided sort function.
  */
 CELIX_UTILS_EXPORT
-void celix_arrayList_sortEntries(celix_array_list_t *list, celix_array_list_sort_entries_fp sortFp);
+void celix_arrayList_sortEntries(celix_array_list_t *list, celix_array_list_compare_entries_fp compare);
 
 /**
  * @warning Never use this function with array of doubles, since on some 32-bit platform (sizeof(double)==8 && sizeof(void*)==4)
  * @deprecated This function is deprecated, use celix_arrayList_sortEntries instead.
  */
-CELIX_UTILS_EXPORT
+CELIX_UTILS_DEPRECATED_EXPORT
 void celix_arrayList_sort(celix_array_list_t *list, celix_arrayList_sort_fp sortFp);
 
 #ifdef __cplusplus

--- a/libs/utils/src/array_list.c
+++ b/libs/utils/src/array_list.c
@@ -583,21 +583,21 @@ void celix_arrayList_clear(celix_array_list_t *list) {
 }
 
 #if defined(__APPLE__)
-static int celix_arrayList_compareEntries(void *arg, const void * voidA, const void *voidB) {
+static int celix_arrayList_compareEntries(void* arg, const void* voidA, const void* voidB) {
 #else
-static int celix_arrayList_compareEntries(const void* voidA, const void* voidB, void *arg) {
+static int celix_arrayList_compareEntries(const void* voidA, const void* voidB, void* arg) {
 #endif
-    celix_array_list_sort_entries_fp sort = arg;
+    celix_array_list_compare_entries_fp compare = arg;
     const celix_array_list_entry_t* a = voidA;
     const celix_array_list_entry_t* b = voidB;
-    return sort(*a, *b);
+    return compare(*a, *b);
 }
 
-void celix_arrayList_sortEntries(celix_array_list_t *list, celix_array_list_sort_entries_fp sortFp) {
+void celix_arrayList_sortEntries(celix_array_list_t *list, celix_array_list_compare_entries_fp compare) {
 #if defined(__APPLE__)
-    qsort_r(list->elementData, list->size, sizeof(celix_array_list_entry_t), sortFp, celix_arrayList_compareEntries);
+    qsort_r(list->elementData, list->size, sizeof(celix_array_list_entry_t), compare, celix_arrayList_compareEntries);
 #else
-    qsort_r(list->elementData, list->size, sizeof(celix_array_list_entry_t), celix_arrayList_compareEntries, sortFp);
+    qsort_r(list->elementData, list->size, sizeof(celix_array_list_entry_t), celix_arrayList_compareEntries, compare);
 #endif
 }
 


### PR DESCRIPTION
Also renames the compare function pointer typedef to celix_array_list_compare_entries_fp instead of celix_array_list_sort_entries_fp and adds the framework bundle to the `lb` result.