### PR TITLE
Add .note section to embed_bundle_linux.s to prevent executable stack

### DIFF
--- a/cmake/cmake_celix/templates/embed_bundle_linux.s
+++ b/cmake/cmake_celix/templates/embed_bundle_linux.s
@@ -27,3 +27,4 @@ celix_embedded_bundle_@EMBED_BUNDLE_NAME@_start:
 .balign 64
 celix_embedded_bundle_@EMBED_BUNDLE_NAME@_end:
 .byte 0
+.section .note.GNU-stack,"",%progbits


### PR DESCRIPTION
This PR adds the .section .note.GNU-stack,"",%progbits directive to the embed_bundle_linux.s template file. This change addresses the "missing .note.GNU-stack section implies executable stack" warning from ld.

By adding this directive, we explicitly signal to the linker that the object file does not require an executable stack. 