### PR TITLE
Feature/array list return status on modification

### DIFF
--- a/libs/error_injector/CMakeLists.txt
+++ b/libs/error_injector/CMakeLists.txt
@@ -36,6 +36,7 @@ add_subdirectory(stat)
 add_subdirectory(fts)
 add_subdirectory(dlfcn)
 add_subdirectory(ifaddrs)
+add_subdirectory(celix_array_list)
 
 celix_subproject(ERROR_INJECTOR_MDNSRESPONDER "Option to enable building the mdnsresponder error injector" OFF)
 if (ERROR_INJECTOR_MDNSRESPONDER)

--- a/libs/error_injector/asprintf/CMakeLists.txt
+++ b/libs/error_injector/asprintf/CMakeLists.txt
@@ -20,5 +20,7 @@ add_library(asprintf_ei STATIC src/asprintf_ei.cc)
 target_include_directories(asprintf_ei PUBLIC ${CMAKE_CURRENT_LIST_DIR}/include)
 target_link_libraries(asprintf_ei PUBLIC Celix::error_injector)
 # It plays nicely with address sanitizer this way.
-target_link_options(asprintf_ei INTERFACE LINKER:--wrap,asprintf)
+target_link_options(asprintf_ei INTERFACE
+        LINKER:--wrap,vasprintf
+        LINKER:--wrap,asprintf)
 add_library(Celix::asprintf_ei ALIAS asprintf_ei)

--- a/libs/error_injector/asprintf/include/asprintf_ei.h
+++ b/libs/error_injector/asprintf/include/asprintf_ei.h
@@ -27,6 +27,8 @@ extern "C" {
 
 CELIX_EI_DECLARE(asprintf, int);
 
+CELIX_EI_DECLARE(vasprintf, int);
+
 #ifdef __cplusplus
 }
 #endif

