### PR TITLE
Fix issue that a NULL bundle handle still got an activator.

### DIFF
--- a/libs/framework/include/celix_constants.h
+++ b/libs/framework/include/celix_constants.h
@@ -188,7 +188,7 @@ extern "C" {
  * @brief Celix framework environment property (named "CELIX_FRAMEWORK_CLEAN_CACHE_DIR_ON_CREATE") specifying
  * whether to delete the cache dir on framework creation.
  *
- * If not specified "true" is used.
+ * The default value is false
  */
 #define CELIX_FRAMEWORK_CLEAN_CACHE_DIR_ON_CREATE "CELIX_FRAMEWORK_CLEAN_CACHE_DIR_ON_CREATE"
 

--- a/libs/framework/src/celix_libloader.c
+++ b/libs/framework/src/celix_libloader.c
@@ -53,6 +53,50 @@ void* celix_libloader_getSymbol(celix_library_handle_t *handle, const char *name
     return dlsym(handle, name);
 }
 
+celix_bundle_activator_create_fp celix_libloader_findBundleActivatorCreate(celix_library_handle_t* bundleActivatorHandle) {
+    celix_bundle_activator_create_fp result = NULL;
+    if (bundleActivatorHandle != NULL) {
+        result = (celix_bundle_activator_create_fp) dlsym(bundleActivatorHandle, CELIX_FRAMEWORK_BUNDLE_ACTIVATOR_CREATE);
+        if (result == NULL) {
+            result = (celix_bundle_activator_create_fp) dlsym(bundleActivatorHandle, OSGI_FRAMEWORK_DEPRECATED_BUNDLE_ACTIVATOR_CREATE);
+        }
+    }
+    return result;
+}
+
+celix_bundle_activator_start_fp celix_libloader_findBundleActivatorStart(celix_library_handle_t* bundleActivatorHandle) {
+    celix_bundle_activator_start_fp result = NULL;
+    if (bundleActivatorHandle != NULL) {
+        result = (celix_bundle_activator_start_fp) dlsym(bundleActivatorHandle, CELIX_FRAMEWORK_BUNDLE_ACTIVATOR_START);
+        if (result == NULL) {
+            result = (celix_bundle_activator_start_fp) dlsym(bundleActivatorHandle, OSGI_FRAMEWORK_DEPRECATED_BUNDLE_ACTIVATOR_START);
+        }
+    }
+    return result;
+}
+
+celix_bundle_activator_stop_fp celix_libloader_findBundleActivatorStop(celix_library_handle_t* bundleActivatorHandle) {
+    celix_bundle_activator_stop_fp result = NULL;
+    if (bundleActivatorHandle != NULL) {
+        result = (celix_bundle_activator_stop_fp) dlsym(bundleActivatorHandle, CELIX_FRAMEWORK_BUNDLE_ACTIVATOR_STOP);
+        if (result == NULL) {
+            result = (celix_bundle_activator_stop_fp) dlsym(bundleActivatorHandle, OSGI_FRAMEWORK_DEPRECATED_BUNDLE_ACTIVATOR_STOP);
+        }
+    }
+    return result;
+}
+
+celix_bundle_activator_destroy_fp celix_libloader_findBundleActivatorDestroy(celix_library_handle_t* bundleActivatorHandle) {
+    celix_bundle_activator_destroy_fp result = NULL;
+    if (bundleActivatorHandle != NULL) {
+        result = (celix_bundle_activator_destroy_fp) dlsym(bundleActivatorHandle, CELIX_FRAMEWORK_BUNDLE_ACTIVATOR_DESTROY);
+        if (result == NULL) {
+            result = (celix_bundle_activator_destroy_fp) dlsym(bundleActivatorHandle, OSGI_FRAMEWORK_DEPRECATED_BUNDLE_ACTIVATOR_DESTROY);
+        }
+    }
+    return result;
+}
+
 const char* celix_libloader_getLastError() {
     return dlerror();
 }

--- a/libs/framework/src/celix_libloader.h
+++ b/libs/framework/src/celix_libloader.h
@@ -24,28 +24,62 @@
 
 typedef void celix_library_handle_t;
 
+typedef celix_status_t (*celix_bundle_activator_create_fp)(bundle_context_t *context, void **userData);
+typedef celix_status_t (*celix_bundle_activator_start_fp)(void *userData, bundle_context_t *context);
+typedef celix_status_t (*celix_bundle_activator_stop_fp)(void *userData, bundle_context_t *context);
+typedef celix_status_t (*celix_bundle_activator_destroy_fp)(void *userData, bundle_context_t *context);
+
+
 /**
  * @brief Load library using the provided path.
  * @return a library handle or NULL if the library could not be loaded.
  */
-celix_library_handle_t* celix_libloader_open(celix_bundle_context_t *ctx, const char *libPath);
+celix_library_handle_t* celix_libloader_open(celix_bundle_context_t* ctx, const char* libPath);
 
 /**
  * @brief Close the library
  */
-void celix_libloader_close(celix_bundle_context_t *ctx, celix_library_handle_t *handle);
+void celix_libloader_close(celix_bundle_context_t* ctx, celix_library_handle_t* handle);
 
 /**
  * @brief Get the address of a symbol with the provided name.
  * @return The symbol address of NULL if the symbol could not be found.
  */
-void* celix_libloader_getSymbol(celix_library_handle_t *handle, const char *name);
+void* celix_libloader_getSymbol(celix_library_handle_t* handle, const char* name);
 
 /**
  * @brief Returns the last celix_libloader_open error
  * @return The last error or NULL.
  */
 const char* celix_libloader_getLastError();
+
+/**
+ * @brief Tries to find the bundle activator create function for the provide bundle activator library handle.
+ * @param bundleActivatorHandle The bundle activator library handle.
+ * @return The found bundle activator create function or NULL.
+ */
+celix_bundle_activator_create_fp celix_libloader_findBundleActivatorCreate(celix_library_handle_t* bundleActivatorHandle);
+
+/**
+ * @brief Tries to find the bundle activator start function for the provide bundle activator library handle.
+ * @param bundleActivatorHandle The bundle activator library handle.
+ * @return The found bundle activator start function or NULL.
+ */
+celix_bundle_activator_start_fp celix_libloader_findBundleActivatorStart(celix_library_handle_t* bundleActivatorHandle);
+
+/**
+ * @brief Tries to find the bundle activator stop function for the provide bundle activator library handle.
+ * @param bundleActivatorHandle The bundle activator library handle.
+ * @return The found bundle activator stop function or NULL.
+ */
+celix_bundle_activator_stop_fp celix_libloader_findBundleActivatorStop(celix_library_handle_t* bundleActivatorHandle);
+
+/**
+ * @brief Tries to find the bundle activator destroy function for the provide bundle activator library handle.
+ * @param bundleActivatorHandle The bundle activator library handle.
+ * @return The found bundle activator destroy function or NULL.
+ */
+celix_bundle_activator_destroy_fp celix_libloader_findBundleActivatorDestroy(celix_library_handle_t* bundleActivatorHandle);
 
 /**
  * @brief Tries to find the bundle activator library for the provided addr and if found tries to


### PR DESCRIPTION
This pull request addresses an issue related to the management of bundle activator symbols within the framework library.

Previously, when a bundle lacked an activator library, the dlsym function was still invoked with a NULL argument. This could result in potentially invalid bundle activator functions being executed if the relevant symbols were present in the main executable. This hotfix PR ensure that it the bundle activator handle is NULL, dlsym is not called.

Also fixes a invalid default in the celix_constants.h documentation for the config property `CELIX_FRAMEWORK_CLEAN_CACHE_DIR_ON_CREATE`.