### PR TITLE
Hotfix/LDAP filter for Version Range

### DIFF
--- a/bundles/shell/shell/src/dm_shell_list_command.c
+++ b/bundles/shell/shell/src/dm_shell_list_command.c
@@ -24,6 +24,7 @@
 #include "celix_bundle_context.h"
 #include "celix_dependency_manager.h"
 #include "celix_dm_component.h"
+#include "std_commands.h"
 
 static void parseCommandLine(const char*line, celix_array_list_t **requestedBundleIds, bool *fullInfo, bool *wtf, FILE *err) {
     *fullInfo = false;
@@ -49,7 +50,7 @@ static void parseCommandLine(const char*line, celix_array_list_t **requestedBund
     free (str);
 }
 
-celix_status_t dmListCommand_execute(void* handle, char * line, FILE *out, FILE *err) {
+bool dmListCommand_execute(void* handle, const char* line, FILE *out, FILE *err) {
     celix_bundle_context_t *ctx = handle;
     celix_dependency_manager_t *mng = celix_bundleContext_getDependencyManager(ctx);
 
@@ -91,5 +92,5 @@ celix_status_t dmListCommand_execute(void* handle, char * line, FILE *out, FILE 
 
     celix_arrayList_destroy(bundleIds);
 
-    return CELIX_SUCCESS;
+    return true;
 }

--- a/libs/utils/gtest/src/VersionRangeTestSuite.cc
+++ b/libs/utils/gtest/src/VersionRangeTestSuite.cc
@@ -21,6 +21,7 @@
 
 #include "version.h"
 #include "version_range.h" //NOTE testing celix_version_range through the deprecated version_range api.
+#include "celix_stdlib_cleanup.h"
 #include "celix_version_range.h"
 #include "version_private.h"
 
@@ -414,4 +415,14 @@ TEST_F(VersionRangeTestSuite, createLdapFilterInPlaceInfiniteHigh) {
     EXPECT_STREQ(buffer, "(&(service.version>1.2.3))");
 
     versionRange_destroy(range);
+}
+
+TEST_F(VersionRangeTestSuite, createLdapFilterWithQualifier) {
+    celix_autoptr(celix_version_t) low = celix_version_createVersion(1, 2, 2, "0");
+    celix_autoptr(celix_version_t) high = celix_version_createVersion(1, 2, 2, "0");
+
+    celix_autoptr(celix_version_range_t) range = celix_versionRange_createVersionRange(celix_steal_ptr(low), true,
+                                                                                       celix_steal_ptr(high), true);
+    celix_autofree char* filter = celix_versionRange_createLDAPFilter(range, "service.version");
+    EXPECT_STREQ(filter, "(&(service.version>=1.2.2.0)(service.version<=1.2.2.0))");
 }

--- a/libs/utils/src/version_range.c
+++ b/libs/utils/src/version_range.c
@@ -246,15 +246,21 @@ char* celix_versionRange_createLDAPFilter(const celix_version_range_t* range, co
 
     int ret = -1;
     if(range->high == NULL) {
-        ret = asprintf(&output, "(&(%s%s%i.%i.%i))",
-                       serviceVersionAttributeName, range->isLowInclusive ? ">=" : ">", range->low->major,
-                       range->low->minor, range->low->micro);
-    } else {
-        ret = asprintf(&output, "(&(%s%s%i.%i.%i)(%s%s%i.%i.%i))",
+        ret = asprintf(&output, "(&(%s%s%i.%i.%i%s%s))",
                        serviceVersionAttributeName, range->isLowInclusive ? ">=" : ">", range->low->major,
                        range->low->minor, range->low->micro,
+                       range->low->qualifier ? "." : "",
+                       range->low->qualifier ? range->low->qualifier : "");
+    } else {
+        ret = asprintf(&output, "(&(%s%s%i.%i.%i%s%s)(%s%s%i.%i.%i%s%s))",
+                       serviceVersionAttributeName, range->isLowInclusive ? ">=" : ">", range->low->major,
+                       range->low->minor, range->low->micro,
+                       range->low->qualifier ? "." : "",
+                          range->low->qualifier ? range->low->qualifier : "",
                        serviceVersionAttributeName, range->isHighInclusive ? "<=" : "<", range->high->major,
-                       range->high->minor, range->high->micro);
+                       range->high->minor, range->high->micro,
+                       range->high->qualifier ? "." : "",
+                       range->high->qualifier ? range->high->qualifier : "");
     }
 
     if (ret < 0) {


### PR DESCRIPTION
I was surprised to find that our `dm_exmaple` remained broken (`dm wtf` gives phase2b) though #432 has already been fixed.
It turns out that the culprit is version range LDAP filter which ignores the qualifier term of a version.