### PR TITLE
Add  to BUILD_PATH

### DIFF
--- a/cmake/cmake_celix/BundlePackaging.cmake
+++ b/cmake/cmake_celix/BundlePackaging.cmake
@@ -360,8 +360,10 @@ function(add_celix_bundle)
 
         if(APPLE)
             set_target_properties(${BUNDLE_TARGET_NAME} PROPERTIES INSTALL_RPATH "@loader_path")
+            set_target_properties(${BUNDLE_TARGET_NAME} PROPERTIES BUILD_RPATH "@loader_path")
         else()
             set_target_properties(${BUNDLE_TARGET_NAME} PROPERTIES INSTALL_RPATH "$ORIGIN")
+            set_target_properties(${BUNDLE_TARGET_NAME} PROPERTIES BUILD_RPATH "$ORIGIN")
         endif()
 
         if (NOT BUNDLE_DO_NOT_CONFIGURE_SYMBOL_VISIBILITY)


### PR DESCRIPTION
This hotfix adds the $ORIGIN (loader_path) to the RPATH for bundle activator libraries during build. 

Note that previously  RPATH was set to $ORIGIN with  target property `BUILD_WITH_INSTALL_RPATH` (see https://github.com/apache/celix/blob/rel/celix-2.3.0/cmake/cmake_celix/BundlePackaging.cmake#L341). But this brings issues while building and testing celix. 

WIth `BUILD_WITH_INSTALL_RPATH` removed and because the bundle activator libs in Apache Celix bundles are never install (they are added into zip during build) the current used RPATH contains build paths and no $ORIGIN path. 
If $ORIGIN in not part of the RPATH, libraries inside the bundles cannot be successfully loaded on targets, but this is not apparent during build (because the build paths set in RPATH do exist). 

Adding $ORIGIN to the build RPATH solve the bundle loading issues, but is not an ideal solution because the build specific paths are also still in the RPATH for installed bundles. 
