### PR TITLE
Avoid leaving partial archive in case of errors.

### DIFF
--- a/libs/error_injector/CMakeLists.txt
+++ b/libs/error_injector/CMakeLists.txt
@@ -45,6 +45,7 @@ add_subdirectory(celix_bundle)
 add_subdirectory(celix_version)
 add_subdirectory(celix_hash_map)
 add_subdirectory(celix_long_hash_map)
+add_subdirectory(unistd)
 
 if (BUILD_CELIX_DFI)
     add_subdirectory(dfi)

--- a/libs/error_injector/unistd/CMakeLists.txt
+++ b/libs/error_injector/unistd/CMakeLists.txt
@@ -1,0 +1,24 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+add_library(unistd_ei STATIC src/unistd_ei.cc)
+
+target_include_directories(unistd_ei PUBLIC ${CMAKE_CURRENT_LIST_DIR}/include)
+target_link_libraries(unistd_ei PUBLIC Celix::error_injector)
+
+target_link_options(unistd_ei INTERFACE LINKER:--wrap,getcwd)
+add_library(Celix::unistd_ei ALIAS unistd_ei)

--- a/libs/error_injector/unistd/include/unistd_ei.h
+++ b/libs/error_injector/unistd/include/unistd_ei.h
@@ -1,0 +1,35 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+ */
+
+#ifndef CELIX_UNISTD_EI_H
+#define CELIX_UNISTD_EI_H
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <unistd.h>
+
+#include "celix_error_injector.h"
+
+CELIX_EI_DECLARE(getcwd, char*);
+
+#ifdef __cplusplus
+}
+#endif
+#endif // CELIX_UNISTD_EI_H

--- a/libs/error_injector/unistd/src/unistd_ei.cc
+++ b/libs/error_injector/unistd/src/unistd_ei.cc
@@ -1,0 +1,33 @@
+/*
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+ */
+
+#include "unistd_ei.h"
+
+#include <errno.h>
+
+extern "C" {
+char* __real_getcwd(char* buf, size_t size);
+CELIX_EI_DEFINE(getcwd, char*)
+char* __wrap_getcwd(char* buf, size_t size) {
+    errno = ENOMEM;
+    CELIX_EI_IMPL(getcwd);
+    errno = 0;
+    return __real_getcwd(buf, size);
+}
+}

--- a/libs/framework/gtest/CMakeLists.txt
+++ b/libs/framework/gtest/CMakeLists.txt
@@ -146,6 +146,7 @@ if (LINKER_WRAP_SUPPORTED)
             Celix::dlfcn_ei
             Celix::unistd_ei
             Celix::hash_map_ei
+            Celix::properties_ei
             GTest::gtest GTest::gtest_main
     )
 

--- a/libs/framework/gtest/CMakeLists.txt
+++ b/libs/framework/gtest/CMakeLists.txt
@@ -129,7 +129,7 @@ if (LINKER_WRAP_SUPPORTED)
             src/CelixFrameworkUtilsErrorInjectionTestSuite.cc
             src/CelixBundleContextBundlesWithErrorTestSuite.cc
             src/CelixBundleCacheErrorInjectionTestSuite.cc
-    )
+            )
     target_compile_definitions(test_framework_with_ei PRIVATE
             SIMPLE_TEST_BUNDLE1_LOCATION="${SIMPLE_TEST_BUNDLE1}"
             SIMPLE_CXX_BUNDLE_LOC="${SIMPLE_CXX_BUNDLE_LOC}"
@@ -144,6 +144,7 @@ if (LINKER_WRAP_SUPPORTED)
             Celix::utils_ei
             Celix::asprintf_ei
             Celix::dlfcn_ei
+            Celix::unistd_ei
             Celix::hash_map_ei
             GTest::gtest GTest::gtest_main
     )

--- a/libs/framework/gtest/src/BundleArchiveWithErrorInjectionTestSuite.cc
+++ b/libs/framework/gtest/src/BundleArchiveWithErrorInjectionTestSuite.cc
@@ -226,3 +226,20 @@ TEST_F(CelixBundleArchiveErrorInjectionTestSuite, ArchiveCreateErrorTest) {
 
     EXPECT_EQ(CELIX_SUCCESS, celix_bundleCache_destroy(cache));
 }
+
+TEST_F(CelixBundleArchiveErrorInjectionTestSuite, ArchiveReviseErrorTest) {
+    celix_bundle_cache_t* cache = nullptr;
+    createCache(&cache);
+    bundle_archive_t* archive = nullptr;
+
+    // revision creation failure
+    EXPECT_EQ(CELIX_SUCCESS,
+              celix_bundleArchive_create(&fw, TEST_ARCHIVE_ROOT, 1, SIMPLE_TEST_BUNDLE1_LOCATION, &archive));
+    EXPECT_NE(nullptr, archive);
+    celix_ei_expect_calloc((void*)celix_bundleRevision_create, 0, nullptr);
+    EXPECT_EQ(CELIX_ENOMEM, bundleArchive_revise(archive, SIMPLE_TEST_BUNDLE1_LOCATION, nullptr));
+    EXPECT_EQ(CELIX_SUCCESS, bundleArchive_destroy(archive));
+    EXPECT_EQ(CELIX_SUCCESS, celix_utils_deleteDirectory(TEST_ARCHIVE_ROOT, nullptr));
+
+    EXPECT_EQ(CELIX_SUCCESS, celix_bundleCache_destroy(cache));
+}

