### PR TITLE
Hotfox/libuuid conflict

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -381,8 +381,8 @@ class CelixConan(ConanFile):
             self.requires("libzip/[>=1.7.3 <2.0.0]")
             self.options['libzip'].shared = True
         if self.options.build_framework or self.options.build_pubsub:
-            self.requires("libuuid/1.0.3")
-            self.options['libuuid'].shared = True
+            self.requires("util-linux-libuuid/2.39")
+            self.options['util-linux-libuuid'].shared = True
         if self.options.build_framework or self.options.build_celix_etcdlib:
             self.requires("libcurl/[>=7.64.1 <8.0.0]")
             self.options['libcurl'].shared = True


### PR DESCRIPTION
We encounter libuuid conflict:

```
ERROR: At least two recipes provides the same functionality:
 - 'libuuid' provided by 'libuuid/1.0.3', 'util-linux-libuuid/2.39'
 ```

It turns out that some conan packages has switched to 'util-linux-libuuid/2.39', which is claimed to be the most  actively maintained fork of libuuid (https://github.com/conan-io/conan-center-index/pull/17664).