--- a/libs/error_injector/asprintf/src/asprintf_ei.cc
+++ b/libs/error_injector/asprintf/src/asprintf_ei.cc
@@ -24,6 +24,15 @@
 
 extern "C" {
 
+int __real_vasprintf(char** buf, const char* format, va_list args);
+CELIX_EI_DEFINE(vasprintf, int)
+int __wrap_vasprintf(char** buf, const char* format, va_list args) {
+    errno = ENOMEM;
+    CELIX_EI_IMPL(vasprintf);
+    errno = 0;
+    return __real_vasprintf(buf, format, args);
+}
+
 int __real_asprintf(char** buf, const char* format, ...);
 CELIX_EI_DEFINE(asprintf, int)
 int __wrap_asprintf(char** buf, const char* format, ...) {
@@ -32,7 +41,7 @@ int __wrap_asprintf(char** buf, const char* format, ...) {
     errno = 0;
     va_list args;
     va_start(args, format);
-    int rc = vasprintf(buf, format, args);
+    int rc = __real_vasprintf(buf, format, args);
     va_end(args);
     return rc;
 }

--- a/libs/error_injector/celix_array_list/CMakeLists.txt
+++ b/libs/error_injector/celix_array_list/CMakeLists.txt
@@ -1,0 +1,35 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+add_library(array_list_ei STATIC src/celix_array_list_ei.cc)
+
+target_include_directories(array_list_ei PUBLIC ${CMAKE_CURRENT_LIST_DIR}/include)
+target_link_libraries(array_list_ei PUBLIC Celix::error_injector Celix::utils)
+target_link_options(array_list_ei INTERFACE
+        LINKER:--wrap,celix_arrayList_create
+        LINKER:--wrap,celix_arrayList_createWithOptions
+        LINKER:--wrap,celix_arrayList_add
+        LINKER:--wrap,celix_arrayList_addInt
+        LINKER:--wrap,celix_arrayList_addLong
+        LINKER:--wrap,celix_arrayList_addUInt
+        LINKER:--wrap,celix_arrayList_addULong
+        LINKER:--wrap,celix_arrayList_addFloat
+        LINKER:--wrap,celix_arrayList_addDouble
+        LINKER:--wrap,celix_arrayList_addBool
+        LINKER:--wrap,celix_arrayList_addSize
+)
+add_library(Celix::array_list_ei ALIAS array_list_ei)

--- a/libs/error_injector/celix_array_list/include/celix_array_list_ei.h
+++ b/libs/error_injector/celix_array_list/include/celix_array_list_ei.h
@@ -1,0 +1,54 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+ */
+
+#ifndef CELIX_CELIX_ARRAY_LIST_EI_H
+#define CELIX_CELIX_ARRAY_LIST_EI_H
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "celix_array_list.h"
+#include "celix_error_injector.h"
+
+CELIX_EI_DECLARE(celix_arrayList_create, celix_array_list_t*);
+
+CELIX_EI_DECLARE(celix_arrayList_createWithOptions, celix_array_list_t*);
+
+CELIX_EI_DECLARE(celix_arrayList_add, celix_status_t);
+
+CELIX_EI_DECLARE(celix_arrayList_addInt, celix_status_t);
+
+CELIX_EI_DECLARE(celix_arrayList_addLong, celix_status_t);
+
+CELIX_EI_DECLARE(celix_arrayList_addUInt, celix_status_t);
+
+CELIX_EI_DECLARE(celix_arrayList_addULong, celix_status_t);
+
+CELIX_EI_DECLARE(celix_arrayList_addFloat, celix_status_t);
+
+CELIX_EI_DECLARE(celix_arrayList_addDouble, celix_status_t);
+
+CELIX_EI_DECLARE(celix_arrayList_addBool, celix_status_t);
+
+CELIX_EI_DECLARE(celix_arrayList_addSize, celix_status_t);
+
+#ifdef __cplusplus
+}
+#endif
+#endif //CELIX_CELIX_ARRAY_LIST_EI_H

--- a/libs/error_injector/celix_array_list/src/celix_array_list_ei.cc
+++ b/libs/error_injector/celix_array_list/src/celix_array_list_ei.cc
@@ -1,0 +1,101 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+ */
+
+#include "celix_array_list_ei.h"
+
+extern "C" {
+
+void *__real_celix_arrayList_create(void);
+CELIX_EI_DEFINE(celix_arrayList_create, celix_array_list_t*)
+void *__wrap_celix_arrayList_create(void) {
+    CELIX_EI_IMPL(celix_arrayList_create);
+    return __real_celix_arrayList_create();
+}
+
+void *__real_celix_arrayList_createWithOptions(const celix_array_list_create_options_t* opts);
+CELIX_EI_DEFINE(celix_arrayList_createWithOptions, celix_array_list_t*)
+void *__wrap_celix_arrayList_createWithOptions(const celix_array_list_create_options_t* opts) {
+    CELIX_EI_IMPL(celix_arrayList_createWithOptions);
+    return __real_celix_arrayList_createWithOptions(opts);
+}
+
+celix_status_t __real_celix_arrayList_add(celix_array_list_t* list, void* value);
+CELIX_EI_DEFINE(celix_arrayList_add, celix_status_t)
+celix_status_t __wrap_celix_arrayList_add(celix_array_list_t* list, void* value) {
+    CELIX_EI_IMPL(celix_arrayList_add);
+    return __real_celix_arrayList_add(list, value);
+}
+
+celix_status_t __real_celix_arrayList_addInt(celix_array_list_t* list, int value);
+CELIX_EI_DEFINE(celix_arrayList_addInt, celix_status_t)
+celix_status_t __wrap_celix_arrayList_addInt(celix_array_list_t* list, int value) {
+    CELIX_EI_IMPL(celix_arrayList_addInt);
+    return __real_celix_arrayList_addInt(list, value);
+}
+
+celix_status_t __real_celix_arrayList_addLong(celix_array_list_t* list, long value);
+CELIX_EI_DEFINE(celix_arrayList_addLong, celix_status_t)
+celix_status_t __wrap_celix_arrayList_addLong(celix_array_list_t* list, long value) {
+    CELIX_EI_IMPL(celix_arrayList_addLong);
+    return __real_celix_arrayList_addLong(list, value);
+}
+
+celix_status_t __real_celix_arrayList_addUInt(celix_array_list_t* list, unsigned int value);
+CELIX_EI_DEFINE(celix_arrayList_addUInt, celix_status_t)
+celix_status_t __wrap_celix_arrayList_addUInt(celix_array_list_t* list, unsigned int value) {
+    CELIX_EI_IMPL(celix_arrayList_addUInt);
+    return __real_celix_arrayList_addUInt(list, value);
+}
+
+celix_status_t __real_celix_arrayList_addULong(celix_array_list_t* list, unsigned long value);
+CELIX_EI_DEFINE(celix_arrayList_addULong, celix_status_t)
+celix_status_t __wrap_celix_arrayList_addULong(celix_array_list_t* list, unsigned long value) {
+    CELIX_EI_IMPL(celix_arrayList_addULong);
+    return __real_celix_arrayList_addULong(list, value);
+}
+
+celix_status_t __real_celix_arrayList_addFloat(celix_array_list_t* list, float value);
+CELIX_EI_DEFINE(celix_arrayList_addFloat, celix_status_t)
+celix_status_t __wrap_celix_arrayList_addFloat(celix_array_list_t* list, float value) {
+    CELIX_EI_IMPL(celix_arrayList_addFloat);
+    return __real_celix_arrayList_addFloat(list, value);
+}
+
+celix_status_t __real_celix_arrayList_addDouble(celix_array_list_t* list, double value);
+CELIX_EI_DEFINE(celix_arrayList_addDouble, celix_status_t)
+celix_status_t __wrap_celix_arrayList_addDouble(celix_array_list_t* list, double value) {
+    CELIX_EI_IMPL(celix_arrayList_addDouble);
+    return __real_celix_arrayList_addDouble(list, value);
+}
+
+celix_status_t __real_celix_arrayList_addBool(celix_array_list_t* list, bool value);
+CELIX_EI_DEFINE(celix_arrayList_addBool, celix_status_t)
+celix_status_t __wrap_celix_arrayList_addBool(celix_array_list_t* list, bool value) {
+    CELIX_EI_IMPL(celix_arrayList_addBool);
+    return __real_celix_arrayList_addBool(list, value);
+}
+
+celix_status_t __real_celix_arrayList_addSize(celix_array_list_t* list, size_t value);
+CELIX_EI_DEFINE(celix_arrayList_addSize, celix_status_t)
+celix_status_t __wrap_celix_arrayList_addSize(celix_array_list_t* list, size_t value) {
+    CELIX_EI_IMPL(celix_arrayList_addSize);
+    return __real_celix_arrayList_addSize(list, value);
+}
+
+}

--- a/libs/utils/gtest/CMakeLists.txt
+++ b/libs/utils/gtest/CMakeLists.txt
@@ -82,8 +82,9 @@ if (LINKER_WRAP_SUPPORTED)
             src/FileUtilsErrorInjectionTestSuite.cc
             src/ConvertUtilsErrorInjectionTestSuite.cc
             src/IpUtilsErrorInjectionTestSuite.cc
-            )
-    target_link_libraries(test_utils_with_ei PRIVATE Celix::zip_ei Celix::stdio_ei Celix::stat_ei Celix::fts_ei Celix::utils_obj Celix::utils_ei Celix::ifaddrs_ei GTest::gtest GTest::gtest_main)
+            src/ArrayListErrorInjectionTestSuite.cc
+    )
+    target_link_libraries(test_utils_with_ei PRIVATE Celix::zip_ei Celix::stdio_ei Celix::stat_ei Celix::fts_ei Celix::utils_obj Celix::utils_ei Celix::ifaddrs_ei Celix::malloc_ei GTest::gtest GTest::gtest_main)
     target_include_directories(test_utils_with_ei PRIVATE ../src) #for version_private (needs refactoring of test)
     celix_deprecated_utils_headers(test_utils_with_ei)
     add_dependencies(test_utils_with_ei test_utils_resources)