--- a/libs/framework/gtest/src/BundleArchiveWithErrorInjectionTestSuite.cc
+++ b/libs/framework/gtest/src/BundleArchiveWithErrorInjectionTestSuite.cc
@@ -18,24 +18,27 @@
  */
 
 #include <gtest/gtest.h>
-#include "bundle_archive_private.h"
-#include "celix/FrameworkFactory.h"
-#include "celix_constants.h"
-#include "celix_framework_utils.h"
-#include "malloc_ei.h"
-#include "celix_utils_ei.h"
-#include "asprintf_ei.h"
 
-//extern declarations for testing purposes. Note signatures are not correct, but that is not important for the test.
-extern "C" celix_status_t celix_bundleRevision_create(void);
+#include "celix_constants.h"
+#include "celix_file_utils.h"
+#include "celix_framework_utils.h"
+#include "celix_log.h"
+#include "celix_properties_ei.h"
+#include "celix_utils_ei.h"
+
+#include "celix/FrameworkFactory.h"
+
+#include "asprintf_ei.h"
+#include "bundle_archive_private.h"
+#include "bundle_revision_private.h"
+#include "framework_private.h"
+#include "malloc_ei.h"
 
 class BundleArchiveWithErrorInjectionTestSuite : public ::testing::Test {
-public:
+  public:
     BundleArchiveWithErrorInjectionTestSuite() {
-        fw = celix::createFramework({
-             {"CELIX_LOGGING_DEFAULT_ACTIVE_LOG_LEVEL", "trace"},
-             {CELIX_FRAMEWORK_CLEAN_CACHE_DIR_ON_CREATE, "true"}
-        });
+        fw = celix::createFramework(
+            {{"CELIX_LOGGING_DEFAULT_ACTIVE_LOG_LEVEL", "trace"}, {CELIX_FRAMEWORK_CLEAN_CACHE_DIR_ON_CREATE, "true"}});
         ctx = fw->getFrameworkBundleContext();
     }
 
@@ -46,6 +49,7 @@ public:
     }
 
     void teardownErrorInjectors() {
+        celix_ei_expect_celix_properties_create(nullptr, 0, nullptr);
         celix_ei_expect_asprintf(nullptr, 0, 0);
         celix_ei_expect_calloc(nullptr, 0, nullptr);
         celix_ei_expect_malloc(nullptr, 0, nullptr);
@@ -58,41 +62,47 @@ public:
     }
 
     void installBundleAndExpectFailure() {
-        //When I create bundle from a bundle zip by installing a bundle
-        //Then the bundle install fails, and the bundle id is < 0
+        // When I create bundle from a bundle zip by installing a bundle
+        // Then the bundle install fails, and the bundle id is < 0
         long bndId = ctx->installBundle(SIMPLE_TEST_BUNDLE1_LOCATION);
         EXPECT_LT(bndId, 0);
     }
 
-protected:
+  protected:
     std::shared_ptr<celix::Framework> fw{};
     std::shared_ptr<celix::BundleContext> ctx{};
 };
 
