### PR TITLE
Feature/error injector ergonomics

### DIFF
--- a/bundles/pubsub/pubsub_spi/CMakeLists.txt
+++ b/bundles/pubsub/pubsub_spi/CMakeLists.txt
@@ -28,7 +28,7 @@ target_include_directories(pubsub_spi PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>)
 
 target_link_libraries(pubsub_spi PUBLIC Celix::framework Celix::pubsub_api)
-target_link_libraries(pubsub_spi PUBLIC Celix::pubsub_utils )
+target_link_libraries(pubsub_spi PUBLIC Celix::pubsub_utils libuuid::libuuid)
 celix_deprecated_utils_headers(pubsub_spi)
 celix_deprecated_framework_headers(pubsub_spi)
 add_library(Celix::pubsub_spi ALIAS pubsub_spi)

--- a/libs/error_injector/api/celix_error_injector.h
+++ b/libs/error_injector/api/celix_error_injector.h
@@ -82,6 +82,18 @@ do {                                                                            
             case 4:                                                                                      \
                 CELIX_EI_GET_CALLER(addr, 4);                                                            \
                 break;                                                                                   \
+            case 5:                                                                                      \
+                CELIX_EI_GET_CALLER(addr, 5);                                                            \
+                break;                                                                                   \
+            case 6:                                                                                      \
+                CELIX_EI_GET_CALLER(addr, 6);                                                            \
+                break;                                                                                   \
+            case 7:                                                                                      \
+                CELIX_EI_GET_CALLER(addr, 7);                                                            \
+                break;                                                                                   \
+            case 8:                                                                                      \
+                CELIX_EI_GET_CALLER(addr, 8);                                                            \
+                break;                                                                                   \
             default:                                                                                     \
                 assert(0);                                                                               \
             }                                                                                            \

--- a/libs/framework/CMakeLists.txt
+++ b/libs/framework/CMakeLists.txt
@@ -35,8 +35,9 @@ set(FRAMEWORK_SRC
         src/celix_bundle_state.c
         src/celix_framework_utils.c
         src/celix_module_private.h)
-add_library(framework SHARED ${FRAMEWORK_SRC})
 set(FRAMEWORK_DEPS libuuid::libuuid CURL::libcurl ZLIB::ZLIB ${CMAKE_DL_LIBS})