--- a/libs/utils/gtest/src/ArrayListErrorInjectionTestSuite.cc
+++ b/libs/utils/gtest/src/ArrayListErrorInjectionTestSuite.cc
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "celix_array_list.h"
+#include "malloc_ei.h"
+
+class ArrayListErrorInjectionTestSuite : public ::testing::Test {
+public:
+    ArrayListErrorInjectionTestSuite() = default;
+    ~ArrayListErrorInjectionTestSuite() noexcept override {
+        celix_ei_expect_realloc(nullptr, 0, nullptr);
+    }
+};
+
+TEST_F(ArrayListErrorInjectionTestSuite, TestAddFunctions) {
+    //Given an array list with a capacity of 10 (whitebox knowledge)
+    auto* list = celix_arrayList_create();
+
+    //When adding 10 elements, no error is expected
+    for (int i = 0; i < 10; ++i) {
+        EXPECT_EQ(CELIX_SUCCESS, celix_arrayList_addInt(list, i));
+    }
+    EXPECT_EQ(10, celix_arrayList_size(list));
+
+    //And realloc is primed to fail
+    celix_ei_expect_realloc(CELIX_EI_UNKNOWN_CALLER, 1, nullptr);
+
+    //Then adding an element should fail
+    EXPECT_EQ(CELIX_ENOMEM, celix_arrayList_addInt(list, 10));
+    EXPECT_EQ(10, celix_arrayList_size(list));
+}

