### PR TITLE
Replace ci config with ctest --output-on-failure

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           cd build
           source activate_run.sh
-          ctest --verbose
+          ctest --output-on-failure
           source deactivate_run.sh
       - name: Test Installed Celix
         run: |
@@ -75,5 +75,4 @@ jobs:
         run: |
           cd $GITHUB_WORKSPACE/build
           export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH:$(pwd)/utils:$(pwd)/framework:$(pwd)/dfi
-          make test ARGS="-V"
-
+          ctest --output-on-failure

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -63,7 +63,7 @@ jobs:
         run: |
           cd build
           source activate_run.sh
-          ctest --verbose
+          ctest --output-on-failure
           source deactivate_run.sh
       - name: Test Installed Celix
         env:
@@ -119,4 +119,4 @@ jobs:
       run: |
         cd $GITHUB_WORKSPACE/build
         export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH:$(pwd)/utils:$(pwd)/framework:$(pwd)/dfi
-        make test ARGS="-V"
+        ctest --output-on-failure


### PR DESCRIPTION
Small PR that updates the running of test on the CI server so that the log output is less verbose (except on failure). 
This should help in more easily read what went wrong if a CI test fails.