### PR TITLE
Hotfix/Fix broken dependency specification in CelixConfig.cmake.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -209,7 +209,7 @@ add_subdirectory(bundles)
 add_subdirectory(misc/experimental)
 
 #Example as last, because some example will check if underlining options are enabled
-add_subdirectory(examples/celix-examples examples)
+add_subdirectory(examples/celix-examples)
 
 #export targets
 install(EXPORT celix NAMESPACE Celix:: DESTINATION share/celix/cmake FILE Targets.cmake COMPONENT cmake)
@@ -218,6 +218,15 @@ install_celix_targets(celix NAMESPACE Celix:: DESTINATION share/celix/cmake FILE
 #install celix cmake modules
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules/ DESTINATION share/celix/cmake/Modules)
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/cmake/cmake_celix/ DESTINATION share/celix/cmake/cmake_celix)
+
+file(GENERATE
+        OUTPUT "${PROJECT_BINARY_DIR}/celix/gen/cmake/CelixDeps.cmake"
+        INPUT cmake/CelixDeps.cmake.in
+        )
+
+install(FILES
+        "${PROJECT_BINARY_DIR}/celix/gen/cmake/CelixDeps.cmake"
+        DESTINATION share/celix/cmake COMPONENT cmake)
 
 #configure and install CelixConfig and CelixConfigVersion files
 configure_file(cmake/CelixConfigVersion.cmake.in

--- a/cmake/CelixConfig.cmake
+++ b/cmake/CelixConfig.cmake
@@ -29,6 +29,18 @@ get_filename_component(REL_INSTALL_DIR "${REL_INSTALL_DIR}" PATH)
 get_filename_component(REL_INSTALL_DIR "${REL_INSTALL_DIR}" PATH)
 
 include("${REL_INSTALL_DIR}/share/celix/cmake/cmake_celix/UseCelix.cmake") #adds celix commands (e.g. add_celix_bundle)
+
+include(CMakeFindDependencyMacro)
+
+find_dependency(ZLIB) #Needed by framework
+find_dependency(libuuid) #Needed by framework
+find_dependency(CURL) #Needed by framework (used for curl initialization), etcdlib
+find_dependency(libzip) #Needed by utils
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_dependency(Threads)
+
+include("${REL_INSTALL_DIR}/share/celix/cmake/CelixDeps.cmake") #adds celix optional dependencies
+
 include("${REL_INSTALL_DIR}/share/celix/cmake/Targets.cmake") #imports lib and exe targets (e.g. Celix::framework)
 
 include("${REL_INSTALL_DIR}/share/celix/cmake/CelixTargets.cmake")
@@ -74,15 +86,6 @@ set(CELIX_BUNDLES_DIR ${REL_INSTALL_DIR}/share/celix/bundles)
 set(CELIX_SHELL_BUNDLE ${CELIX_BUNDLES_DIR}/shell.zip)
 set(CELIX_SHELL_TUI_BUNDLE ${CELIX_BUNDLES_DIR}/shell_tui.zip)
 
-include(CMakeFindDependencyMacro)
-
-find_dependency(ZLIB) #Needed by framework
-find_dependency(libuuid) #Needed by framework
-find_dependency(CURL) #Needed by framework (used for curl initialization), etcdlib
-find_dependency(libzip) #Needed by utils
-set(THREADS_PREFER_PTHREAD_FLAG ON)
-find_dependency(Threads)
-
 if (NOT TARGET ZLIB::ZLIB)
   #Note more recent zlib will create ZLIB::ZLIB target
   message("Note ZLIB::ZLIB target not created by find_package(ZLIB). Creating ZLIB::ZLIB Target.")
@@ -102,31 +105,3 @@ if (NOT TARGET CURL::libcurl)
           INTERFACE_INCLUDE_DIRECTORIES "${CURL_INCLUDE_DIRS}"
           )
 endif ()
-
-if (TARGET Celix::dfi)
-  find_dependency(libffi)
-  find_dependency(jansson)
-endif ()
-if (TARGET Celix::etcdlib)
-  find_dependency(jansson)
-endif ()
-if (TARGET Celix::RsaConfiguredDiscovery)
-  find_dependency(RapidJSON)
-endif ()
-if (TARGET Celix::rsa_discovery_common OR TARGET Celix::bonjour_shell)
-  find_dependency(LibXml2)
-endif ()
-if (TARGET  Celix::celix_pubsub_admin_zmq OR TARGET Celix::celix_pubsub_admin_zmq_v2)
-  find_dependency(ZeroMQ)
-  find_dependency(czmq)
-endif ()
-if (TARGET Celix::pubsub_admin_nanomsg)
-  find_dependency(NanoMsg)
-endif ()
-if (TARGET Celix::http_admin_api)
-  find_dependency(civetweb)
-endif ()
-if (TARGET Celix::rsa_discovery_zeroconf)
-  find_dependency(DNSSD)
-endif ()
-