--- a/libs/utils/gtest/src/ArrayListErrorInjectionTestSuite.cc
+++ b/libs/utils/gtest/src/ArrayListErrorInjectionTestSuite.cc
@@ -46,4 +46,6 @@ TEST_F(ArrayListErrorInjectionTestSuite, TestAddFunctions) {
     //Then adding an element should fail
     EXPECT_EQ(CELIX_ENOMEM, celix_arrayList_addInt(list, 10));
     EXPECT_EQ(10, celix_arrayList_size(list));
+
+    celix_arrayList_destroy(list);
 }

--- a/libs/utils/gtest/src/ArrayListTestSuite.cc
+++ b/libs/utils/gtest/src/ArrayListTestSuite.cc
@@ -230,3 +230,30 @@ TEST_F(ArrayListTestSuite, TestSortForArrayList) {
 
     celix_arrayList_destroy(list);
 }
+
+TEST_F(ArrayListTestSuite, TestReturnStatusAddFunctions) {
+    auto* list = celix_arrayList_create();
+    ASSERT_TRUE(list != nullptr);
+    EXPECT_EQ(0, celix_arrayList_size(list));
+
+    //no error, return status is CELIX_SUCCESS
+    EXPECT_EQ(CELIX_SUCCESS, celix_arrayList_addInt(list, 1));
+    EXPECT_EQ(1, celix_arrayList_size(list));
+
+    EXPECT_EQ(CELIX_SUCCESS, celix_arrayList_addLong(list, 2L));
+    EXPECT_EQ(2, celix_arrayList_size(list));
+
+    EXPECT_EQ(CELIX_SUCCESS, celix_arrayList_addFloat(list, 3.0f));
+    EXPECT_EQ(3, celix_arrayList_size(list));
+
+    EXPECT_EQ(CELIX_SUCCESS, celix_arrayList_addDouble(list, 4.0));
+    EXPECT_EQ(4, celix_arrayList_size(list));
+
+    EXPECT_EQ(CELIX_SUCCESS, celix_arrayList_addBool(list, true));
+    EXPECT_EQ(5, celix_arrayList_size(list));
+
+    EXPECT_EQ(CELIX_SUCCESS, celix_arrayList_add(list, (void*)0x42));
+    EXPECT_EQ(6, celix_arrayList_size(list));
+
+    celix_arrayList_destroy(list);
+}

--- a/libs/utils/include/celix_array_list.h
+++ b/libs/utils/include/celix_array_list.h
@@ -244,81 +244,90 @@ size_t celix_arrayList_getSize(const celix_array_list_t *list, int index);
  *
  * @param map The array list.
  * @param value The pointer value to add to the array list.