-
 TEST_F(BundleArchiveWithErrorInjectionTestSuite, BundleArchiveCreatedFailedTest) {
     teardownErrorInjectors();
-    //Given a mocked calloc which returns NULL from a (indirect) call from bundleArchive_create
+    // Given a mocked calloc which returns NULL from a (indirect) call from bundleArchive_create
     celix_ei_expect_calloc((void*)celix_bundleArchive_create, 0, nullptr);
     installBundleAndExpectFailure();
 
     teardownErrorInjectors();
-    //Given a mocked celix_utils_strdup which returns NULL from a (indirect) call from bundleArchive_create
     celix_ei_expect_celix_utils_strdup((void*)celix_bundleArchive_create, 0, nullptr);
     installBundleAndExpectFailure();
 
     teardownErrorInjectors();
-    //Given a mocked malloc which returns NULL from a call from manifest_create
+    celix_ei_expect_celix_utils_strdup((void*)celix_bundleArchive_create, 0, nullptr, 2);
+    installBundleAndExpectFailure();
+
+    teardownErrorInjectors();
+    celix_ei_expect_asprintf((void*)celix_bundleArchive_create, 0, -1);
+    installBundleAndExpectFailure();
+
+    teardownErrorInjectors();
+    // Given a mocked malloc which returns NULL from a call from manifest_create
     celix_ei_expect_malloc((void*)manifest_create, 0, nullptr);
     installBundleAndExpectFailure();
 
     teardownErrorInjectors();
-    //Given a mocked calloc which returns NULL from a call from bundleRevision_create
+    // Given a mocked calloc which returns NULL from a call from bundleRevision_create
     celix_ei_expect_calloc((void*)celix_bundleRevision_create, 0, nullptr);
     installBundleAndExpectFailure();
 
     teardownErrorInjectors();
-    //Given a mocked celix_utils_strdup which returns NULL from a call from bundleRevision_create
+    // Given a mocked celix_utils_strdup which returns NULL from a call from bundleRevision_create
     celix_ei_expect_celix_utils_strdup((void*)celix_bundleRevision_create, 0, nullptr);
     installBundleAndExpectFailure();
 
@@ -102,40 +112,80 @@ TEST_F(BundleArchiveWithErrorInjectionTestSuite, BundleArchiveCreatedFailedTest)
 
 TEST_F(BundleArchiveWithErrorInjectionTestSuite, BundleArchiveCreateCacheDirectoryFailedTest) {
     teardownErrorInjectors();
-    //Given a mocked celix_utils_createDirectory which returns CELIX_FILE_IO_EXCEPTION from a (indirect) call from
-    //bundleArchive_create
+    // Given a mocked celix_utils_createDirectory which returns CELIX_FILE_IO_EXCEPTION from a (indirect) call from
+    // bundleArchive_create
     celix_ei_expect_celix_utils_createDirectory((void*)celix_bundleArchive_create, 1, CELIX_FILE_IO_EXCEPTION);
     installBundleAndExpectFailure();
 
     teardownErrorInjectors();
-    //Given a mocked asprintf which returns -1 from a (indirect) call from bundleArchive_create
+    // Given a mocked asprintf which returns -1 from a (indirect) call from bundleArchive_create
     celix_ei_expect_asprintf((void*)celix_bundleArchive_create, 1, -1);
     installBundleAndExpectFailure();
 
     teardownErrorInjectors();
-    //Given a mocked celix_utils_createDirectory which returns CELIX_FILE_IO_EXCEPTION from a second (indirect) call
-    // from bundleArchive_create
+    // Given a mocked celix_utils_createDirectory which returns CELIX_FILE_IO_EXCEPTION from a second (indirect) call
+    //  from bundleArchive_create
     celix_ei_expect_celix_utils_createDirectory((void*)celix_bundleArchive_create, 1, CELIX_FILE_IO_EXCEPTION, 2);
     installBundleAndExpectFailure();
 
     teardownErrorInjectors();
-    //Given a mocked asprintf which returns -1 from a (indirect) call from bundleArchive_create
+    // Given a mocked asprintf which returns -1 from a (indirect) call from bundleArchive_create
     celix_ei_expect_asprintf((void*)celix_bundleArchive_create, 1, -1, 2);
     installBundleAndExpectFailure();
 
     teardownErrorInjectors();
-    //Given a mocked celix_utils_createDirectory which returns CELIX_FILE_IO_EXCEPTION from a third (indirect) call
-    // from bundleArchive_create
+    // Given a mocked celix_utils_createDirectory which returns CELIX_FILE_IO_EXCEPTION from a third (indirect) call
+    //  from bundleArchive_create
     celix_ei_expect_celix_utils_createDirectory((void*)celix_bundleArchive_create, 1, CELIX_FILE_IO_EXCEPTION, 3);
     installBundleAndExpectFailure();
 
     teardownErrorInjectors();
-    //Given a mocked celix_utils_strdup which returns NULL from a (indirect) call from bundleArchive_create
+    // Given a mocked celix_utils_strdup which returns NULL from a (indirect) call from bundleArchive_create
     celix_ei_expect_celix_utils_strdup((void*)celix_bundleArchive_create, 1, nullptr);
     installBundleAndExpectFailure();
 
     teardownErrorInjectors();
-    //Given a mocked celix_utils_strdup which returns NULL from a second (indirect) call from bundleArchive_create
+    // Given a mocked celix_utils_strdup which returns NULL from a second (indirect) call from bundleArchive_create
     celix_ei_expect_celix_utils_strdup((void*)celix_bundleArchive_create, 1, nullptr, 2);
     installBundleAndExpectFailure();
+}
+
+constexpr const char* const TEST_ARCHIVE_ROOT = ".test_archive_root";
+
+class CelixBundleArchiveErrorInjectionTestSuite : public ::testing::Test {
+  public:
+    CelixBundleArchiveErrorInjectionTestSuite() {
+        fw.configurationMap = celix_properties_create();
+        fw.logger = celix_frameworkLogger_create(CELIX_LOG_LEVEL_TRACE);
+    }
+    ~CelixBundleArchiveErrorInjectionTestSuite() override {
+        celix_frameworkLogger_destroy(fw.logger);
+        celix_properties_destroy(fw.configurationMap);
+    }
+    void createCache(celix_bundle_cache_t** cache) {
+        celix_properties_setBool(fw.configurationMap, CELIX_FRAMEWORK_CACHE_USE_TMP_DIR, true);
+        EXPECT_EQ(CELIX_SUCCESS, celix_bundleCache_create(&fw, &fw.cache));
+        *cache = fw.cache;
+    }
+    struct celix_framework fw {};
+};
+
+TEST_F(CelixBundleArchiveErrorInjectionTestSuite, ArchiveCreateErrorTest) {
+    celix_bundle_cache_t* cache = nullptr;
+    createCache(&cache);
+
+    bundle_archive_t* archive = nullptr;
+    celix_ei_expect_calloc((void*)celix_bundleRevision_create, 0, nullptr);
+    EXPECT_EQ(CELIX_ENOMEM,
+              celix_bundleArchive_create(&fw, TEST_ARCHIVE_ROOT, 1, SIMPLE_TEST_BUNDLE1_LOCATION, &archive));
+    EXPECT_EQ(nullptr, archive);
+    EXPECT_FALSE(celix_utils_directoryExists(TEST_ARCHIVE_ROOT));
+
+    celix_ei_expect_celix_properties_create((void*)celix_bundleArchive_create, 1, nullptr);
+    EXPECT_EQ(CELIX_ENOMEM,
+              celix_bundleArchive_create(&fw, TEST_ARCHIVE_ROOT, 1, SIMPLE_TEST_BUNDLE1_LOCATION, &archive));
+    EXPECT_EQ(nullptr, archive);
+    EXPECT_FALSE(celix_utils_directoryExists(TEST_ARCHIVE_ROOT));
+
+    EXPECT_EQ(CELIX_SUCCESS, celix_bundleCache_destroy(cache));
 }

--- a/libs/framework/gtest/src/CelixBundleCacheErrorInjectionTestSuite.cc
+++ b/libs/framework/gtest/src/CelixBundleCacheErrorInjectionTestSuite.cc
@@ -17,8 +17,10 @@
   under the License.
  */
 
-#include "asprintf_ei.h"
-#include "bundle_archive_private.h"
+#include "gtest/gtest.h"
+
+#include <string>
+
 #include "celix_bundle_cache.h"
 #include "celix_constants.h"
 #include "celix_file_utils.h"
@@ -26,75 +28,83 @@
 #include "celix_log.h"
 #include "celix_properties.h"
 #include "celix_utils_ei.h"
+
+#include "asprintf_ei.h"
+#include "bundle_archive_private.h"
+#include "bundle_revision_private.h"
 #include "framework_private.h"
 #include "malloc_ei.h"
-#include "gtest/gtest.h"
-#include <string>
+#include "manifest.h"
+#include "unistd_ei.h"
 
 class CelixBundleCacheErrorInjectionTestSuite : public ::testing::Test {
-public:
+  public:
     CelixBundleCacheErrorInjectionTestSuite() {
         fw.configurationMap = celix_properties_create();
         fw.logger = celix_frameworkLogger_create(CELIX_LOG_LEVEL_TRACE);
     }
 
     ~CelixBundleCacheErrorInjectionTestSuite() override {
+        celix_ei_expect_getcwd(nullptr, 0, nullptr);
         celix_ei_expect_celix_utils_writeOrCreateString(nullptr, 0, nullptr);
         celix_ei_expect_celix_utils_createDirectory(nullptr, 0, CELIX_SUCCESS);
         celix_ei_expect_celix_utils_deleteDirectory(nullptr, 0, CELIX_SUCCESS);
         celix_ei_expect_celix_utils_strdup(nullptr, 0, nullptr);
         celix_ei_expect_asprintf(nullptr, 0, -1);
         celix_ei_expect_celix_stringHashMap_create(nullptr, 0, nullptr);
+        celix_ei_expect_malloc(nullptr, 0, nullptr);
         celix_ei_expect_calloc(nullptr, 0, nullptr);
         celix_frameworkLogger_destroy(fw.logger);
         celix_properties_destroy(fw.configurationMap);
     }
-
+    void createCache(celix_bundle_cache_t** cache) {
+        celix_properties_setBool(fw.configurationMap, CELIX_FRAMEWORK_CACHE_USE_TMP_DIR, true);
+        EXPECT_EQ(CELIX_SUCCESS, celix_bundleCache_create(&fw, &fw.cache));
+        *cache = fw.cache;
+    }
     struct celix_framework fw {};
 };
 
 TEST_F(CelixBundleCacheErrorInjectionTestSuite, CacheCreateErrorTest) {
-    celix_bundle_cache_t *cache = nullptr;
-    celix_ei_expect_calloc((void*) celix_bundleCache_create, 0, nullptr);
+    celix_bundle_cache_t* cache = nullptr;
+    celix_ei_expect_calloc((void*)celix_bundleCache_create, 0, nullptr);
     EXPECT_EQ(CELIX_ENOMEM, celix_bundleCache_create(&fw, &cache));
     EXPECT_EQ(nullptr, cache);
-    celix_ei_expect_celix_stringHashMap_create((void*) celix_bundleCache_create, 0, nullptr);
+    celix_ei_expect_celix_stringHashMap_create((void*)celix_bundleCache_create, 0, nullptr);
     EXPECT_EQ(CELIX_ENOMEM, celix_bundleCache_create(&fw, &cache));
     EXPECT_EQ(nullptr, cache);
     celix_properties_setBool(fw.configurationMap, CELIX_FRAMEWORK_CACHE_USE_TMP_DIR, true);
-    celix_ei_expect_asprintf((void*) celix_bundleCache_create, 0, -1);
+    celix_ei_expect_asprintf((void*)celix_bundleCache_create, 0, -1);
     EXPECT_EQ(CELIX_ENOMEM, celix_bundleCache_create(&fw, &cache));
     EXPECT_EQ(nullptr, cache);
     celix_properties_setBool(fw.configurationMap, CELIX_FRAMEWORK_CACHE_USE_TMP_DIR, false);
-    celix_ei_expect_celix_utils_strdup((void*) celix_bundleCache_create, 0, nullptr);
+    celix_ei_expect_celix_utils_strdup((void*)celix_bundleCache_create, 0, nullptr);
     EXPECT_EQ(CELIX_ENOMEM, celix_bundleCache_create(&fw, &cache));
     EXPECT_EQ(nullptr, cache);
     celix_properties_setBool(fw.configurationMap, CELIX_FRAMEWORK_CLEAN_CACHE_DIR_ON_CREATE, true);
-    celix_ei_expect_celix_utils_deleteDirectory((void*) celix_bundleCache_create, 1, CELIX_FILE_IO_EXCEPTION);
+    celix_ei_expect_celix_utils_deleteDirectory((void*)celix_bundleCache_create, 1, CELIX_FILE_IO_EXCEPTION);
     EXPECT_EQ(CELIX_FILE_IO_EXCEPTION, celix_bundleCache_create(&fw, &cache));
     EXPECT_EQ(nullptr, cache);
     celix_properties_setBool(fw.configurationMap, CELIX_FRAMEWORK_CLEAN_CACHE_DIR_ON_CREATE, false);
-    celix_ei_expect_celix_utils_createDirectory((void*) celix_bundleCache_create, 0, CELIX_FILE_IO_EXCEPTION);
+    celix_ei_expect_celix_utils_createDirectory((void*)celix_bundleCache_create, 0, CELIX_FILE_IO_EXCEPTION);
     EXPECT_EQ(CELIX_FILE_IO_EXCEPTION, celix_bundleCache_create(&fw, &cache));
     EXPECT_EQ(nullptr, cache);
 }
 
 TEST_F(CelixBundleCacheErrorInjectionTestSuite, CacheDeleteErrorTest) {
-    celix_bundle_cache_t *cache = nullptr;
-    celix_properties_setBool(fw.configurationMap, CELIX_FRAMEWORK_CACHE_USE_TMP_DIR, true);
-    EXPECT_EQ(CELIX_SUCCESS, celix_bundleCache_create(&fw, &cache));
-    celix_ei_expect_celix_utils_deleteDirectory((void*) celix_bundleCache_deleteCacheDir, 0, CELIX_FILE_IO_EXCEPTION);
+    celix_bundle_cache_t* cache = nullptr;
+    createCache(&cache);
+    celix_ei_expect_celix_utils_deleteDirectory((void*)celix_bundleCache_deleteCacheDir, 0, CELIX_FILE_IO_EXCEPTION);
     EXPECT_EQ(CELIX_FILE_IO_EXCEPTION, celix_bundleCache_deleteCacheDir(cache));
     EXPECT_EQ(CELIX_SUCCESS, celix_bundleCache_destroy(cache));
 }
 
 TEST_F(CelixBundleCacheErrorInjectionTestSuite, ArchiveCreateErrorTest) {
-    celix_bundle_cache_t *cache = nullptr;
+    celix_bundle_cache_t* cache = nullptr;
+    createCache(&cache);
+
     bundle_archive_t* archive = nullptr;
-    celix_properties_setBool(fw.configurationMap, CELIX_FRAMEWORK_CACHE_USE_TMP_DIR, true);
-    EXPECT_EQ(CELIX_SUCCESS, celix_bundleCache_create(&fw, &cache));
-    fw.cache = cache;
-    celix_ei_expect_celix_utils_writeOrCreateString((void*) celix_bundleCache_createArchive, 0, nullptr);
+    celix_ei_expect_celix_utils_writeOrCreateString((void*)celix_bundleCache_createArchive, 0, nullptr);
     EXPECT_EQ(CELIX_ENOMEM, celix_bundleCache_createArchive(cache, 1, SIMPLE_TEST_BUNDLE1_LOCATION, &archive));
     EXPECT_EQ(nullptr, archive);
     EXPECT_EQ(-1, celix_bundleCache_findBundleIdForLocation(cache, SIMPLE_TEST_BUNDLE1_LOCATION));
@@ -103,7 +113,7 @@ TEST_F(CelixBundleCacheErrorInjectionTestSuite, ArchiveCreateErrorTest) {
 
     EXPECT_EQ(CELIX_SUCCESS, celix_bundleCache_create(&fw, &cache));
     fw.cache = cache;
-    celix_ei_expect_calloc((void*) celix_bundleArchive_create, 0, nullptr);
+    celix_ei_expect_calloc((void*)celix_bundleArchive_create, 0, nullptr);
     EXPECT_EQ(CELIX_ENOMEM, celix_bundleCache_createArchive(cache, 1, SIMPLE_TEST_BUNDLE1_LOCATION, &archive));
     EXPECT_EQ(nullptr, archive);
     EXPECT_EQ(-1, celix_bundleCache_findBundleIdForLocation(cache, SIMPLE_TEST_BUNDLE1_LOCATION));
@@ -111,14 +121,40 @@ TEST_F(CelixBundleCacheErrorInjectionTestSuite, ArchiveCreateErrorTest) {
     EXPECT_EQ(CELIX_SUCCESS, celix_bundleCache_destroy(cache));
 }
 
-TEST_F(CelixBundleCacheErrorInjectionTestSuite, ArchiveDestroyErrorTest) {
-    celix_bundle_cache_t *cache = nullptr;
+TEST_F(CelixBundleCacheErrorInjectionTestSuite, SystemArchiveCreateErrorTest) {
+    celix_bundle_cache_t* cache = nullptr;
+    createCache(&cache);
+
     bundle_archive_t* archive = nullptr;
-    celix_properties_setBool(fw.configurationMap, CELIX_FRAMEWORK_CACHE_USE_TMP_DIR, true);
-    EXPECT_EQ(CELIX_SUCCESS, celix_bundleCache_create(&fw, &cache));
-    fw.cache = cache;
+    celix_ei_expect_calloc((void*)celix_bundleArchive_create, 0, nullptr);
+    EXPECT_EQ(CELIX_ENOMEM, celix_bundleCache_createSystemArchive(&fw, &archive));
+    EXPECT_EQ(nullptr, archive);
+
+    celix_ei_expect_getcwd((void*)celix_bundleArchive_create, 0, nullptr);
+    EXPECT_EQ(CELIX_ENOMEM, celix_bundleCache_createSystemArchive(&fw, &archive));
+    EXPECT_EQ(nullptr, archive);
+
+    celix_ei_expect_getcwd((void*)celix_bundleArchive_create, 0, nullptr, 2);
+    EXPECT_EQ(CELIX_ENOMEM, celix_bundleCache_createSystemArchive(&fw, &archive));
+    EXPECT_EQ(nullptr, archive);
+
+    celix_ei_expect_malloc((void*)manifest_create, 0, nullptr);
+    EXPECT_EQ(CELIX_ENOMEM, celix_bundleCache_createSystemArchive(&fw, &archive));
+    EXPECT_EQ(nullptr, archive);
+
+    celix_ei_expect_calloc((void*)celix_bundleRevision_create, 0, nullptr);
+    EXPECT_EQ(CELIX_ENOMEM, celix_bundleCache_createSystemArchive(&fw, &archive));
+    EXPECT_EQ(nullptr, archive);
+
+    EXPECT_EQ(CELIX_SUCCESS, celix_bundleCache_destroy(cache));
+}
+
+TEST_F(CelixBundleCacheErrorInjectionTestSuite, ArchiveDestroyErrorTest) {
+    celix_bundle_cache_t* cache = nullptr;
+    createCache(&cache);
+    bundle_archive_t* archive = nullptr;
     EXPECT_EQ(CELIX_SUCCESS, celix_bundleCache_createArchive(cache, 1, SIMPLE_TEST_BUNDLE1_LOCATION, &archive));
-    celix_ei_expect_celix_utils_deleteDirectory((void*) celix_bundleCache_destroyArchive, 1, CELIX_FILE_IO_EXCEPTION);
+    celix_ei_expect_celix_utils_deleteDirectory((void*)celix_bundleCache_destroyArchive, 1, CELIX_FILE_IO_EXCEPTION);
     std::string storeRoot = celix_bundleArchive_getPersistentStoreRoot(archive);
     EXPECT_EQ(CELIX_FILE_IO_EXCEPTION, celix_bundleCache_destroyArchive(cache, archive));
     EXPECT_TRUE(celix_utils_directoryExists(storeRoot.c_str()));
@@ -126,20 +162,19 @@ TEST_F(CelixBundleCacheErrorInjectionTestSuite, ArchiveDestroyErrorTest) {
 }
 
 TEST_F(CelixBundleCacheErrorInjectionTestSuite, CreateBundleArchivesCacheErrorTest) {
-    celix_bundle_cache_t *cache = nullptr;
+    celix_bundle_cache_t* cache = nullptr;
     celix_properties_set(fw.configurationMap, CELIX_AUTO_START_1, SIMPLE_TEST_BUNDLE1_LOCATION);
-    celix_properties_setBool(fw.configurationMap, CELIX_FRAMEWORK_CACHE_USE_TMP_DIR, true);
-    EXPECT_EQ(CELIX_SUCCESS, celix_bundleCache_create(&fw, &cache));
-    fw.cache = cache;
-    celix_ei_expect_celix_utils_deleteDirectory((void*) celix_bundleCache_createBundleArchivesCache, 0, CELIX_FILE_IO_EXCEPTION);
+    createCache(&cache);
+    celix_ei_expect_celix_utils_deleteDirectory(
+        (void*)celix_bundleCache_createBundleArchivesCache, 0, CELIX_FILE_IO_EXCEPTION);
     EXPECT_EQ(CELIX_FILE_IO_EXCEPTION, celix_bundleCache_createBundleArchivesCache(&fw, true));
-    celix_ei_expect_celix_utils_writeOrCreateString((void*) celix_bundleCache_createBundleArchivesCache, 1, nullptr);
+    celix_ei_expect_celix_utils_writeOrCreateString((void*)celix_bundleCache_createBundleArchivesCache, 1, nullptr);
     EXPECT_EQ(CELIX_ENOMEM, celix_bundleCache_createBundleArchivesCache(&fw, true));
     celix_properties_unset(fw.configurationMap, CELIX_AUTO_START_1);
     celix_properties_set(fw.configurationMap, CELIX_AUTO_INSTALL, SIMPLE_TEST_BUNDLE1_LOCATION);
-    celix_ei_expect_celix_utils_writeOrCreateString((void*) celix_bundleCache_createBundleArchivesCache, 1, nullptr);
+    celix_ei_expect_celix_utils_writeOrCreateString((void*)celix_bundleCache_createBundleArchivesCache, 1, nullptr);
     EXPECT_EQ(CELIX_ENOMEM, celix_bundleCache_createBundleArchivesCache(&fw, true));
-    celix_ei_expect_celix_utils_writeOrCreateString((void*) celix_bundleCache_createArchive, 0, nullptr);
+    celix_ei_expect_celix_utils_writeOrCreateString((void*)celix_bundleCache_createArchive, 0, nullptr);
     EXPECT_EQ(CELIX_ENOMEM, celix_bundleCache_createBundleArchivesCache(&fw, true));
     EXPECT_EQ(CELIX_SUCCESS, celix_bundleCache_destroy(cache));
 }

--- a/libs/framework/gtest/src/CelixBundleCacheErrorInjectionTestSuite.cc
+++ b/libs/framework/gtest/src/CelixBundleCacheErrorInjectionTestSuite.cc
@@ -109,15 +109,13 @@ TEST_F(CelixBundleCacheErrorInjectionTestSuite, ArchiveCreateErrorTest) {
     EXPECT_EQ(nullptr, archive);
     EXPECT_EQ(-1, celix_bundleCache_findBundleIdForLocation(cache, SIMPLE_TEST_BUNDLE1_LOCATION));
     EXPECT_FALSE(celix_bundleCache_isBundleIdAlreadyUsed(cache, 1));
-    EXPECT_EQ(CELIX_SUCCESS, celix_bundleCache_destroy(cache));
 
-    EXPECT_EQ(CELIX_SUCCESS, celix_bundleCache_create(&fw, &cache));
-    fw.cache = cache;
     celix_ei_expect_calloc((void*)celix_bundleArchive_create, 0, nullptr);
     EXPECT_EQ(CELIX_ENOMEM, celix_bundleCache_createArchive(cache, 1, SIMPLE_TEST_BUNDLE1_LOCATION, &archive));
     EXPECT_EQ(nullptr, archive);
     EXPECT_EQ(-1, celix_bundleCache_findBundleIdForLocation(cache, SIMPLE_TEST_BUNDLE1_LOCATION));
     EXPECT_FALSE(celix_bundleCache_isBundleIdAlreadyUsed(cache, 1));
+
     EXPECT_EQ(CELIX_SUCCESS, celix_bundleCache_destroy(cache));
 }
 

--- a/libs/framework/gtest/src/CelixBundleCacheTestSuite.cc
+++ b/libs/framework/gtest/src/CelixBundleCacheTestSuite.cc
@@ -51,7 +51,9 @@ TEST_F(CelixBundleCacheTestSuite, ArchiveCreateDestroyTest) {
     bundle_archive_t* archive = nullptr;
     EXPECT_EQ(CELIX_SUCCESS, celix_bundleCache_createArchive(fw.cache, 1, SIMPLE_TEST_BUNDLE1_LOCATION, &archive));
     EXPECT_NE(nullptr, archive);
-    EXPECT_STREQ(SIMPLE_TEST_BUNDLE1_LOCATION, celix_bundleArchive_getLocation(archive));
+    auto location = celix_bundleArchive_getLocation(archive);
+    EXPECT_STREQ(SIMPLE_TEST_BUNDLE1_LOCATION, location);
+    free(location);
     EXPECT_EQ(1, celix_bundleCache_findBundleIdForLocation(fw.cache, SIMPLE_TEST_BUNDLE1_LOCATION));
     EXPECT_TRUE(celix_bundleCache_isBundleIdAlreadyUsed(fw.cache, 1));
     std::string loc = celix_bundleArchive_getPersistentStoreRoot(archive);

--- a/libs/framework/gtest/src/CelixBundleCacheTestSuite.cc
+++ b/libs/framework/gtest/src/CelixBundleCacheTestSuite.cc
@@ -51,6 +51,7 @@ TEST_F(CelixBundleCacheTestSuite, ArchiveCreateDestroyTest) {
     bundle_archive_t* archive = nullptr;
     EXPECT_EQ(CELIX_SUCCESS, celix_bundleCache_createArchive(fw.cache, 1, SIMPLE_TEST_BUNDLE1_LOCATION, &archive));
     EXPECT_NE(nullptr, archive);
+    EXPECT_STREQ(SIMPLE_TEST_BUNDLE1_LOCATION, celix_bundleArchive_getLocation(archive));
     EXPECT_EQ(1, celix_bundleCache_findBundleIdForLocation(fw.cache, SIMPLE_TEST_BUNDLE1_LOCATION));
     EXPECT_TRUE(celix_bundleCache_isBundleIdAlreadyUsed(fw.cache, 1));
     std::string loc = celix_bundleArchive_getPersistentStoreRoot(archive);
@@ -69,6 +70,7 @@ TEST_F(CelixBundleCacheTestSuite, SystemArchiveCreateDestroyTest) {
     EXPECT_EQ(0, celix_bundleArchive_getId(archive));
     EXPECT_EQ(CELIX_SUCCESS, bundleArchive_getArchiveRoot(archive, &archiveRoot));
     EXPECT_EQ(nullptr, archiveRoot);
+    EXPECT_EQ(nullptr, celix_bundleArchive_getLocation(archive));
     EXPECT_EQ(CELIX_SUCCESS, celix_bundleCache_destroyArchive(fw.cache, archive));
 }
 

--- a/libs/framework/include_deprecated/bundle_archive.h
+++ b/libs/framework/include_deprecated/bundle_archive.h
@@ -96,8 +96,11 @@ CELIX_FRAMEWORK_DEPRECATED_EXPORT celix_status_t bundleArchive_getPersistentStat
  *
  * @param[in] archive The bundle archive.
  * @param[out] lastModified The last modified time of the bundle archive.
- * @return CELIX_SUCCESS if the last modified time could be retrieved, CELIX_FILE_IO_EXCEPTION if the last modified
- * time could not be retrieved. Check errno for more specific error information.
+ * @return Status code indication failure or success:
+ *      - CELIX_SUCCESS when no errors are encountered.
+ *      - CELIX_FILE_IO_EXCEPTION if the last modified time could not be retrieved.
+ *        Check errno for more specific error information.when root of the archive is not a directory.
+ *      - CELIX_ENOMEM not enough memory for manifest file path.
  */
 CELIX_FRAMEWORK_DEPRECATED_EXPORT celix_status_t celix_bundleArchive_getLastModified(bundle_archive_pt archive, struct timespec* lastModified);
 

--- a/libs/framework/src/bundle_archive.c
+++ b/libs/framework/src/bundle_archive.c
@@ -437,7 +437,7 @@ celix_status_t bundleArchive_revise(bundle_archive_pt archive, const char * loca
             archive->revision = revised;
             bundleRevision_destroy(current);
         } else {
-            status = CELIX_BUNDLE_EXCEPTION;
+            status = CELIX_ENOMEM;
             reason = "bundle revision creation";
         }
     } else {
@@ -452,7 +452,7 @@ celix_status_t bundleArchive_revise(bundle_archive_pt archive, const char * loca
     }
 revise_finished:
     celixThreadMutex_unlock(&archive->lock);
-    framework_logIfError(archive->fw->logger, status, reason, "Cannot update bundle archive %s", updatedBundleUrl);
+    framework_logIfError(archive->fw->logger, status, reason, "Cannot update bundle archive %s", updateUrl);
     return status;
 }
 

--- a/libs/framework/src/bundle_archive_private.h
+++ b/libs/framework/src/bundle_archive_private.h
@@ -21,6 +21,8 @@
 #ifndef BUNDLE_ARCHIVE_PRIVATE_H_
 #define BUNDLE_ARCHIVE_PRIVATE_H_
 
+#include <time.h>
+
 #include "bundle_archive.h"
 
 #ifdef __cplusplus
@@ -72,6 +74,11 @@ const char* celix_bundleArchive_getPersistentStoreRoot(bundle_archive_t *archive
   * Returns the root of the current revision.
   */
 const char* celix_bundleArchive_getCurrentRevisionRoot(bundle_archive_pt archive);
+
+/**
+ * Return the last modified time of the bundle archive.
+ */
+celix_status_t celix_bundleArchive_getLastModifiedInternal(bundle_archive_pt archive, struct timespec* lastModified);
 
 #ifdef __cplusplus
 }

--- a/libs/framework/src/bundle_revision.c
+++ b/libs/framework/src/bundle_revision.c
@@ -55,7 +55,9 @@ celix_status_t celix_bundleRevision_create(celix_framework_t* fw, const char *ro
 bundle_revision_t* bundleRevision_revise(const bundle_revision_t* rev, const char* updatedBundleUrl) {
     bundle_revision_pt newRev = NULL;
     manifest_pt clonedManifest = manifest_clone(rev->manifest);
-    celix_bundleRevision_create(rev->fw, rev->root, updatedBundleUrl, clonedManifest, &newRev);
+    if (clonedManifest) {
+        celix_bundleRevision_create(rev->fw, rev->root, updatedBundleUrl, clonedManifest, &newRev);
+    }
     return newRev;
 }
 


### PR DESCRIPTION
This PR is another step towards solving #556:

* Residual archive directory is removed in case of errors.
* A minor logging error is fixed.
* Eliminate disk write when loading from cache to help extend life of flash storage.
* More tests are added.