### PR TITLE
Refactor celix_container_bundles_dir to use add_custom_target

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -51,6 +51,7 @@ jobs:
             -o celix:enable_testing_dependency_manager_for_cxx11=True
         run: |
           #force require libcurl 7.64.1, due to a sha256 verify issue in libcurl/7.87.0
+          sudo apt-get install -yq --no-install-recommends ninja-build
           conan install . celix/ci -pr:b release -pr:h default -if build ${CONAN_BUILD_OPTIONS} -b missing  -b cpputest --require-override=libcurl/7.64.1 --require-override=openssl/1.1.1s
       - name: Build
         env:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -56,6 +56,7 @@ jobs:
         env:
           CC: ${{ matrix.compiler[0] }}
           CXX: ${{ matrix.compiler[1] }}
+          CONAN_CMAKE_GENERATOR: ninja
         run: |
           conan build . -bf build --configure
           conan build . -bf build --build
@@ -69,6 +70,7 @@ jobs:
         env:
           CC: ${{ matrix.compiler[0] }}
           CXX: ${{ matrix.compiler[1] }}
+          CONAN_CMAKE_GENERATOR: ninja
         run: |
           conan create -pr:b release -pr:h default -tf examples/conan_test_package -tbf test-build -o celix:celix_cxx17=True -o celix:celix_install_deprecated_api=True --require-override=libcurl/7.64.1 --require-override=openssl/1.1.1s .
 

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -56,7 +56,7 @@ jobs:
         env:
           CC: ${{ matrix.compiler[0] }}
           CXX: ${{ matrix.compiler[1] }}
-          CONAN_CMAKE_GENERATOR: ninja
+          CONAN_CMAKE_GENERATOR: Ninja
         run: |
           conan build . -bf build --configure
           conan build . -bf build --build
@@ -70,7 +70,7 @@ jobs:
         env:
           CC: ${{ matrix.compiler[0] }}
           CXX: ${{ matrix.compiler[1] }}
-          CONAN_CMAKE_GENERATOR: ninja
+          CONAN_CMAKE_GENERATOR: Ninja
         run: |
           conan create -pr:b release -pr:h default -tf examples/conan_test_package -tbf test-build -o celix:celix_cxx17=True -o celix:celix_install_deprecated_api=True --require-override=libcurl/7.64.1 --require-override=openssl/1.1.1s .
 


### PR DESCRIPTION
This PR addresses an issue where changes to bundle zip files were not being copied to the "bundles" directory in the container.

The process of copying updated bundles to a container "bundles" dir appears to have broken at some point. Unfortunately, I couldn't trace back the specific change that introduced this issue using git blame.

Originally, the copying of bundles was tracked with a timestamp file, in combination with a CMake `add_custom_command`. However, attempts to resolve the problem with the add_custom_command proved unsuccessful, leading me to replace it with `add_custom_target`.

In my opinion, a custom target is less than ideal, as a custom target dependency always triggers whenever a target is built. A comparison of the time to run `make -j` when nothing has changed demonstrated that on my systems, it took twice as long (albeit still under 1 second).

An upside is that the current change  seems to fix the usage  CMake -> Ninja, which I previously had issues with.
Building with `ninja`, compared to `make -j`, is significantly faster.

In conclusion, despite its drawbacks, I believe this update is necessary for now to resolve the issue. Possibly in the future, we can revert to using add_custom_command instead of add_custom_target.