+ * @return CELIX_SUCCESS if the value is added, CELIX_ENOMEM if the array list is out of memory.
  */
 CELIX_UTILS_EXPORT
-void celix_arrayList_add(celix_array_list_t *list, void* value);
+celix_status_t celix_arrayList_add(celix_array_list_t *list, void* value);
 
 /**
  * @brief add pointer entry to the back of the array list.
  *
  * @param map The array list.
  * @param value The int value to add to the array list.
+ * @return CELIX_SUCCESS if the value is added, CELIX_ENOMEM if the array list is out of memory.
  */
 CELIX_UTILS_EXPORT
-void celix_arrayList_addInt(celix_array_list_t *list, int value);
+celix_status_t celix_arrayList_addInt(celix_array_list_t *list, int value);
 
 /**
  * @brief add pointer entry to the back of the array list.
  *
  * @param map The array list.
  * @param value The long value to add to the array list.
+ * @return CELIX_SUCCESS if the value is added, CELIX_ENOMEM if the array list is out of memory.
  */
 CELIX_UTILS_EXPORT
-void celix_arrayList_addLong(celix_array_list_t *list, long value);
+celix_status_t celix_arrayList_addLong(celix_array_list_t *list, long value);
 
 /**
  * @brief add pointer entry to the back of the array list.
  *
  * @param map The array list.
  * @param value The unsigned int value to add to the array list.
+ * @return CELIX_SUCCESS if the value is added, CELIX_ENOMEM if the array list is out of memory.
  */
 CELIX_UTILS_EXPORT
-void celix_arrayList_addUInt(celix_array_list_t *list, unsigned int value);
+celix_status_t celix_arrayList_addUInt(celix_array_list_t *list, unsigned int value);
 
 /**
  * @brief add pointer entry to the back of the array list.
  *
  * @param map The array list.
  * @param value The unsigned long value to add to the array list.
+ * @return CELIX_SUCCESS if the value is added, CELIX_ENOMEM if the array list is out of memory.
  */
 CELIX_UTILS_EXPORT
-void celix_arrayList_addULong(celix_array_list_t *list, unsigned long value);
+celix_status_t celix_arrayList_addULong(celix_array_list_t *list, unsigned long value);
 
 /**
  * @brief add pointer entry to the back of the array list.
  *
  * @param map The array list.
  * @param value The float value to add to the array list.
+ * @return CELIX_SUCCESS if the value is added, CELIX_ENOMEM if the array list is out of memory.
  */
 CELIX_UTILS_EXPORT
-void celix_arrayList_addFloat(celix_array_list_t *list, float value);
+celix_status_t celix_arrayList_addFloat(celix_array_list_t *list, float value);
 
 /**
  * @brief add pointer entry to the back of the array list.
  *
  * @param map The array list.
  * @param value The double value to add to the array list.
+ * @return CELIX_SUCCESS if the value is added, CELIX_ENOMEM if the array list is out of memory.
  */
 CELIX_UTILS_EXPORT
-void celix_arrayList_addDouble(celix_array_list_t *list, double value);
+celix_status_t celix_arrayList_addDouble(celix_array_list_t *list, double value);
 
 /**
  * @brief add pointer entry to the back of the array list.
  *
  * @param map The array list.
  * @param value The bool value to add to the array list.
+ * @return CELIX_SUCCESS if the value is added, CELIX_ENOMEM if the array list is out of memory.
  */
 CELIX_UTILS_EXPORT
-void celix_arrayList_addBool(celix_array_list_t *list, bool value);
+celix_status_t celix_arrayList_addBool(celix_array_list_t *list, bool value);
 
 /**
  * @brief add pointer entry to the back of the array list.
  *
  * @param map The array list.
  * @param value The size_t value to add to the array list.
+ * @return CELIX_SUCCESS if the value is added, CELIX_ENOMEM if the array list is out of memory.
  */
 CELIX_UTILS_EXPORT