--- a/cmake/CelixDeps.cmake.in
+++ b/cmake/CelixDeps.cmake.in
@@ -1,0 +1,13 @@
+$<$<BOOL:$<TARGET_NAME_IF_EXISTS:Celix::dfi>>:find_dependency(libffi)>
+$<$<BOOL:$<TARGET_NAME_IF_EXISTS:Celix::dfi>>:find_dependency(jansson)>
+$<$<BOOL:$<TARGET_NAME_IF_EXISTS:Celix::etcdlib>>:find_dependency(jansson)>
+$<$<BOOL:$<TARGET_NAME_IF_EXISTS:Celix::RsaConfiguredDiscovery>>:find_dependency(RapidJSON)>
+$<$<BOOL:$<TARGET_NAME_IF_EXISTS:Celix::rsa_discovery_common>>:find_dependency(LibXml2)>
+$<$<BOOL:$<TARGET_NAME_IF_EXISTS:Celix::bonjour_shell>>:find_dependency(LibXml2)>
+$<$<BOOL:$<TARGET_NAME_IF_EXISTS:Celix::celix_pubsub_admin_zmq>>:find_dependency(ZeroMQ)>
+$<$<BOOL:$<TARGET_NAME_IF_EXISTS:Celix::celix_pubsub_admin_zmq_v2>>:find_dependency(ZeroMQ)>
+$<$<BOOL:$<TARGET_NAME_IF_EXISTS:Celix::celix_pubsub_admin_zmq>>:find_dependency(czmq)>
+$<$<BOOL:$<TARGET_NAME_IF_EXISTS:Celix::celix_pubsub_admin_zmq_v2>>:find_dependency(czmq)>
+$<$<BOOL:$<TARGET_NAME_IF_EXISTS:Celix::pubsub_admin_nanomsg>>:find_dependency(NanoMsg)>
+$<$<BOOL:$<TARGET_NAME_IF_EXISTS:Celix::http_admin_api>>:find_dependency(civetweb)>
+$<$<BOOL:$<TARGET_NAME_IF_EXISTS:Celix::rsa_discovery_zeroconf>>:find_dependency(DNSSD)>

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -21,7 +21,7 @@
 # To build these example:
 # - build and install celix
 # - Create a new build project dir and cd to it
-# - set the MAKE_FIND_ROOT_PATH to the install location
+# - set the CMAKE_FIND_ROOT_PATH to the install location
 #   of Celix (e.g. /opt/local) if this is different from
 #   /usr or /usr/local
 # - cmake <loc_to_celix_src>/examples
@@ -33,4 +33,4 @@ project (CelixUse C CXX ASM)
 set(CMAKE_C_FLAGS "-D_GNU_SOURCE -std=gnu99 ${CMAKE_C_FLAGS}")
 set(CMAKE_CXX_STANDARD 17)
 find_package(Celix REQUIRED)
-add_subdirectory(celix-examples examples)
+add_subdirectory(celix-examples)

--- a/examples/celix-examples/CMakeLists.txt
+++ b/examples/celix-examples/CMakeLists.txt
@@ -21,7 +21,6 @@ else ()
     set(EXAMPLES true) #celix_subproject is only available in the celix project -> using examples dir in other project is also supported
     option(CELIX_CXX14 ON)
     option(CELIX_CXX17 ON)
-    find_package(Celix REQUIRED)
 endif ()
 if (EXAMPLES)
     add_definitions(-DADD_CELIX_DEPRECATED_WARNING) #ensure that no deprecated api is used in the examples


### PR DESCRIPTION
This PR fixes the error when building examples standalone:

1. build and install Celix

```bash
sudo apt-get install -yq --no-install-recommends \
    build-essential \
    git \
    curl \
    uuid-dev \
    libjansson-dev \
    libcurl4-openssl-dev \
    default-jdk \
    libffi-dev \
    libzip-dev \
    libxml2-dev \
    libczmq-dev \
    libcpputest-dev \
    rapidjson-dev

cd celix
mkdir build
cd build
cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=/home/peng/Desktop/celix ..
make -j
make install
cd ../
```
2. build our examples

```bash
cd examples
mkdir build
cd build
cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_INSTALL_PREFIX=/home/peng/Desktop/celix ..
make
```

```
CMake Error at CMakeLists.txt:35 (find_package):
  Found package configuration file:

    /home/peng/Desktop/celix/lib/cmake/Celix/CelixConfig.cmake

  but it set Celix_FOUND to FALSE so package "Celix" is considered to be NOT
  FOUND.  Reason given by package:

  The following imported targets are referenced, but are missing:
  civetweb::civetweb


```