### PR TITLE
Revert "[RFC]the OSGi semantics of bundle uninstall."

### DIFF
--- a/libs/framework/gtest/src/CelixBundleContextBundlesTestSuite.cc
+++ b/libs/framework/gtest/src/CelixBundleContextBundlesTestSuite.cc
@@ -28,7 +28,6 @@
 #include <celix_log_utils.h>
 
 #include "celix_api.h"
-#include "celix_file_utils.h"
 
 class CelixBundleContextBundlesTestSuite : public ::testing::Test {
 public:
@@ -153,29 +152,6 @@ TEST_F(CelixBundleContextBundlesTestSuite, InstallAndUninstallBundlesTest) {
     ASSERT_FALSE(celix_bundleContext_isBundleActive(ctx, bndId2)); //not auto started
     ASSERT_TRUE(celix_bundleContext_isBundleActive(ctx, bndId3));
 
-    char *bndRoot1 = nullptr;
-    ASSERT_TRUE(celix_bundleContext_useBundle(ctx, bndId1, &bndRoot1, [](void* handle, const celix_bundle_t* bnd) {
-        char **root = static_cast<char **>(handle);
-        *root = celix_bundle_getEntry(bnd, "/");
-    }));
-    ASSERT_TRUE(bndRoot1 != nullptr);
-    char* bndRoot2 = nullptr;
-    ASSERT_TRUE(celix_bundleContext_useBundle(ctx, bndId2, &bndRoot2, [](void* handle, const celix_bundle_t* bnd) {
-        char **root = static_cast<char **>(handle);
-        *root = celix_bundle_getEntry(bnd, "/");
-    }));
-    ASSERT_TRUE(bndRoot2 != nullptr);
-    char* bndRoot3 = nullptr;
-    ASSERT_TRUE(celix_bundleContext_useBundle(ctx, bndId3, &bndRoot3, [](void* handle, const celix_bundle_t* bnd) {
-        char **root = static_cast<char **>(handle);
-        *root = celix_bundle_getEntry(bnd, "/");
-    }));
-    ASSERT_TRUE(bndRoot3 != nullptr);
-
-    ASSERT_TRUE(celix_utils_directoryExists(bndRoot1));
-    ASSERT_TRUE(celix_utils_directoryExists(bndRoot2));
-    ASSERT_TRUE(celix_utils_directoryExists(bndRoot3));
-
     //uninstall bundles
     ASSERT_TRUE(celix_bundleContext_uninstallBundle(ctx, bndId1));
     ASSERT_TRUE(celix_bundleContext_uninstallBundle(ctx, bndId2));
@@ -188,14 +164,6 @@ TEST_F(CelixBundleContextBundlesTestSuite, InstallAndUninstallBundlesTest) {
     ASSERT_FALSE(celix_bundleContext_isBundleActive(ctx, bndId1)); //not uninstall -> not active
     ASSERT_FALSE(celix_bundleContext_isBundleActive(ctx, bndId2));
     ASSERT_FALSE(celix_bundleContext_isBundleActive(ctx, bndId3));
-
-    ASSERT_FALSE(celix_utils_directoryExists(bndRoot1));
-    ASSERT_FALSE(celix_utils_directoryExists(bndRoot2));
-    ASSERT_FALSE(celix_utils_directoryExists(bndRoot3));
-
-    free(bndRoot1);
-    free(bndRoot2);
-    free(bndRoot3);
 
     //reinstall bundles
     long bndId4 = celix_bundleContext_installBundle(ctx, TEST_BND1_LOC, true);

--- a/libs/framework/src/framework_bundle_lifecycle_handler.c
+++ b/libs/framework/src/framework_bundle_lifecycle_handler.c
@@ -47,7 +47,7 @@ static void* celix_framework_BundleLifecycleHandlingThread(void *data) {
             break;
         case CELIX_BUNDLE_LIFECYCLE_UNINSTALL:
             celix_framework_bundleEntry_decreaseUseCount(handler->bndEntry);
-            celix_framework_uninstallBundleEntry(handler->framework, handler->bndEntry, true);
+            celix_framework_uninstallBundleEntry(handler->framework, handler->bndEntry);
             break;
         default: //update
             celix_framework_updateBundleEntry(handler->framework, handler->bndEntry, handler->updatedBundleUrl);
@@ -143,7 +143,7 @@ celix_status_t celix_framework_uninstallBundleOnANonCelixEventThread(celix_frame
         celix_framework_createAndStartBundleLifecycleHandler(fw, bndEntry, CELIX_BUNDLE_LIFECYCLE_UNINSTALL, NULL);
         return CELIX_SUCCESS;
     } else {
-        return celix_framework_uninstallBundleEntry(fw, bndEntry, true);
+        return celix_framework_uninstallBundleEntry(fw, bndEntry);
     }
 }
 

--- a/libs/framework/src/framework_private.h
+++ b/libs/framework/src/framework_private.h
@@ -40,7 +40,6 @@
 
 #include "celix_threads.h"
 #include "service_registry.h"
-#include <stdbool.h>
 
 #ifndef CELIX_FRAMEWORK_DEFAULT_STATIC_EVENT_QUEUE_SIZE
 #define CELIX_FRAMEWORK_DEFAULT_STATIC_EVENT_QUEUE_SIZE 1024
@@ -427,7 +426,7 @@ celix_status_t celix_framework_stopBundleEntry(celix_framework_t* fw, celix_fram
 /**
  * Uninstall a bundle. Cannot be called on the Celix event thread.
  */
-celix_status_t celix_framework_uninstallBundleEntry(celix_framework_t* fw, celix_framework_bundle_entry_t* bndEntry, bool permanent);
+celix_status_t celix_framework_uninstallBundleEntry(celix_framework_t* fw, celix_framework_bundle_entry_t* bndEntry);
 
 /**
  * Uninstall a bundle. Cannot be called on the Celix event thread.


### PR DESCRIPTION
Reverts apache/celix#554

Uninstall should be done through `celix_bundleCache`.