-void celix_arrayList_addSize(celix_array_list_t *list, size_t value);
+celix_status_t celix_arrayList_addSize(celix_array_list_t *list, size_t value);
 
 /**
  * @brief Returns the index of the provided entry, if found.

--- a/libs/utils/include/celix_errno.h
+++ b/libs/utils/include/celix_errno.h
@@ -53,6 +53,12 @@ extern "C" {
 #define CELIX_DO_IF(status, expr) ((status) == CELIX_SUCCESS) ? (expr) : (status)
 
 /*!
+ * Helper macro which check the current status and executes a goto the provided label if the
+ * status is not CELIX_SUCCESS (0)
+ */
+#define CELIX_GOTO_IF_ERR(status, label) if ((status) != CELIX_SUCCESS) { goto label; }
+
+/*!
  * \defgroup celix_errno Error Codes
  * \ingroup framework
  * \{

--- a/libs/utils/include_deprecated/array_list.h
+++ b/libs/utils/include_deprecated/array_list.h
@@ -47,7 +47,7 @@ CELIX_UTILS_DEPRECATED_EXPORT void arrayList_destroy(celix_array_list_t *list);
 
 CELIX_UTILS_DEPRECATED_EXPORT void arrayList_trimToSize(celix_array_list_t *list);
 
-CELIX_UTILS_DEPRECATED_EXPORT void arrayList_ensureCapacity(celix_array_list_t *list, int capacity);
+CELIX_UTILS_DEPRECATED_EXPORT celix_status_t arrayList_ensureCapacity(celix_array_list_t *list, int capacity);
 
 CELIX_UTILS_DEPRECATED_EXPORT unsigned int arrayList_size(celix_array_list_t *list);
 

--- a/libs/utils/src/array_list.c
+++ b/libs/utils/src/array_list.c
@@ -90,7 +90,8 @@ void arrayList_trimToSize(array_list_pt list) {
     }
 }
 
-void arrayList_ensureCapacity(array_list_pt list, int capacity) {
+celix_status_t arrayList_ensureCapacity(array_list_pt list, int capacity) {
+    celix_status_t status = CELIX_SUCCESS;
     celix_array_list_entry_t *newList;
     list->modCount++;
     size_t oldCapacity = list->capacity;
@@ -100,9 +101,13 @@ void arrayList_ensureCapacity(array_list_pt list, int capacity) {
             newCapacity = capacity;
         }
         newList = realloc(list->elementData, sizeof(celix_array_list_entry_t) * newCapacity);
-        list->capacity = newCapacity;
-        list->elementData = newList;
+        if (newList != NULL) {
+            list->capacity = newCapacity;
+            list->elementData = newList;
+        }
+        status = newList == NULL ? CELIX_ENOMEM : CELIX_SUCCESS;
     }
+    return status;
 }
 
 unsigned int arrayList_size(array_list_pt list) {
@@ -280,7 +285,7 @@ array_list_pt arrayList_clone(array_list_pt list) {
 //    arrayList_ensureCapacity(new, list->size);
 //    memcpy(new->elementData, list->elementData, list->size);
 //    new->size = list->size;
-    
+
     for (i = 0; i < arrayList_size(list); i++) {
         arrayList_add(new, arrayList_get(list, i));
     }
@@ -420,65 +425,75 @@ double celix_arrayList_getDouble(const celix_array_list_t *list, int index) { re
 bool celix_arrayList_getBool(const celix_array_list_t *list, int index) { return arrayList_getEntry(list, index).boolVal; }
 size_t celix_arrayList_getSize(const celix_array_list_t *list, int index) { return arrayList_getEntry(list, index).sizeVal; }
 
-static void arrayList_addEntry(celix_array_list_t *list, celix_array_list_entry_t entry) {
-    arrayList_ensureCapacity(list, (int)list->size + 1);
-    list->elementData[list->size++] = entry;
+static celix_status_t celix_arrayList_addEntry(celix_array_list_t *list, celix_array_list_entry_t entry) {
+    celix_status_t status = arrayList_ensureCapacity(list, (int)list->size + 1);
+    if (status == CELIX_SUCCESS) {
+        list->elementData[list->size++] = entry;
+    }
+    return status;
 }
 
-void celix_arrayList_add(celix_array_list_t *list, void * element) {
+celix_status_t celix_arrayList_add(celix_array_list_t *list, void * element) {
     celix_array_list_entry_t entry;
     memset(&entry, 0, sizeof(entry));
     entry.voidPtrVal = element;
-    arrayList_addEntry(list, entry);
+    return celix_arrayList_addEntry(list, entry);
 }
 
-void celix_arrayList_addInt(celix_array_list_t *list, int val) { 
+celix_status_t celix_arrayList_addInt(celix_array_list_t *list, int val) {
     celix_array_list_entry_t entry;
     memset(&entry, 0, sizeof(entry));
     entry.intVal = val;
-    arrayList_addEntry(list, entry);
+    return celix_arrayList_addEntry(list, entry);
 }
-void celix_arrayList_addLong(celix_array_list_t *list, long val) { 
+
+celix_status_t celix_arrayList_addLong(celix_array_list_t *list, long val) {
     celix_array_list_entry_t entry;
     memset(&entry, 0, sizeof(entry));
     entry.longVal = val;
-    arrayList_addEntry(list, entry);
+    return celix_arrayList_addEntry(list, entry);
 }
-void celix_arrayList_addUInt(celix_array_list_t *list, unsigned int val) { 
+
+celix_status_t celix_arrayList_addUInt(celix_array_list_t *list, unsigned int val) {
     celix_array_list_entry_t entry;
     memset(&entry, 0, sizeof(entry));
     entry.uintVal = val;
-    arrayList_addEntry(list, entry);
+    return celix_arrayList_addEntry(list, entry);
 }
-void celix_arrayList_addULong(celix_array_list_t *list, unsigned long val) { 
+
+celix_status_t celix_arrayList_addULong(celix_array_list_t *list, unsigned long val) {
     celix_array_list_entry_t entry;
     memset(&entry, 0, sizeof(entry));
     entry.ulongVal = val;
-    arrayList_addEntry(list, entry);
+    return celix_arrayList_addEntry(list, entry);
 }
-void celix_arrayList_addDouble(celix_array_list_t *list, double val) { 
+
+celix_status_t celix_arrayList_addDouble(celix_array_list_t *list, double val) {
     celix_array_list_entry_t entry;
     memset(&entry, 0, sizeof(entry));
     entry.doubleVal = val;
-    arrayList_addEntry(list, entry);
+    return celix_arrayList_addEntry(list, entry);
 }
-void celix_arrayList_addFloat(celix_array_list_t *list, float val) { 
+
+celix_status_t celix_arrayList_addFloat(celix_array_list_t *list, float val) {
     celix_array_list_entry_t entry;
     memset(&entry, 0, sizeof(entry));
     entry.floatVal = val;
-    arrayList_addEntry(list, entry);
+    return celix_arrayList_addEntry(list, entry);
 }
-void celix_arrayList_addBool(celix_array_list_t *list, bool val) { 
+
+celix_status_t celix_arrayList_addBool(celix_array_list_t *list, bool val) {
     celix_array_list_entry_t entry;
     memset(&entry, 0, sizeof(entry));
     entry.boolVal = val;
-    arrayList_addEntry(list, entry);
+    return celix_arrayList_addEntry(list, entry);
 }
-void celix_arrayList_addSize(celix_array_list_t *list, size_t val) { 
+
+celix_status_t celix_arrayList_addSize(celix_array_list_t *list, size_t val) {
     celix_array_list_entry_t entry;
     memset(&entry, 0, sizeof(entry));
     entry.sizeVal = val;
-    arrayList_addEntry(list, entry);
+    return celix_arrayList_addEntry(list, entry);
 }
 
 int celix_arrayList_indexOf(celix_array_list_t *list, celix_array_list_entry_t entry) {


### PR DESCRIPTION
This PR adds a celix_status_t return to the `celix_arrayList_add*` functions.

Also adds a array_list_ei lib and adds vasprintf ei to the asprintf_ei lib. 

The code is based on the array list updates from #518 