### PR TITLE
Hotfix/macos action fix

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -9,7 +9,7 @@ on:
 jobs:
 
   build-conan:
-    runs-on: macOS-10.15
+    runs-on: macOS-latest
     timeout-minutes: 120
     steps:
       - name: Checkout source code

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -9,7 +9,7 @@ on:
 jobs:
 
   build-conan:
-    runs-on: macOS-latest
+    runs-on: macOS-11
     timeout-minutes: 120
     steps:
       - name: Checkout source code


### PR DESCRIPTION
GitHub Action does not support macOS-10.15 anymore.
Rather than macOS-latest, we use macOS-11 for build time optimization.