### PR TITLE
hotfix/fix use-after-free caused by cancelled service tracker.

### DIFF
--- a/bundles/remote_services/discovery_zeroconf/src/discovery_zeroconf_watcher.c
+++ b/bundles/remote_services/discovery_zeroconf/src/discovery_zeroconf_watcher.c
@@ -153,8 +153,7 @@ celix_status_t discoveryZeroconfWatcher_create(celix_bundle_context_t *ctx, celi
     *watcherOut = watcher;
     return CELIX_SUCCESS;
 thread_err:
-    celix_bundleContext_stopTrackerAsync(ctx, watcher->epListenerTrkId, NULL, NULL);
-    celix_bundleContext_waitForAsyncStopTracker(ctx, watcher->epListenerTrkId);
+    celix_bundleContext_stopTracker(ctx, watcher->epListenerTrkId);
 epl_tracker_err:
     celix_longHashMap_destroy(watcher->epls);
     celix_stringHashMap_destroy(watcher->watchedServices);

--- a/libs/framework/include_deprecated/service_tracker.h
+++ b/libs/framework/include_deprecated/service_tracker.h
@@ -84,6 +84,15 @@ CELIX_FRAMEWORK_DEPRECATED_EXPORT celix_service_tracker_t* celix_serviceTracker_
 );
 
 /**
+ * Creates a closed service tracker.
+ * It is similar to serviceTracker_create.
+ */
+CELIX_FRAMEWORK_DEPRECATED_EXPORT celix_service_tracker_t* celix_serviceTracker_createClosedWithOptions(
+    celix_bundle_context_t *ctx,
+    const celix_service_tracking_options_t *opts
+);
+
+/**
  * Creates and starts (open) a service tracker.
  * Note that is different from the serviceTracker_create function, because is also starts the service tracker
  */

--- a/libs/framework/src/service_tracker.c
+++ b/libs/framework/src/service_tracker.c
@@ -632,28 +632,35 @@ celix_service_tracker_t* celix_serviceTracker_create(
     return celix_serviceTracker_createWithOptions(ctx, &opts);
 }
 
-celix_service_tracker_t* celix_serviceTracker_createWithOptions(
-        bundle_context_t *ctx,
-        const celix_service_tracking_options_t *opts
-) {
-    celix_service_tracker_t *tracker = NULL;
+celix_service_tracker_t* celix_serviceTracker_createClosedWithOptions(celix_bundle_context_t* ctx,
+                                                                      const celix_service_tracking_options_t* opts) {
+    celix_service_tracker_t* tracker = NULL;
     const char* serviceName = NULL;
-    char *filter = NULL;
+    char* filter = NULL;
     assert(ctx != NULL);
     assert(opts != NULL);
     serviceName = opts->filter.serviceName == NULL ? "*" : opts->filter.serviceName;
-    filter = celix_serviceRegistry_createFilterFor(ctx->framework->registry, opts->filter.serviceName, opts->filter.versionRange, opts->filter.filter);
-    if(filter == NULL) {
-        celix_framework_log(ctx->framework->logger, CELIX_LOG_LEVEL_ERROR, __FUNCTION__, __BASE_FILE__, __LINE__,
+    filter = celix_serviceRegistry_createFilterFor(
+        ctx->framework->registry, opts->filter.serviceName, opts->filter.versionRange, opts->filter.filter);
+    if (filter == NULL) {
+        celix_framework_log(ctx->framework->logger,
+                            CELIX_LOG_LEVEL_ERROR,
+                            __FUNCTION__,
+                            __BASE_FILE__,
+                            __LINE__,
                             "Error cannot create filter.");
         return NULL;
     }
     tracker = calloc(1, sizeof(*tracker));
-    if(tracker == NULL) {
+    if (tracker == NULL) {
         free(filter);
-        celix_framework_log(ctx->framework->logger, CELIX_LOG_LEVEL_ERROR, __FUNCTION__, __BASE_FILE__, __LINE__,
+        celix_framework_log(ctx->framework->logger,
+                            CELIX_LOG_LEVEL_ERROR,
+                            __FUNCTION__,
+                            __BASE_FILE__,
+                            __LINE__,
                             "No memory for tracker.");
-       return NULL;
+        return NULL;
     }
 
     tracker->context = ctx;
@@ -661,7 +668,7 @@ celix_service_tracker_t* celix_serviceTracker_createWithOptions(
     tracker->filter = filter;
     tracker->state = CELIX_SERVICE_TRACKER_CLOSED;
 
-    //setting callbacks
+    // setting callbacks
     tracker->callbackHandle = opts->callbackHandle;
     tracker->set = opts->set;
     tracker->add = opts->add;
@@ -684,8 +691,18 @@ celix_service_tracker_t* celix_serviceTracker_createWithOptions(
     tracker->currentHighestServiceId = -1;
 
     tracker->listener.handle = tracker;
-    tracker->listener.serviceChanged = (void *) serviceTracker_serviceChanged;
+    tracker->listener.serviceChanged = (void*)serviceTracker_serviceChanged;
+    return tracker;
+}
 
+celix_service_tracker_t* celix_serviceTracker_createWithOptions(
+        bundle_context_t *ctx,
+        const celix_service_tracking_options_t *opts
+) {
+    celix_service_tracker_t *tracker = celix_serviceTracker_createClosedWithOptions(ctx, opts);
+    if(tracker == NULL) {
+       return NULL;
+    }
     serviceTracker_open(tracker);
     return tracker;
 }


### PR DESCRIPTION
This PR fixes #595, a use-after-free introduced by a previous attempt to avoid deadlock, by splitting the creation of a service tracker into two steps:

1. create a closed service tracker if not cancelled under the protection of `ctx->mutex`
2. open the tracker without holding `ctx->mutex`


