### PR TITLE
Hotfix/Add missing `find_package` to make examples standalone.

### DIFF
--- a/examples/celix-examples/CMakeLists.txt
+++ b/examples/celix-examples/CMakeLists.txt
@@ -21,6 +21,7 @@ else ()
     set(EXAMPLES true) #celix_subproject is only available in the celix project -> using examples dir in other project is also supported
     option(CELIX_CXX14 ON)
     option(CELIX_CXX17 ON)
+    find_package(Celix REQUIRED)
 endif ()
 if (EXAMPLES)
     add_definitions(-DADD_CELIX_DEPRECATED_WARNING) #ensure that no deprecated api is used in the examples


### PR DESCRIPTION
https://github.com/apache/celix/issues/576#issuecomment-1600586680

