### PR TITLE
Feature/trim string in place

### DIFF
--- a/bundles/pubsub/pubsub_admin_tcp/src/pubsub_tcp_common.c
+++ b/bundles/pubsub/pubsub_admin_tcp/src/pubsub_tcp_common.c
@@ -19,6 +19,7 @@
 #include <stdio.h>
 #include <string.h>
 #include "pubsub_tcp_common.h"
+#include "celix_utils.h"
 
 
 bool psa_tcp_isPassive(const char* buffer) {
@@ -27,7 +28,7 @@ bool psa_tcp_isPassive(const char* buffer) {
     if (buffer != NULL) {
         char buf[32];
         snprintf(buf, 32, "%s", buffer);
-        char *trimmed = utils_stringTrim(buf);
+        char *trimmed = celix_utils_trimInPlace(buf);
         if (strncasecmp("true", trimmed, strlen("true")) == 0) {
             isPassive = true;
         } else if (strncasecmp("false", trimmed, strlen("false")) == 0) {

--- a/bundles/remote_services/discovery_common/src/endpoint_discovery_poller.c
+++ b/bundles/remote_services/discovery_common/src/endpoint_discovery_poller.c
@@ -34,6 +34,7 @@
 
 #include "bundle_context.h"
 #include "celix_log_helper.h"
+#include "celix_utils.h"
 #include "utils.h"
 
 #include "endpoint_descriptor_reader.h"
@@ -99,7 +100,7 @@ celix_status_t endpointDiscoveryPoller_create(discovery_t *discovery, celix_bund
 	char *save_ptr = NULL;
 	char* tok = strtok_r(endpoints, sep, &save_ptr);
 	while (tok) {
-		endpointDiscoveryPoller_addDiscoveryEndpoint(*poller, utils_stringTrim(tok));
+		endpointDiscoveryPoller_addDiscoveryEndpoint(*poller, celix_utils_trimInPlace(tok));
 		tok = strtok_r(NULL, sep, &save_ptr);
 	}
 	// Clean up after ourselves...

--- a/bundles/remote_services/discovery_common/src/endpoint_discovery_server.c
+++ b/bundles/remote_services/discovery_common/src/endpoint_discovery_server.c
@@ -26,6 +26,7 @@
 #endif
 #include "civetweb.h"
 #include "celix_errno.h"
+#include "celix_utils.h"
 #include "utils.h"
 #include "celix_log_helper.h"
 #include "discovery.h"
@@ -293,8 +294,7 @@ celix_status_t endpointDiscoveryServer_removeEndpoint(endpoint_discovery_server_
 }
 
 static char* format_path(const char* path) {
-    char* result = strdup(path);
-    result = utils_stringTrim(result);
+    char* result = celix_utils_trim(path);
     // check whether the path starts with a leading slash...
     if (result[0] != '/') {
         size_t len = strlen(result);

--- a/bundles/remote_services/remote_service_admin_dfi/src/remote_service_admin_dfi.c
+++ b/bundles/remote_services/remote_service_admin_dfi/src/remote_service_admin_dfi.c
@@ -33,6 +33,7 @@
 #include <jansson.h>
 #include "json_serializer.h"
 #include "utils.h"
+#include "celix_utils.h"
 
 #include "import_registration_dfi.h"
 #include "export_registration_dfi.h"
@@ -597,7 +598,7 @@ celix_status_t remoteServiceAdmin_exportService(remote_service_admin_t *admin, c
 
         token = strtok_r(ecCopy, delimiter, &savePtr);
         while (token != NULL) {
-            if (strncmp(utils_stringTrim(token), RSA_DFI_CONFIGURATION_TYPE, 1024) == 0) {
+            if (strncmp(celix_utils_trimInPlace(token), RSA_DFI_CONFIGURATION_TYPE, 1024) == 0) {
                 export = true;
                 break;
             }
@@ -897,7 +898,7 @@ celix_status_t remoteServiceAdmin_importService(remote_service_admin_t *admin, e
 
         token = strtok_r(ecCopy, delimiter, &savePtr);
         while (token != NULL) {
-            if (strncmp(utils_stringTrim(token), RSA_DFI_CONFIGURATION_TYPE, 1024) == 0) {
+            if (strncmp(celix_utils_trimInPlace(token), RSA_DFI_CONFIGURATION_TYPE, 1024) == 0) {
                 importService = true;
                 break;
             }

--- a/bundles/remote_services/remote_service_admin_shm_v2/rsa_shm/src/rsa_shm_export_registration.c
+++ b/bundles/remote_services/remote_service_admin_shm_v2/rsa_shm/src/rsa_shm_export_registration.c
@@ -113,11 +113,10 @@ celix_status_t exportRegistration_create(celix_bundle_context_t *context,
     char *token, *savePtr;
     token = strtok_r(icCopy, delimiter, &savePtr);
     while (token != NULL) {
-        rsaRpcType = celix_utils_trim(token);
-        if (rsaRpcType != NULL && strncmp(rsaRpcType, RSA_RPC_TYPE_PREFIX, sizeof(RSA_RPC_TYPE_PREFIX) - 1) == 0) {
+        rsaRpcType = celix_utils_trimInPlace(token);
+        if (strncmp(rsaRpcType, RSA_RPC_TYPE_PREFIX, sizeof(RSA_RPC_TYPE_PREFIX) - 1) == 0) {
             break;
         }
-        free(rsaRpcType);
         rsaRpcType = NULL;
         token = strtok_r(NULL, delimiter, &savePtr);
     }
@@ -151,14 +150,12 @@ celix_status_t exportRegistration_create(celix_bundle_context_t *context,
 
     *exportOut = export;
 
-    free(rsaRpcType);
     free(icCopy);
 
     return CELIX_SUCCESS;
 
 tracker_err:
 rpc_type_filter_err:
-    free(rsaRpcType);
 rpc_type_err:
     free(icCopy);
 imported_configs_err:

--- a/bundles/remote_services/remote_service_admin_shm_v2/rsa_shm/src/rsa_shm_impl.c
+++ b/bundles/remote_services/remote_service_admin_shm_v2/rsa_shm/src/rsa_shm_impl.c
@@ -293,14 +293,11 @@ static bool rsaShm_isConfigTypeMatched(celix_properties_t *properties) {
 
         token = strtok_r(ecCopy, delimiter, &savePtr);
         while (token != NULL) {
-            char *configType = celix_utils_trim(token);
-            if (configType != NULL && strncmp(configType, RSA_SHM_CONFIGURATION_TYPE, 1024) == 0) {
+            char *configType = celix_utils_trimInPlace(token);
+            if (strncmp(configType, RSA_SHM_CONFIGURATION_TYPE, 1024) == 0) {
                 matched = true;
-                free(configType);
                 break;
             }
-            free(configType);
-
             token = strtok_r(NULL, delimiter, &savePtr);
         }
 
@@ -657,17 +654,13 @@ celix_status_t rsaShm_importService(rsa_shm_t *admin, endpoint_description_t *en
 
         token = strtok_r(ecCopy, delimiter, &savePtr);
         while (token != NULL) {
-            char *trimmedToken = celix_utils_trim(token);
-            if (trimmedToken != NULL && strcmp(trimmedToken, RSA_SHM_CONFIGURATION_TYPE) == 0) {
+            char *trimmedToken = celix_utils_trimInPlace(token);
+            if (strcmp(trimmedToken, RSA_SHM_CONFIGURATION_TYPE) == 0) {
                 importService = true;
-                free(trimmedToken);
                 break;
             }
-            free(trimmedToken);
-
             token = strtok_r(NULL, delimiter, &savePtr);
         }
-
         free(ecCopy);
     } else {
         celix_logHelper_warning(admin->logHelper, "Mandatory %s element missing from endpoint description", OSGI_RSA_SERVICE_IMPORTED_CONFIGS);

--- a/bundles/remote_services/remote_service_admin_shm_v2/rsa_shm/src/rsa_shm_impl.c
+++ b/bundles/remote_services/remote_service_admin_shm_v2/rsa_shm/src/rsa_shm_impl.c
@@ -381,37 +381,26 @@ celix_status_t rsaShm_exportService(rsa_shm_t *admin, char *serviceId,
             char *provided_save_ptr = NULL;
             char *interface = strtok_r(provided, ",", &provided_save_ptr);
             while (interface != NULL) {
-                interface = celix_utils_trim(interface);
-                if (interface != NULL) {
-                    celix_arrayList_add(interfaces, interface);
-                }
+                celix_arrayList_add(interfaces, celix_utils_trimInPlace(interface));
                 interface = strtok_r(NULL, ",", &provided_save_ptr);
             }
         } else {
             char *provided_save_ptr = NULL;
             char *pinterface = strtok_r(provided, ",", &provided_save_ptr);
             while (pinterface != NULL) {
-                pinterface = celix_utils_trim(pinterface);
-                if (pinterface != NULL) {
-                    celix_arrayList_add(proInterfaces, pinterface);
-                }
+                celix_arrayList_add(proInterfaces, celix_utils_trimInPlace(pinterface));
                 pinterface = strtok_r(NULL, ",", &provided_save_ptr);
             }
 
             char *exports_save_ptr = NULL;
             char *einterface = strtok_r(exports, ",", &exports_save_ptr);
             while (einterface != NULL) {
-                einterface = celix_utils_trim(einterface);
-                bool matched = false;
-                for (int i = 0; einterface != NULL && i < celix_arrayList_size(proInterfaces); ++i) {
+                einterface = celix_utils_trimInPlace(einterface);
+                for (int i = 0; i < celix_arrayList_size(proInterfaces); ++i) {
                     if (strcmp(celix_arrayList_get(proInterfaces, i), einterface) == 0) {
                         celix_arrayList_add(interfaces, einterface);
-                        matched = true;
                         break;
                     }
-                }
-                if (!matched) {
-                    free(einterface);
                 }
                 einterface = strtok_r(NULL, ",", &exports_save_ptr);
             }
@@ -447,13 +436,7 @@ celix_status_t rsaShm_exportService(rsa_shm_t *admin, char *serviceId,
             celix_arrayList_destroy(registrations);
             registrations = NULL;
         }
-        for (int i = 0; i < celix_arrayList_size(interfaces); ++i) {
-            free(celix_arrayList_get(interfaces, i));
-        }
         celix_arrayList_destroy(interfaces);
-        for (int i = 0; i < celix_arrayList_size(proInterfaces); ++i) {
-            free(celix_arrayList_get(proInterfaces, i));
-        }
         celix_arrayList_destroy(proInterfaces);
         free(exports);
         free(provided);

--- a/bundles/remote_services/remote_service_admin_shm_v2/rsa_shm/src/rsa_shm_import_registration.c
+++ b/bundles/remote_services/remote_service_admin_shm_v2/rsa_shm/src/rsa_shm_import_registration.c
@@ -76,11 +76,10 @@ celix_status_t importRegistration_create(celix_bundle_context_t *context,
     char *token, *savePtr;
     token = strtok_r(icCopy, delimiter, &savePtr);
     while (token != NULL) {
-        rsaRpcType = celix_utils_trim(token);
-        if (rsaRpcType != NULL && strncmp(rsaRpcType, RSA_RPC_TYPE_PREFIX, sizeof(RSA_RPC_TYPE_PREFIX) - 1) == 0) {
+        rsaRpcType = celix_utils_trimInPlace(token);
+        if (strncmp(rsaRpcType, RSA_RPC_TYPE_PREFIX, sizeof(RSA_RPC_TYPE_PREFIX) - 1) == 0) {
             break;
         }
-        free(rsaRpcType);
         rsaRpcType = NULL;
         token = strtok_r(NULL, delimiter, &savePtr);
     }
@@ -113,13 +112,11 @@ celix_status_t importRegistration_create(celix_bundle_context_t *context,
 
     *importOut = import;
 
-    free(rsaRpcType);
     free(icCopy);
 
     return CELIX_SUCCESS;
 tracker_err:
 rpc_type_filter_err:
-    free(rsaRpcType);
 rpc_type_err:
     free(icCopy);
 imported_configs_err:

--- a/bundles/shell/remote_shell/src/remote_shell.c
+++ b/bundles/shell/remote_shell/src/remote_shell.c
@@ -32,6 +32,7 @@
 #include <sys/socket.h>
 
 #include "celix_log_helper.h"
+#include "celix_utils.h"
 
 #include "remote_shell.h"
 
@@ -215,8 +216,7 @@ static celix_status_t remoteShell_connection_execute(connection_pt connection, c
 	celix_status_t status = CELIX_SUCCESS;
 
 	if (status == CELIX_SUCCESS) {
-		char *dline = strdup(command);
-		char *line = utils_stringTrim(dline);
+		char *line = celix_utils_trim(command);
 		int len = strlen(line);
 
 		if (len == 0) {
@@ -228,7 +228,7 @@ static celix_status_t remoteShell_connection_execute(connection_pt connection, c
             fflush(connection->socketStream);
 		}
 
-		free(dline);
+		free(line);
 	}
 
 	return status;

--- a/bundles/shell/shell_tui/src/shell_tui.c
+++ b/bundles/shell/shell_tui/src/shell_tui.c
@@ -26,6 +26,7 @@
 
 #include "celix_array_list.h"
 #include "celix_shell.h"
+#include "celix_utils.h"
 #include "shell_tui.h"
 #include "utils.h"
 #include <signal.h>
@@ -277,7 +278,7 @@ static int shellTui_parseInputPlain(shell_tui_t* shellTui, shell_context_t* ctx)
     int nr_chars = read(shellTui->inputFd, buffer, LINE_SIZE-pos-1);
     for(int bufpos = 0; bufpos < nr_chars; bufpos++) {
         if (buffer[bufpos] == KEY_ENTER) { //end of line -> forward command
-            line = utils_stringTrim(in);
+            line = celix_utils_trimInPlace(in);
             celixThreadMutex_lock(&shellTui->mutex);
             if (shellTui->shell != NULL) {
                 shellTui->shell->executeCommand(shellTui->shell->handle, line, shellTui->output, shellTui->error);
@@ -392,7 +393,7 @@ static int shellTui_parseInputForControl(shell_tui_t* shellTui, shell_context_t*
         pos = 0;
         in[pos] = '\0';
 
-        line = utils_stringTrim(dline);
+        line = celix_utils_trimInPlace(dline);
         if ((strlen(line) == 0)) {
             continue;
         }

--- a/libs/framework/src/manifest_parser.c
+++ b/libs/framework/src/manifest_parser.c
@@ -28,6 +28,7 @@
 #include <string.h>
 
 #include "utils.h"
+#include "celix_utils.h"
 #include "celix_constants.h"
 #include "manifest_parser.h"
 #include "capability.h"
@@ -155,7 +156,7 @@ static linked_list_pt manifestParser_parseDelimitedString(const char * value, co
 			}
 
 			if (strlen(buffer) > 0) {
-				linkedList_addElement(list, strdup(utils_stringTrim(buffer)));
+				linkedList_addElement(list, celix_utils_trim(buffer));
 			}
 		}
 	}

--- a/libs/framework/src/module.c
+++ b/libs/framework/src/module.c
@@ -439,7 +439,7 @@ static celix_status_t celix_module_loadLibrariesInManifestEntry(celix_module_t* 
         char lib[128];
         lib[127] = '\0';
         strncpy(lib, pathToken, 127);
-        char *trimmedLib = utils_stringTrim(lib);
+        char *trimmedLib = celix_utils_trimInPlace(lib);
         status = celix_module_loadLibraryForManifestEntry(module, trimmedLib, archive, &handle);
 
         if ( (status == CELIX_SUCCESS) && (activator != NULL) && (strcmp(trimmedLib, activator) == 0) ) {

--- a/libs/utils/gtest/src/CelixUtilsTestSuite.cc
+++ b/libs/utils/gtest/src/CelixUtilsTestSuite.cc
@@ -259,7 +259,7 @@ TEST_F(UtilsTestSuite, StringTrimTest) {
     free(trimmed);
 
     // Empty string
-    trimmed = utils_stringTrim(celix_utils_strdup("  abc   "));
+    trimmed = celix_utils_trim("  abc   ");
     EXPECT_STREQ("abc", trimmed);
     free(trimmed);
 }

--- a/libs/utils/include/celix_utils.h
+++ b/libs/utils/include/celix_utils.h
@@ -105,6 +105,14 @@ CELIX_UTILS_EXPORT bool celix_utils_containsWhitespace(const char* s);
  * Caller is owner of the returned string.
  */
 CELIX_UTILS_EXPORT char* celix_utils_trim(const char* string);
+/**
+ * @brief Trims the provided string in place.
+ *
+ * The trim will remove eny leading and trailing whitespaces (' ', '\t', etc based on `isspace`)/
+ * @param string the string to be trimmed.
+ * @return string.
+ */
+CELIX_UTILS_EXPORT char* celix_utils_trimInPlace(char* string);
 
 /**
  * @brief Check if a string is NULL or empty "".

--- a/libs/utils/include/celix_utils.h
+++ b/libs/utils/include/celix_utils.h
@@ -101,14 +101,14 @@ CELIX_UTILS_EXPORT bool celix_utils_containsWhitespace(const char* s);
 /**
  * @brief Returns a trimmed string.
  *
- * The trim will remove eny leading and trailing whitespaces (' ', '\t', etc based on `isspace`)/
+ * The trim will remove any leading and trailing whitespaces (' ', '\t', etc based on `isspace`)/
  * Caller is owner of the returned string.
  */
 CELIX_UTILS_EXPORT char* celix_utils_trim(const char* string);
 /**
  * @brief Trims the provided string in place.
  *
- * The trim will remove eny leading and trailing whitespaces (' ', '\t', etc based on `isspace`)/
+ * The trim will remove any leading and trailing whitespaces (' ', '\t', etc based on `isspace`)/
  * @param string the string to be trimmed.
  * @return string.
  */

--- a/libs/utils/src/celix_convert_utils.c
+++ b/libs/utils/src/celix_convert_utils.c
@@ -52,7 +52,7 @@ bool celix_utils_convertStringToBool(const char* val, bool defaultValue, bool* c
         if (valCopy == NULL) {
             return result;
         }
-        char *trimmed = utils_stringTrim(valCopy);
+        char *trimmed = celix_utils_trimInPlace(valCopy);
         if (strcasecmp("true", trimmed) == 0) {
             result = true;
             if (converted) {
@@ -114,7 +114,7 @@ celix_version_t* celix_utils_convertStringToVersion(const char* val, const celix
         if (firstDot != NULL && lastDot != NULL && firstDot != lastDot) {
             char buf[64];
             char* valCopy = celix_utils_writeOrCreateString(buf, sizeof(buf), "%s", val);
-            char *trimmed = utils_stringTrim(valCopy);
+            char *trimmed = celix_utils_trimInPlace(valCopy);
             result = celix_version_createVersionFromString(trimmed);
             celix_utils_freeStringIfNotEqual(buf, valCopy);
         }

--- a/libs/utils/src/properties.c
+++ b/libs/utils/src/properties.c
@@ -26,6 +26,7 @@
 #include "properties.h"
 #include "celix_build_assert.h"
 #include "celix_properties.h"
+#include "celix_utils.h"
 #include "utils.h"
 #include "hash_map_private.h"
 #include <errno.h>
@@ -191,7 +192,7 @@ static void parseLine(const char* line, celix_properties_t *props) {
 
     if (!isComment) {
         //printf("putting 'key'/'value' '%s'/'%s' in properties\n", utils_stringTrim(key), utils_stringTrim(value));
-        celix_properties_set(props, utils_stringTrim(key), utils_stringTrim(value));
+        celix_properties_set(props, celix_utils_trimInPlace(key), celix_utils_trimInPlace(value));
     }
     if(key) {
         free(key);
@@ -451,7 +452,7 @@ bool celix_properties_getAsBool(const celix_properties_t *props, const char *key
     if (val != NULL) {
         char buf[32];
         snprintf(buf, 32, "%s", val);
-        char *trimmed = utils_stringTrim(buf);
+        char *trimmed = celix_utils_trimInPlace(buf);
         if (strncasecmp("true", trimmed, strlen("true")) == 0) {
             result = true;
         } else if (strncasecmp("false", trimmed, strlen("false")) == 0) {

--- a/libs/utils/src/utils.c
+++ b/libs/utils/src/utils.c
@@ -152,6 +152,9 @@ static char* celix_utilsTrimInternal(char *string) {
 char* celix_utils_trim(const char* string) {
     return celix_utilsTrimInternal(celix_utils_strdup(string));
 }
+char* celix_utils_trimInPlace(char* string) {
+    return celix_utilsTrimInternal(string);
+}
 
 char* utils_stringTrim(char* string) {
     return celix_utilsTrimInternal(string);


### PR DESCRIPTION
This PR adds deprecated `utils_stringTrim` back as `celix_utils_trimInPlace`, and recover all its proper use throughout the whole code base. 

I notice that currently there are two `celix_ei_expect_celix_utils_trim` in `RsaShmUnitTestSuite`. 
Please help review the rsa_shm part (including its testing). @xuzhenbao