### PR TITLE
Move celix::Exception to utils and refactor to use using ctor

### DIFF
--- a/libs/framework/include/celix/FrameworkExceptions.h
+++ b/libs/framework/include/celix/FrameworkExceptions.h
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#pragma once
+
+#include "celix/Exception.h"
+
+namespace celix {
+
+    /**
+     * @brief Celix Service Registration Exception
+     */
+    class ServiceRegistrationException : public ::celix::Exception {
+    public:
+      using celix::Exception::Exception;
+    };
+
+    /**
+     * @brief Celix Tracker Exception
+     */
+    class TrackerException : public ::celix::Exception {
+    public:
+        using celix::Exception::Exception;
+    };
+}

--- a/libs/framework/include/celix/ServiceRegistration.h
+++ b/libs/framework/include/celix/ServiceRegistration.h
@@ -24,9 +24,9 @@
 #include <vector>
 #include <functional>
 
+#include "celix/FrameworkExceptions.h"
 #include "celix/Constants.h"
 #include "celix/Properties.h"
-#include "celix/Exception.h"
 #include "celix_bundle_context.h"
 #include "celix_bundle.h"
 #include "celix_framework.h"
@@ -338,12 +338,12 @@ namespace celix {
                 std::lock_guard<std::mutex> lck{mutex};
                 svcId = celix_bundleContext_registerServiceWithOptionsAsync(cCtx.get(), &opts);
                 if (svcId < 0) {
-                    throw celix::Exception{"Cannot register service"};
+                    throw celix::ServiceRegistrationException{"Cannot register service"};
                 }
             } else /*sync*/ {
                 long localSvcId = celix_bundleContext_registerServiceWithOptions(cCtx.get(), &opts);
                 if (localSvcId < 0) {
-                    throw celix::Exception{"Cannot register service"};
+                    throw celix::ServiceRegistrationException{"Cannot register service"};
                 }
                 {
                     std::lock_guard<std::mutex> lck{mutex};

--- a/libs/framework/include/celix/Trackers.h
+++ b/libs/framework/include/celix/Trackers.h
@@ -29,15 +29,14 @@
 #include <thread>
 
 #include "celix_utils.h"
+#include "celix_bundle_context.h"
+#include "celix_framework.h"
+#include "celix/FrameworkExceptions.h"
 #include "celix/Properties.h"
 #include "celix/Utils.h"
 #include "celix/Bundle.h"
 #include "celix/Constants.h"
 #include "celix/Filter.h"
-#include "celix/Exception.h"
-#include "celix_bundle_context.h"
-#include "celix_framework.h"
-
 
 namespace celix {
 
@@ -244,7 +243,7 @@ namespace celix {
                 //NOTE assuming the opts already configured the callbacks
                 trkId = celix_bundleContext_trackServicesWithOptionsAsync(cCtx.get(), &opts);
                 if (trkId < 0) {
-                    throw celix::Exception{"Cannot open service tracker"};
+                    throw celix::TrackerException{"Cannot open service tracker"};
                 }
             }
         }
@@ -654,7 +653,7 @@ namespace celix {
                 //NOTE the opts already configured the callbacks
                 trkId = celix_bundleContext_trackBundlesWithOptionsAsync(cCtx.get(), &opts);
                 if (trkId < 0) {
-                    throw celix::Exception{"Cannot open bundle tracker"};
+                    throw celix::TrackerException{"Cannot open bundle tracker"};
                 }
             }
         }
@@ -821,7 +820,7 @@ namespace celix {
                             trk->state = TrackerState::OPEN;
                         });
                 if (trkId < 0) {
-                    throw celix::Exception{"Cannot open meta tracker"};
+                    throw celix::TrackerException{"Cannot open meta tracker"};
                 }
             }
         }

--- a/libs/utils/include/celix/Exception.h
+++ b/libs/utils/include/celix/Exception.h
@@ -18,27 +18,16 @@
  */
 #pragma once
 
-#include <exception>
+#include <stdexcept>
 
 namespace celix {
 
     /**
      * @brief Celix runtime Exception
      */
-    class Exception : public std::exception {
+    class Exception : public std::runtime_error {
     public:
-        explicit Exception(std::string msg) : w{std::move(msg)} {}
-
-        Exception(const Exception&) = default;
-        Exception(Exception&&) = default;
-        Exception& operator=(const Exception&) = default;
-        Exception& operator=(Exception&&) = default;
-
-        const char* what() const noexcept override {
-            return w.c_str();
-        }
-    private:
-        std::string w;
+        using std::runtime_error::runtime_error;
     };
 
 }

--- a/libs/utils/include/celix/Filter.h
+++ b/libs/utils/include/celix/Filter.h
@@ -23,6 +23,7 @@
 #include <cstring>
 
 #include "celix_filter.h"
+#include "celix/Exception.h"
 #include "celix/Properties.h"
 
 namespace celix {
@@ -30,20 +31,9 @@ namespace celix {
     /**
      * @brief FilterException
      */
-    class FilterException : public std::exception {
+    class FilterException : public ::celix::Exception {
     public:
-        explicit FilterException(std::string msg) : w{std::move(msg)} {}
-
-        FilterException(const FilterException&) = default;
-        FilterException(FilterException&&) = default;
-        FilterException& operator=(const FilterException&) = default;
-        FilterException& operator=(FilterException&&) = default;
-
-        const char* what() const noexcept override {
-            return w.c_str();
-        }
-    private:
-        std::string w;
+        using celix::Exception::Exception;
     };
 
     /**


### PR DESCRIPTION
Small PR that:
 - Moves celix::Exception to celix utils
 - Adds 2 exception for service registration and tracking
 - Simplifies exception by using the runtime_error ctor