+
+add_library(framework SHARED ${FRAMEWORK_SRC})
 
 set_target_properties(framework
         PROPERTIES

--- a/libs/framework/CMakeLists.txt
+++ b/libs/framework/CMakeLists.txt
@@ -19,7 +19,7 @@ find_package(ZLIB REQUIRED)
 find_package(libuuid REQUIRED)
 find_package(CURL REQUIRED)
 
-set(SOURCES
+set(FRAMEWORK_SRC
         src/attribute.c src/bundle.c src/bundle_archive.c src/celix_bundle_cache.c
         src/bundle_context.c src/bundle_revision.c src/celix_errorcodes.c
         src/framework.c src/manifest.c
@@ -35,41 +35,31 @@ set(SOURCES
         src/celix_bundle_state.c
         src/celix_framework_utils.c
         src/celix_module_private.h)
-add_library(framework_obj OBJECT ${SOURCES})
+add_library(framework SHARED ${FRAMEWORK_SRC})
+set(FRAMEWORK_DEPS libuuid::libuuid CURL::libcurl ZLIB::ZLIB ${CMAKE_DL_LIBS})
 
-target_include_directories(framework_obj PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>
-)
-target_include_directories(framework_obj PRIVATE ${CMAKE_CURRENT_LIST_DIR}/include_deprecated)
-target_compile_options(framework_obj PRIVATE -DUSE_FILE32API)
-target_compile_options(framework_obj PRIVATE -Wno-deprecated-declarations) #note part of the api is deprecated, ignore this warning on own api
-target_link_libraries(framework_obj PUBLIC Celix::utils ${CELIX_OPTIONAL_EXTRA_LIBS})
-target_link_libraries(framework_obj PUBLIC libuuid::libuuid CURL::libcurl ZLIB::ZLIB)
-target_link_libraries(framework_obj PRIVATE ${CMAKE_DL_LIBS})
-#Note visibility preset is also needed on OBJECT libraries, to work correctly
-set_target_properties(framework_obj PROPERTIES C_VISIBILITY_PRESET hidden)
-celix_deprecated_utils_headers(framework_obj)
-
-add_library(framework SHARED)
-generate_export_header(framework
-        BASE_NAME "CELIX_FRAMEWORK"
-        EXPORT_FILE_NAME "${CMAKE_BINARY_DIR}/celix/gen/includes/framework/celix_framework_export.h")
-target_include_directories(framework_obj PUBLIC $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/celix/gen/includes/framework>)
-# We are building this library
-target_compile_definitions(framework_obj PRIVATE framework_EXPORTS)
-
-target_link_libraries(framework PUBLIC framework_obj)
 set_target_properties(framework
-    PROPERTIES
+        PROPERTIES
         C_VISIBILITY_PRESET hidden
         "VERSION" "${CELIX_MAJOR}.${CELIX_MINOR}.${CELIX_MICRO}"
         "SOVERSION" ${CELIX_MAJOR}
         OUTPUT_NAME "celix_framework")
+target_include_directories(framework PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>
+)
+target_include_directories(framework PRIVATE ${CMAKE_CURRENT_LIST_DIR}/include_deprecated)
+target_compile_options(framework PRIVATE -DUSE_FILE32API)
+target_compile_options(framework PRIVATE -Wno-deprecated-declarations) #note part of the api is deprecated, ignore this warning on own api
+target_link_libraries(framework PUBLIC Celix::utils ${CELIX_OPTIONAL_EXTRA_LIBS})
+target_link_libraries(framework PRIVATE ${FRAMEWORK_DEPS})
 
+generate_export_header(framework
+        BASE_NAME "CELIX_FRAMEWORK"
+        EXPORT_FILE_NAME "${CMAKE_BINARY_DIR}/celix/gen/includes/framework/celix_framework_export.h")
+target_include_directories(framework PUBLIC $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/celix/gen/includes/framework>)
 celix_deprecated_utils_headers(framework)
 
-# By omitting OBJECTS DESTINATION, object files will NOT be installed.
-install(TARGETS framework framework_obj EXPORT celix LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT framework
+install(TARGETS framework EXPORT celix LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT framework
         INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/celix/framework)
 install(DIRECTORY include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/celix/framework COMPONENT framework)
 install(DIRECTORY include_deprecated/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/celix/framework COMPONENT framework)
@@ -77,9 +67,19 @@ install(DIRECTORY ${CMAKE_BINARY_DIR}/celix/gen/includes/framework/ DESTINATION 
 
 #Alias setup to match external usage
 add_library(Celix::framework ALIAS framework)
-add_library(Celix::framework_obj ALIAS framework_obj)
 
 if (ENABLE_TESTING AND CELIX_CXX17) #framework tests are C++17
+    add_library(framework_cut STATIC ${FRAMEWORK_SRC})
+    target_include_directories(framework_cut PUBLIC
+            ${CMAKE_CURRENT_LIST_DIR}/src
+            ${CMAKE_CURRENT_LIST_DIR}/include
+            ${CMAKE_BINARY_DIR}/celix/gen/includes/framework
+            ${CMAKE_CURRENT_LIST_DIR}/include_deprecated
+            )
+    target_compile_options(framework_cut PRIVATE -DUSE_FILE32API)
+    target_compile_options(framework_cut PRIVATE -Wno-deprecated-declarations) #note part of the api is deprecated, ignore this warning on own api
+    target_link_libraries(framework_cut PUBLIC Celix::utils ${CELIX_OPTIONAL_EXTRA_LIBS} ${FRAMEWORK_DEPS})
+    celix_deprecated_utils_headers(framework_cut)
     add_subdirectory(gtest)
 endif()
 

--- a/libs/framework/gtest/CMakeLists.txt
+++ b/libs/framework/gtest/CMakeLists.txt
@@ -130,7 +130,7 @@ if (LINKER_WRAP_SUPPORTED)
             SIMPLE_TEST_BUNDLE1_LOCATION="${SIMPLE_TEST_BUNDLE1}"
             SIMPLE_CXX_BUNDLE_LOC="${SIMPLE_CXX_BUNDLE_LOC}"
     )
-    target_include_directories(test_framework_with_ei PRIVATE ../src)
+    target_include_directories(test_framework_with_ei PRIVATE ../src ../include_deprecated)
     add_celix_bundle_dependencies(test_framework_with_ei simple_test_bundle1 simple_cxx_bundle)
     celix_target_embedded_bundles(test_framework_with_ei simple_test_bundle1)
     celix_deprecated_utils_headers(test_framework_with_ei)

--- a/libs/framework/gtest/CMakeLists.txt
+++ b/libs/framework/gtest/CMakeLists.txt
@@ -59,7 +59,7 @@ set(CELIX_FRAMEWORK_TEST_SOURCES
 )
 
 add_executable(test_framework ${CELIX_FRAMEWORK_TEST_SOURCES})
-target_link_libraries(test_framework PRIVATE Celix::framework CURL::libcurl GTest::gtest GTest::gtest_main)
+target_link_libraries(test_framework PRIVATE framework_cut CURL::libcurl GTest::gtest GTest::gtest_main)
 celix_deprecated_framework_headers(test_framework)
 
 
@@ -130,12 +130,11 @@ if (LINKER_WRAP_SUPPORTED)
             SIMPLE_TEST_BUNDLE1_LOCATION="${SIMPLE_TEST_BUNDLE1}"
             SIMPLE_CXX_BUNDLE_LOC="${SIMPLE_CXX_BUNDLE_LOC}"
     )
-    target_include_directories(test_framework_with_ei PRIVATE ../src ../include_deprecated)
     add_celix_bundle_dependencies(test_framework_with_ei simple_test_bundle1 simple_cxx_bundle)
     celix_target_embedded_bundles(test_framework_with_ei simple_test_bundle1)
     celix_deprecated_utils_headers(test_framework_with_ei)
     target_link_libraries(test_framework_with_ei PRIVATE
-            Celix::framework_obj
+            framework_cut
             Celix::malloc_ei
             Celix::utils_ei
             Celix::asprintf_ei

--- a/libs/framework/gtest/CMakeLists.txt
+++ b/libs/framework/gtest/CMakeLists.txt
@@ -153,7 +153,7 @@ if (ENABLE_TESTING_DEPENDENCY_MANAGER_FOR_CXX11)
     add_executable(test_dep_man_with_cxx11
             src/DependencyManagerTestSuite.cc
             )
-    target_link_libraries(test_dep_man_with_cxx11 PRIVATE Celix::framework CURL::libcurl GTest::gtest GTest::gtest_main)
+    target_link_libraries(test_dep_man_with_cxx11 PRIVATE framework_cut CURL::libcurl GTest::gtest GTest::gtest_main)
     target_compile_definitions(test_dep_man_with_cxx11 PRIVATE
             SIMPLE_CXX_DEP_MAN_BUNDLE_LOC="${SIMPLE_CXX_DEP_MAN_BUNDLE_LOC}"
             )
@@ -172,7 +172,7 @@ if (ENABLE_TESTING_FOR_CXX14)
     set(CMAKE_CXX_STANDARD 14)
 
     add_executable(test_framework_with_cxx14 ${CELIX_FRAMEWORK_TEST_SOURCES})
-    target_link_libraries(test_framework_with_cxx14 PRIVATE Celix::framework CURL::libcurl GTest::gtest GTest::gtest_main)
+    target_link_libraries(test_framework_with_cxx14 PRIVATE framework_cut CURL::libcurl GTest::gtest GTest::gtest_main)
     celix_deprecated_utils_headers(test_framework_with_cxx14)
     celix_deprecated_framework_headers(test_framework_with_cxx14)
     add_celix_bundle_dependencies(test_framework_with_cxx14

--- a/libs/framework/gtest/CMakeLists.txt
+++ b/libs/framework/gtest/CMakeLists.txt
@@ -59,7 +59,9 @@ set(CELIX_FRAMEWORK_TEST_SOURCES
 )
 
 add_executable(test_framework ${CELIX_FRAMEWORK_TEST_SOURCES})
-target_link_libraries(test_framework PRIVATE framework_cut CURL::libcurl GTest::gtest GTest::gtest_main)
+# framework_cut makes error injector work
+# Celix::framework makes bundles loadable (otherwise we need an copy of framework in each bundle, celix_bundle_private_libs)
+target_link_libraries(test_framework PRIVATE framework_cut Celix::framework CURL::libcurl GTest::gtest GTest::gtest_main)
 celix_deprecated_framework_headers(test_framework)
 
 
@@ -135,6 +137,7 @@ if (LINKER_WRAP_SUPPORTED)
     celix_deprecated_utils_headers(test_framework_with_ei)
     target_link_libraries(test_framework_with_ei PRIVATE
             framework_cut
+            Celix::framework
             Celix::malloc_ei
             Celix::utils_ei
             Celix::asprintf_ei
@@ -153,7 +156,7 @@ if (ENABLE_TESTING_DEPENDENCY_MANAGER_FOR_CXX11)
     add_executable(test_dep_man_with_cxx11
             src/DependencyManagerTestSuite.cc
             )
-    target_link_libraries(test_dep_man_with_cxx11 PRIVATE framework_cut CURL::libcurl GTest::gtest GTest::gtest_main)
+    target_link_libraries(test_dep_man_with_cxx11 PRIVATE framework_cut Celix::framework CURL::libcurl GTest::gtest GTest::gtest_main)
     target_compile_definitions(test_dep_man_with_cxx11 PRIVATE
             SIMPLE_CXX_DEP_MAN_BUNDLE_LOC="${SIMPLE_CXX_DEP_MAN_BUNDLE_LOC}"
             )
@@ -172,7 +175,7 @@ if (ENABLE_TESTING_FOR_CXX14)
     set(CMAKE_CXX_STANDARD 14)
 
     add_executable(test_framework_with_cxx14 ${CELIX_FRAMEWORK_TEST_SOURCES})
-    target_link_libraries(test_framework_with_cxx14 PRIVATE framework_cut CURL::libcurl GTest::gtest GTest::gtest_main)
+    target_link_libraries(test_framework_with_cxx14 PRIVATE framework_cut Celix::framework CURL::libcurl GTest::gtest GTest::gtest_main)
     celix_deprecated_utils_headers(test_framework_with_cxx14)
     celix_deprecated_framework_headers(test_framework_with_cxx14)
     add_celix_bundle_dependencies(test_framework_with_cxx14

--- a/libs/framework/gtest/src/CelixBundleContextBundlesWithErrorTestSuite.cc
+++ b/libs/framework/gtest/src/CelixBundleContextBundlesWithErrorTestSuite.cc
@@ -82,7 +82,7 @@ TEST_F(CelixBundleContextBundlesWithErrorTestSuite, privateLibraryLoadErrorAbort
 }
 
 TEST_F(CelixBundleContextBundlesWithErrorTestSuite, failedToGetLibraryPath) {
-    celix_ei_expect_celix_utils_writeOrCreateString((void *)celix_framework_installBundle, 8, nullptr, 2);
+    celix_ei_expect_celix_utils_writeOrCreateString((void *)celix_module_loadLibraries, 2, nullptr);
     long bndId = celix_bundleContext_installBundle(ctx, SIMPLE_CXX_BUNDLE_LOC, true);
     ASSERT_TRUE(bndId > 0); //bundle is installed, but not started
 

--- a/libs/framework/gtest/src/CelixBundleContextBundlesWithErrorTestSuite.cc
+++ b/libs/framework/gtest/src/CelixBundleContextBundlesWithErrorTestSuite.cc
@@ -24,7 +24,9 @@
 extern "C" {
 #include "celix_libloader.h"
 }
+#include "celix_module_private.h"
 #include "celix_properties.h"
+#include "celix_utils_ei.h"
 #include "dlfcn_ei.h"
 
 class CelixBundleContextBundlesWithErrorTestSuite : public ::testing::Test {
@@ -46,6 +48,7 @@ public:
     ~CelixBundleContextBundlesWithErrorTestSuite() override {
         celix_frameworkFactory_destroyFramework(fw);
         celix_ei_expect_dlopen(nullptr, 0, nullptr);
+        celix_ei_expect_celix_utils_writeOrCreateString(nullptr, 0, nullptr);
     }
 
     CelixBundleContextBundlesWithErrorTestSuite(CelixBundleContextBundlesWithErrorTestSuite&&) = delete;
@@ -68,6 +71,18 @@ TEST_F(CelixBundleContextBundlesWithErrorTestSuite, activatorLoadErrorAbortBundl
 
 TEST_F(CelixBundleContextBundlesWithErrorTestSuite, privateLibraryLoadErrorAbortBundleResolution) {
     celix_ei_expect_dlopen(CELIX_EI_UNKNOWN_CALLER, 0, nullptr, 2);
+    long bndId = celix_bundleContext_installBundle(ctx, SIMPLE_CXX_BUNDLE_LOC, true);
+    ASSERT_TRUE(bndId > 0); //bundle is installed, but not started
+
+    bool called = celix_bundleContext_useBundle(ctx, bndId, nullptr, [](void */*handle*/, const celix_bundle_t *bnd) {
+        auto state = celix_bundle_getState(bnd);
+        ASSERT_EQ(state, CELIX_BUNDLE_STATE_INSTALLED);
+    });
+    ASSERT_TRUE(called);
+}
+
+TEST_F(CelixBundleContextBundlesWithErrorTestSuite, failedToGetLibraryPath) {
+    celix_ei_expect_celix_utils_writeOrCreateString((void *)celix_framework_installBundle, 8, nullptr, 2);
     long bndId = celix_bundleContext_installBundle(ctx, SIMPLE_CXX_BUNDLE_LOC, true);
     ASSERT_TRUE(bndId > 0); //bundle is installed, but not started
 

--- a/libs/framework/src/bundle_archive_private.h
+++ b/libs/framework/src/bundle_archive_private.h
@@ -41,9 +41,8 @@ extern "C" {
 
 /**
  * @brief Create bundle archive.
- * @note Symbol exported for testing purposes.
  */
-CELIX_FRAMEWORK_EXPORT celix_status_t celix_bundleArchive_create(celix_framework_t* fw, const char *archiveRoot, long id, const char *location, bundle_archive_pt *bundle_archive);
+celix_status_t celix_bundleArchive_create(celix_framework_t* fw, const char *archiveRoot, long id, const char *location, bundle_archive_pt *bundle_archive);
 
 celix_status_t bundleArchive_destroy(bundle_archive_pt archive);
 

--- a/libs/framework/src/bundle_private.h
+++ b/libs/framework/src/bundle_private.h
@@ -22,7 +22,6 @@
 
 #include "bundle.h"
 #include "celix_bundle.h"
-#include "celix_framework_export.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -56,12 +55,10 @@ celix_bundle_createFromArchive(celix_framework_t *framework, bundle_archive_pt a
 /**
  * @brief Get the bundle archive.
  *
- * @note Symbol export is needed for unit tests.
- *
  * @param[in] bundle The bundle.
  * @return The bundle archive.
  */
-CELIX_FRAMEWORK_EXPORT bundle_archive_t *celix_bundle_getArchive(const celix_bundle_t *bundle);
+bundle_archive_t *celix_bundle_getArchive(const celix_bundle_t *bundle);
 
 /**
  * Destroys the bundle.

--- a/libs/framework/src/bundle_revision_private.h
+++ b/libs/framework/src/bundle_revision_private.h
@@ -50,8 +50,6 @@ struct bundleRevision {
  * Creates a new revision for the given inputFile or location.
  * The location parameter is used to identify the bundle.
  *
- * @note Symbol exported for testing purposes.
- *
  * @param fw The Celix framework where to create the bundle revision.
  * @param root The root for this revision in which the bundle is extracted and state is stored.
  * @param location The location associated with the revision.
@@ -62,7 +60,7 @@ struct bundleRevision {
  * 		- CELIX_SUCCESS when no errors are encountered.
  * 		- CELIX_ENOMEM If allocating memory for <code>bundle_revision</code> failed.
  */
-CELIX_FRAMEWORK_EXPORT celix_status_t celix_bundleRevision_create(celix_framework_t* fw, const char *root, const char *location, manifest_pt manifest, bundle_revision_pt *bundle_revision);
+celix_status_t celix_bundleRevision_create(celix_framework_t* fw, const char *root, const char *location, manifest_pt manifest, bundle_revision_pt *bundle_revision);
 
 bundle_revision_t* bundleRevision_revise(const bundle_revision_t* revision, const char* updatedBundleUrl);
 

--- a/libs/framework/src/celix_framework_utils_private.h
+++ b/libs/framework/src/celix_framework_utils_private.h
@@ -23,7 +23,6 @@
 #include <time.h>
 
 #include "celix_framework_utils.h"
-#include "celix_framework_export.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -31,8 +30,6 @@ extern "C" {
 
 /**
  * @brief Checks whether the provided bundle url is newer than the provided time.
- *
- * @note Symbol export is required for unit testing.
  *
  * @param fw Celix framework (used for logging).
  * @param bundleURL The bundle url. Which must be the following:
@@ -44,12 +41,10 @@ extern "C" {
  * @return Whether the bundle url is newer than the provided time. Will also be true if time is NULL or if the bundleUrl
  *         is an embedded:// url.
  */
-CELIX_FRAMEWORK_EXPORT bool celix_framework_utils_isBundleUrlNewerThan(celix_framework_t* fw, const char* bundleURL, const struct timespec* time);
+bool celix_framework_utils_isBundleUrlNewerThan(celix_framework_t* fw, const char* bundleURL, const struct timespec* time);
 
 /**
  * @brief extracts a bundle for the given cache.
- *
- * @note Symbol export is required for unit testing.
  *
  * @param fw Optional Celix framework (used for logging).
  *           If NULL the result of celix_frameworkLogger_globalLogger() will be used for logging.
@@ -61,7 +56,7 @@ CELIX_FRAMEWORK_EXPORT bool celix_framework_utils_isBundleUrlNewerThan(celix_fra
  *  - no :// -> assuming that the url is a file path (same as with a file:// prefix)
  * @return CELIX_SUCCESS is the bundle was correctly extracted.
  */
-CELIX_FRAMEWORK_EXPORT celix_status_t celix_framework_utils_extractBundle(celix_framework_t *fw, const char *bundleURL,  const char* extractPath);
+celix_status_t celix_framework_utils_extractBundle(celix_framework_t *fw, const char *bundleURL,  const char* extractPath);
 
 /**
  * @brief Checks whether the provided bundle url is valid.
@@ -73,15 +68,13 @@ CELIX_FRAMEWORK_EXPORT celix_status_t celix_framework_utils_extractBundle(celix_
  *
  *  If a bundle url is invalid, this function will print - on error level - why the url is invalid.
  *
- *  @note Symbol export is required for unit testing.
- *
  * @param fw Optional Celix framework (used for logging).
  *           If NULL the result of celix_frameworkLogger_globalLogger() will be used for logging.
  * @param bundleURL A bundle url to check.
  * @param silent If true, this function will not write error logs when the bundle url is not valid.
  * @return Whether the bundle url is valid.
  */
-CELIX_FRAMEWORK_EXPORT bool celix_framework_utils_isBundleUrlValid(celix_framework_t *fw, const char *bundleURL, bool silent);
+bool celix_framework_utils_isBundleUrlValid(celix_framework_t *fw, const char *bundleURL, bool silent);
 
 #ifdef __cplusplus
 }

--- a/libs/framework/src/module.c
+++ b/libs/framework/src/module.c
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+#include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -409,7 +410,7 @@ static celix_status_t celix_module_loadLibraryForManifestEntry(celix_module_t* m
 
     if (!path) {
         fw_logCode(module->fw->logger, CELIX_LOG_LEVEL_ERROR, status, "Cannot create full library path");
-        return status;
+        return errno;
     }
 
     status = celix_module_loadLibrary(module, path, handle);

--- a/libs/utils/CMakeLists.txt
+++ b/libs/utils/CMakeLists.txt
@@ -28,7 +28,7 @@ if (NOT OPEN_MEMSTREAM_EXISTS)
     install(DIRECTORY include/memstream/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/celix/memstream COMPONENT framework)
 endif()
 
-add_library(utils_obj OBJECT
+set(UTILS_SRC
         src/array_list.c
         src/hash_map.c
         src/linked_list.c
@@ -45,51 +45,49 @@ add_library(utils_obj OBJECT
         src/celix_file_utils.c
         src/celix_convert_utils.c
         ${MEMSTREAM_SOURCES}
-)
+        )
+set(UTILS_PRIVATE_DEPS libzip::libzip)
+set(UTILS_PUBLIC_DEPS)
 
-target_link_libraries(utils_obj PRIVATE libzip::libzip)
-#Note visibility preset is also needed on OBJECT libraries, to work correctly
-set_target_properties(utils_obj PROPERTIES C_VISIBILITY_PRESET hidden)
-if (NOT OPEN_MEMSTREAM_EXISTS)
-    target_compile_definitions(utils_obj PUBLIC -DCELIX_UTILS_NO_MEMSTREAM_AVAILABLE)
-endif ()
+add_library(utils SHARED ${UTILS_SRC})
 
-if (ANDROID)
-    target_compile_definitions(utils_obj PRIVATE -DUSE_FILE32API)
-endif ()
-
-if (NOT APPLE)
-    target_link_libraries(utils_obj PUBLIC -lrt)
-endif ()
-
-target_include_directories(utils_obj PUBLIC
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>
-        $<BUILD_INTERFACE:${MEMSTREAM_INCLUDE_DIR}>
-        $<INSTALL_INTERFACE:include/celix/utils>)
-target_include_directories(utils_obj PRIVATE src include_deprecated)
-IF(UNIX AND NOT ANDROID)
-    target_link_libraries(utils_obj PRIVATE m pthread)
-ELSEIF(ANDROID)
-    target_link_libraries(utils_obj PRIVATE m)
-ENDIF()
-
-add_library(utils SHARED)
-target_link_libraries(utils PUBLIC utils_obj)
-generate_export_header(utils
-        BASE_NAME "CELIX_UTILS"
-        EXPORT_FILE_NAME "${CMAKE_BINARY_DIR}/celix/gen/includes/utils/celix_utils_export.h")
-target_include_directories(utils_obj PUBLIC $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/celix/gen/includes/utils>)
-# We are building this library
-target_compile_definitions(utils_obj PRIVATE utils_EXPORTS)
-
+target_link_libraries(utils PRIVATE libzip::libzip)
 set_target_properties(utils
         PROPERTIES
         C_VISIBILITY_PRESET hidden
         SOVERSION ${CELIX_MAJOR}
         OUTPUT_NAME "celix_utils")
 
-# By omitting OBJECTS DESTINATION, object files will NOT be installed.
-install(TARGETS utils utils_obj EXPORT celix LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT framework
+if (NOT OPEN_MEMSTREAM_EXISTS)
+    target_compile_definitions(utils PUBLIC -DCELIX_UTILS_NO_MEMSTREAM_AVAILABLE)
+endif ()
+
+if (ANDROID)
+    target_compile_definitions(utils PRIVATE -DUSE_FILE32API)
+endif ()
+
+if (NOT APPLE)
+    set(UTILS_PUBLIC_DEPS ${UTILS_PUBLIC_DEPS} rt)
+endif ()
+
+target_include_directories(utils PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/include>
+        $<BUILD_INTERFACE:${MEMSTREAM_INCLUDE_DIR}>
+        )
+target_include_directories(utils PRIVATE src include_deprecated)
+IF(UNIX AND NOT ANDROID)
+    set(UTILS_PRIVATE_DEPS ${UTILS_PRIVATE_DEPS} m pthread)
+ELSEIF(ANDROID)
+    set(UTILS_PRIVATE_DEPS ${UTILS_PRIVATE_DEPS} m)
+ENDIF()
+
+target_link_libraries(utils PUBLIC ${UTILS_PUBLIC_DEPS} PRIVATE ${UTILS_PRIVATE_DEPS})
+generate_export_header(utils
+        BASE_NAME "CELIX_UTILS"
+        EXPORT_FILE_NAME "${CMAKE_BINARY_DIR}/celix/gen/includes/utils/celix_utils_export.h")
+target_include_directories(utils PUBLIC $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/celix/gen/includes/utils>)
+
+install(TARGETS utils EXPORT celix LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT framework
         INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/celix/utils)
 install(DIRECTORY include/
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/celix/utils/
@@ -104,10 +102,18 @@ endif ()
 
 #Alias setup to match external usage
 add_library(Celix::utils ALIAS utils)
-add_library(Celix::utils_obj ALIAS utils_obj)
 
 
 if (ENABLE_TESTING)
+    add_library(utils_cut STATIC ${UTILS_SRC})
+    target_include_directories(utils_cut PUBLIC
+            ${CMAKE_CURRENT_LIST_DIR}/include
+            ${MEMSTREAM_INCLUDE_DIR}
+            ${CMAKE_BINARY_DIR}/celix/gen/includes/utils>
+            src include_deprecated
+            )
+    target_link_libraries(utils_cut PUBLIC ${UTILS_PUBLIC_DEPS} ${UTILS_PRIVATE_DEPS})
+
     if (CELIX_CXX17) #utils tests are C++17
         add_subdirectory(gtest)
     endif()
@@ -121,37 +127,37 @@ if (ENABLE_TESTING)
 
         add_executable(hash_map_test private/test/hash_map_test.cpp)
         target_include_directories(hash_map_test PRIVATE include_deprecated)
-        target_link_libraries(hash_map_test Celix::utils CppUTest::CppUTest pthread)
+        target_link_libraries(hash_map_test utils_cut CppUTest::CppUTest pthread)
 
         add_executable(array_list_test private/test/array_list_test.cpp)
         target_include_directories(array_list_test PRIVATE include_deprecated)
-        target_link_libraries(array_list_test  Celix::utils CppUTest::CppUTest pthread)
+        target_link_libraries(array_list_test utils_cut CppUTest::CppUTest pthread)
 
         add_executable(celix_threads_test private/test/celix_threads_test.cpp)
         target_include_directories(celix_threads_test PRIVATE include_deprecated)
-        target_link_libraries(celix_threads_test Celix::utils CppUTest::CppUTest ${CppUTest_EXT_LIBRARIES} pthread)
+        target_link_libraries(celix_threads_test utils_cut CppUTest::CppUTest ${CppUTest_EXT_LIBRARIES} pthread)
 
         add_executable(linked_list_test private/test/linked_list_test.cpp)
         target_include_directories(linked_list_test PRIVATE include_deprecated)
-        target_link_libraries(linked_list_test  Celix::utils CppUTest::CppUTest pthread)
+        target_link_libraries(linked_list_test utils_cut CppUTest::CppUTest pthread)
 
         add_executable(properties_test private/test/properties_test.cpp)
         target_include_directories(properties_test PRIVATE include_deprecated)
-        target_link_libraries(properties_test CppUTest::CppUTest CppUTest::CppUTestExt  Celix::utils pthread)
+        target_link_libraries(properties_test CppUTest::CppUTest CppUTest::CppUTestExt utils_cut pthread)
 
         add_executable(ip_utils_test private/test/ip_utils_test.cpp)
         target_include_directories(ip_utils_test PRIVATE include_deprecated)
-        target_link_libraries(ip_utils_test CppUTest::CppUTest  Celix::utils pthread)
+        target_link_libraries(ip_utils_test CppUTest::CppUTest  utils_cut pthread)
 
         add_executable(version_test private/test/version_test.cpp)
         target_include_directories(version_test PRIVATE include_deprecated)
-        target_link_libraries(version_test CppUTest::CppUTest  Celix::utils pthread)
+        target_link_libraries(version_test CppUTest::CppUTest utils_cut pthread)
 
 
         if (LINKER_WRAP_SUPPORTED)
             add_executable(version_ei_test private/test/version_ei_test.cc)
             target_include_directories(version_ei_test PRIVATE include_deprecated)
-            target_link_libraries(version_ei_test CppUTest::CppUTest Celix::utils_obj Celix::malloc_ei Celix::utils_ei pthread)
+            target_link_libraries(version_ei_test CppUTest::CppUTest utils_cut Celix::malloc_ei Celix::utils_ei pthread)
             add_test(NAME version_ei_test COMMAND version_ei_test)
         endif ()
 

--- a/libs/utils/CMakeLists.txt
+++ b/libs/utils/CMakeLists.txt
@@ -109,7 +109,7 @@ if (ENABLE_TESTING)
     target_include_directories(utils_cut PUBLIC
             ${CMAKE_CURRENT_LIST_DIR}/include
             ${MEMSTREAM_INCLUDE_DIR}
-            ${CMAKE_BINARY_DIR}/celix/gen/includes/utils>
+            ${CMAKE_BINARY_DIR}/celix/gen/includes/utils
             src include_deprecated
             )
     target_link_libraries(utils_cut PUBLIC ${UTILS_PUBLIC_DEPS} ${UTILS_PRIVATE_DEPS})

--- a/libs/utils/gtest/CMakeLists.txt
+++ b/libs/utils/gtest/CMakeLists.txt
@@ -36,7 +36,7 @@ add_executable(test_utils
         ${CELIX_UTIL_TEST_SOURCES_FOR_CXX_HEADERS}
 )
 
-target_link_libraries(test_utils PRIVATE Celix::utils GTest::gtest GTest::gtest_main libzip::libzip)
+target_link_libraries(test_utils PRIVATE utils_cut GTest::gtest GTest::gtest_main libzip::libzip)
 target_include_directories(test_utils PRIVATE ../src) #for version_private (needs refactoring of test)
 celix_deprecated_utils_headers(test_utils)
 
@@ -84,7 +84,7 @@ if (LINKER_WRAP_SUPPORTED)
             src/IpUtilsErrorInjectionTestSuite.cc
             src/ArrayListErrorInjectionTestSuite.cc
     )
-    target_link_libraries(test_utils_with_ei PRIVATE Celix::zip_ei Celix::stdio_ei Celix::stat_ei Celix::fts_ei Celix::utils_obj Celix::utils_ei Celix::ifaddrs_ei Celix::malloc_ei GTest::gtest GTest::gtest_main)
+    target_link_libraries(test_utils_with_ei PRIVATE Celix::zip_ei Celix::stdio_ei Celix::stat_ei Celix::fts_ei utils_cut Celix::utils_ei Celix::ifaddrs_ei Celix::malloc_ei GTest::gtest GTest::gtest_main)
     target_include_directories(test_utils_with_ei PRIVATE ../src) #for version_private (needs refactoring of test)
     celix_deprecated_utils_headers(test_utils_with_ei)
     add_dependencies(test_utils_with_ei test_utils_resources)
@@ -100,7 +100,7 @@ if (ENABLE_TESTING_FOR_CXX14)
     add_executable(test_utils_cxx_headers_with_cxx14
             ${CELIX_UTIL_TEST_SOURCES_FOR_CXX_HEADERS}
     )
-    target_link_libraries(test_utils_cxx_headers_with_cxx14 PRIVATE Celix::utils GTest::gtest GTest::gtest_main)
+    target_link_libraries(test_utils_cxx_headers_with_cxx14 PRIVATE utils_cut GTest::gtest GTest::gtest_main)
     add_test(NAME test_utils_cxx_headers_with_cxx14 COMMAND test_utils_cxx_headers_with_cxx14)
     setup_target_for_coverage(test_utils_cxx_headers_with_cxx14 SCAN_DIR ..)
 endif ()

--- a/libs/utils/src/array_list_private.h
+++ b/libs/utils/src/array_list_private.h
@@ -28,7 +28,6 @@
 #define array_list_t_PRIVATE_H_
 
 #include "array_list.h"
-#include "celix_utils_export.h"
 
 struct celix_array_list {
     celix_array_list_entry_t* elementData;

--- a/libs/utils/src/hash_map_private.h
+++ b/libs/utils/src/hash_map_private.h
@@ -27,17 +27,15 @@
 #ifndef HASH_MAP_PRIVATE_H_
 #define HASH_MAP_PRIVATE_H_
 
-#include "celix_utils_export.h"
 #include "hash_map.h"
 
-//note functions used for testing, so export is needed
-CELIX_UTILS_EXPORT  unsigned int hashMap_hashCode(const void* toHash);
-CELIX_UTILS_EXPORT  int hashMap_equals(const void* toCompare, const void* compare);
+unsigned int hashMap_hashCode(const void* toHash);
+int hashMap_equals(const void* toCompare, const void* compare);
 
-CELIX_UTILS_EXPORT void hashMap_resize(hash_map_pt map, int newCapacity);
-CELIX_UTILS_EXPORT hash_map_entry_pt hashMap_removeEntryForKey(hash_map_pt map, const void* key);
-CELIX_UTILS_EXPORT  hash_map_entry_pt hashMap_removeMapping(hash_map_pt map, hash_map_entry_pt entry);
-CELIX_UTILS_EXPORT void hashMap_addEntry(hash_map_pt map, int hash, void* key, void* value, int bucketIndex);
+void hashMap_resize(hash_map_pt map, int newCapacity);
+hash_map_entry_pt hashMap_removeEntryForKey(hash_map_pt map, const void* key);
+hash_map_entry_pt hashMap_removeMapping(hash_map_pt map, hash_map_entry_pt entry);
+void hashMap_addEntry(hash_map_pt map, int hash, void* key, void* value, int bucketIndex);
 
 struct hashMapEntry {
     void* key;


### PR DESCRIPTION
With #524 merged, the lack of exported symbols makes error injector hard to use.
For example, to inject error into `celix_utils_writeOrCreateString` called by `celix_module_loadLibraryForManifestEntry`, we need to specify its 9th parent caller `celix_framework_installBundle`:

```C++
TEST_F(CelixBundleContextBundlesWithErrorTestSuite, failedToGetLibraryPath) {
    celix_ei_expect_celix_utils_writeOrCreateString((void *)celix_framework_installBundle, 8, nullptr, 2);
    long bndId = celix_bundleContext_installBundle(ctx, SIMPLE_CXX_BUNDLE_LOC, true);
    ASSERT_TRUE(bndId > 0); //bundle is installed, but not started

    bool called = celix_bundleContext_useBundle(ctx, bndId, nullptr, [](void */*handle*/, const celix_bundle_t *bnd) {
        auto state = celix_bundle_getState(bnd);
        ASSERT_EQ(state, CELIX_BUNDLE_STATE_INSTALLED);
    });
    ASSERT_TRUE(called);
}
```

And the first call made by `celix_framework_installBundle` came from another irrelevant module, which means modification to that module may fail this test case.

Also to make the original test work, we have to export some private API, which break the purpose of symbol visibility control (and thus is very undesirable).

This PR addresses both problems, it builds the code under test as a separate static library(a with _cut suffix) and link it into the test executable. The only downside is that we have to compile the same set of source codes twice instead of once.