### PR TITLE
Feature/614 GitHub cache for Conan and ccach

### DIFF
--- a/.github/workflows/conan_create.yml
+++ b/.github/workflows/conan_create.yml
@@ -46,12 +46,18 @@ jobs:
           path: ${{ env.CONAN_HOME }}
           key: ${{ runner.os }}-builder-${{ env.cache-name }}-${{ matrix.compiler[0] }}-${{ matrix.type }}-${{ hashFiles('conanfile.py') }}
           restore-keys: ${{ runner.os }}-builder-${{ env.cache-name }}-${{ matrix.compiler[0] }}-${{ matrix.type }}-
-      - name: Create Celix
+      - name: Create All
         env:
           CC: ${{ matrix.compiler[0] }}
           CXX: ${{ matrix.compiler[1] }}
         run: |
-          conan inspect .  | awk 'BEGIN { FS="[\t:]+"; output=0 } /build/ && !/build_all/ { if(output) print $1} /^options/ {output=1} /^options_definitions/ {output=0}' | while read option; do conan create . -c tools.cmake.cmaketoolchain:generator=Ninja -b missing -o celix/*:${option}=True  -pr:b default -pr:h default -s:h build_type=${{ matrix.type }} -tf examples/conan_test_package_v2 -o celix/*:celix_cxx17=True -o celix/*:celix_install_deprecated_api=True || exit 1; done
+          conan create . -c tools.cmake.cmaketoolchain:generator=Ninja -b missing -o celix/*:build_all=True  -pr:b default -pr:h default -s:h build_type=${{ matrix.type }} -tf examples/conan_test_package_v2 -o celix/*:celix_cxx17=True -o celix/*:celix_install_deprecated_api=True
+      - name: Create Component
+        env:
+          CC: ${{ matrix.compiler[0] }}
+          CXX: ${{ matrix.compiler[1] }}
+        run: |
+          conan inspect .  | awk 'BEGIN { FS="[\t:]+"; output=0 } /build/ && !/build_all/ { if(output) print $1} /^options/ {output=1} /^options_definitions/ {output=0}' | while read option; do conan create . -c tools.cmake.cmaketoolchain:generator=Ninja -b missing -o celix/*:${option}=True  -pr:b default -pr:h default -s:h build_type=${{ matrix.type }} -tf "" -o celix/*:celix_cxx17=True -o celix/*:celix_install_deprecated_api=True || exit 1; done
       - name: Remove Celix
         run: |
           conan remove -c celix/* 
@@ -79,9 +85,12 @@ jobs:
           path: ${{ env.CONAN_USER_HOME }}
           key: ${{ runner.os }}-builder-${{ env.cache-name }}-${{ hashFiles('conanfile.py') }}
           restore-keys: ${{ runner.os }}-builder-${{ env.cache-name }}-
-      - name: Create Celix
+      - name: Create All
         run: |
-          conan inspect . -a options | awk 'BEGIN { FS="[\t:]+" } /build/ && !/build_all/ { print $1}' | while read option; do conan create . -c tools.cmake.cmaketoolchain:generator=Ninja -b missing -o celix:${option}=True  -pr:b default -pr:h default -tf examples/conan_test_package -tbf test-build -o celix:celix_cxx17=True -o celix:celix_install_deprecated_api=True --require-override=libcurl/7.64.1 --require-override=openssl/1.1.1s --require-override=zlib/1.2.13 || exit 1; done
+          conan create . -c tools.cmake.cmaketoolchain:generator=Ninja -b missing -o celix:build_all=True  -pr:b default -pr:h default -tf examples/conan_test_package -tbf test-build -o celix:celix_cxx17=True -o celix:celix_install_deprecated_api=True --require-override=libcurl/7.64.1 --require-override=openssl/1.1.1s --require-override=zlib/1.2.13
+      - name: Create Component
+        run: |
+          conan inspect . -a options | awk 'BEGIN { FS="[\t:]+" } /build/ && !/build_all/ { print $1}' | while read option; do conan create . -c tools.cmake.cmaketoolchain:generator=Ninja -b missing -o celix:${option}=True  -pr:b default -pr:h default -tbf test-build -o celix:celix_cxx17=True -o celix:celix_install_deprecated_api=True --require-override=libcurl/7.64.1 --require-override=openssl/1.1.1s --require-override=zlib/1.2.13 || exit 1; done
       - name: Remove Celix
         run: |
           conan remove -f 'celix/*'

--- a/.github/workflows/conan_create.yml
+++ b/.github/workflows/conan_create.yml
@@ -13,6 +13,7 @@ env:
   CONAN_HOME: "${{ github.workspace }}/release/"
   CCACHE_NOHASHDIR: true
   CCACHE_DIR: "${{ github.workspace }}/.ccache"
+  CCACHE_SLOPPINESS: "include_file_ctime,include_file_mtime"
 
 
 jobs:

--- a/.github/workflows/conan_create.yml
+++ b/.github/workflows/conan_create.yml
@@ -50,10 +50,10 @@ jobs:
           restore-keys: ${{ runner.os }}-builder-${{ env.cache-name }}-${{ matrix.compiler[0] }}-${{ matrix.type }}-
       - name: Prepare ccache timestamp
         id: ccache_cache_timestamp
-        shell: cmake -P {0} >> $GITHUB_OUTPUT
+        shell: cmake -P {0}
         run: |
           string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
-          message("timestamp=${current_date}")
+          message("::set-output name=timestamp::${current_date}")
       - name: ccache Cache
         uses: actions/cache@v1
         with:
@@ -102,10 +102,10 @@ jobs:
           restore-keys: ${{ runner.os }}-builder-${{ env.cache-name }}-
       - name: Prepare ccache timestamp
         id: ccache_cache_timestamp
-        shell: cmake -P {0} >> $GITHUB_OUTPUT
+        shell: cmake -P {0}
         run: |
           string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
-          message("timestamp=${current_date}")
+          message("::set-output name=timestamp::${current_date}")
       - name: ccache Cache
         uses: actions/cache@v1
         with:

--- a/.github/workflows/conan_create.yml
+++ b/.github/workflows/conan_create.yml
@@ -46,18 +46,18 @@ jobs:
           path: ${{ env.CONAN_HOME }}
           key: ${{ runner.os }}-builder-${{ env.cache-name }}-${{ matrix.compiler[0] }}-${{ matrix.type }}-${{ hashFiles('conanfile.py') }}
           restore-keys: ${{ runner.os }}-builder-${{ env.cache-name }}-${{ matrix.compiler[0] }}-${{ matrix.type }}-
-      - name: Create All
+      - name: Create Celix
         env:
           CC: ${{ matrix.compiler[0] }}
           CXX: ${{ matrix.compiler[1] }}
         run: |
           conan create . -c tools.cmake.cmaketoolchain:generator=Ninja -b missing -o celix/*:build_all=True  -pr:b default -pr:h default -s:h build_type=${{ matrix.type }} -tf examples/conan_test_package_v2 -o celix/*:celix_cxx17=True -o celix/*:celix_install_deprecated_api=True
-      - name: Create Component
+      - name: Dependency Deduction Test
         env:
           CC: ${{ matrix.compiler[0] }}
           CXX: ${{ matrix.compiler[1] }}
         run: |
-          conan inspect .  | awk 'BEGIN { FS="[\t:]+"; output=0 } /build/ && !/build_all/ { if(output) print $1} /^options/ {output=1} /^options_definitions/ {output=0}' | while read option; do conan create . -c tools.cmake.cmaketoolchain:generator=Ninja -b missing -o celix/*:${option}=True  -pr:b default -pr:h default -s:h build_type=${{ matrix.type }} -tf "" -o celix/*:celix_cxx17=True -o celix/*:celix_install_deprecated_api=True || exit 1; done
+          conan inspect .  | awk 'BEGIN { FS="[\t:]+"; output=0 } /build/ && !/build_all/ { if(output) print $1} /^options/ {output=1} /^options_definitions/ {output=0}' | while read option; do conan build . -c tools.cmake.cmaketoolchain:generator=Ninja -b missing -o celix/*:${option}=True  -pr:b default -pr:h default -s:h build_type=${{ matrix.type }} -of  ${option}_dir -o celix/*:celix_cxx17=True -o celix/*:celix_install_deprecated_api=True || exit 1; done
       - name: Remove Celix
         run: |
           conan remove -c celix/* 
@@ -85,12 +85,12 @@ jobs:
           path: ${{ env.CONAN_USER_HOME }}
           key: ${{ runner.os }}-builder-${{ env.cache-name }}-${{ hashFiles('conanfile.py') }}
           restore-keys: ${{ runner.os }}-builder-${{ env.cache-name }}-
-      - name: Create All
+      - name: Create Celix
         run: |
           conan create . -c tools.cmake.cmaketoolchain:generator=Ninja -b missing -o celix:build_all=True  -pr:b default -pr:h default -tf examples/conan_test_package -tbf test-build -o celix:celix_cxx17=True -o celix:celix_install_deprecated_api=True --require-override=libcurl/7.64.1 --require-override=openssl/1.1.1s --require-override=zlib/1.2.13
-      - name: Create Component
+      - name: Dependency Deduction Test
         run: |
-          conan inspect . -a options | awk 'BEGIN { FS="[\t:]+" } /build/ && !/build_all/ { print $1}' | while read option; do conan create . -c tools.cmake.cmaketoolchain:generator=Ninja -b missing -o celix:${option}=True  -pr:b default -pr:h default -tbf test-build -o celix:celix_cxx17=True -o celix:celix_install_deprecated_api=True --require-override=libcurl/7.64.1 --require-override=openssl/1.1.1s --require-override=zlib/1.2.13 || exit 1; done
+          conan inspect . -a options | awk 'BEGIN { FS="[\t:]+" } /build/ && !/build_all/ { print $1}' | while read option; do conan install . -c tools.cmake.cmaketoolchain:generator=Ninja -b missing -o celix:${option}=True  -pr:b default -pr:h default -if ${option}_dir -o celix:celix_cxx17=True -o celix:celix_install_deprecated_api=True --require-override=libcurl/7.64.1 --require-override=openssl/1.1.1s --require-override=zlib/1.2.13 || exit 1; conan build . -bf ${option}_dir || exit 1; done
       - name: Remove Celix
         run: |
           conan remove -f 'celix/*'

--- a/.github/workflows/conan_create.yml
+++ b/.github/workflows/conan_create.yml
@@ -50,10 +50,8 @@ jobs:
           restore-keys: ${{ runner.os }}-builder-${{ env.cache-name }}-${{ matrix.compiler[0] }}-${{ matrix.type }}-
       - name: Prepare ccache timestamp
         id: ccache_cache_timestamp
-        shell: cmake -P {0}
         run: |
-          string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
-          message("::set-output name=timestamp::${current_date}")
+          echo timestamp=`date +"%Y-%m-%d-%H;%M;%S"` >> $GITHUB_OUTPUT
       - name: ccache Cache
         uses: actions/cache@v1
         with:
@@ -102,10 +100,8 @@ jobs:
           restore-keys: ${{ runner.os }}-builder-${{ env.cache-name }}-
       - name: Prepare ccache timestamp
         id: ccache_cache_timestamp
-        shell: cmake -P {0}
         run: |
-          string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
-          message("::set-output name=timestamp::${current_date}")
+          echo timestamp=`date +"%Y-%m-%d-%H;%M;%S"` >> $GITHUB_OUTPUT
       - name: ccache Cache
         uses: actions/cache@v1
         with:

--- a/.github/workflows/conan_create.yml
+++ b/.github/workflows/conan_create.yml
@@ -13,7 +13,7 @@ env:
   CONAN_HOME: "${{ github.workspace }}/release/"
   CCACHE_NOHASHDIR: true
   CCACHE_DIR: "${{ github.workspace }}/.ccache"
-  CCACHE_SLOPPINESS: "include_file_ctime,include_file_mtime"
+  CCACHE_SLOPPINESS: include_file_ctime,include_file_mtime
 
 
 jobs:

--- a/.github/workflows/conan_create.yml
+++ b/.github/workflows/conan_create.yml
@@ -11,6 +11,8 @@ env:
   CONAN_USER_HOME: "${{ github.workspace }}/release/"
   CONAN_USER_HOME_SHORT: "${{ github.workspace }}/release/short"
   CONAN_HOME: "${{ github.workspace }}/release/"
+  CCACHE_NOHASHDIR: true
+  CCACHE_DIR: "${{ github.workspace }}/.ccache"
 
 
 jobs:
@@ -37,7 +39,7 @@ jobs:
         run: |
           # build profile
           conan profile detect -f
-      - name: Using the builtin GitHub Cache Action for .conan
+      - name: Conan Cache
         id: cache-conan
         uses: actions/cache@v1
         env:
@@ -46,18 +48,31 @@ jobs:
           path: ${{ env.CONAN_HOME }}
           key: ${{ runner.os }}-builder-${{ env.cache-name }}-${{ matrix.compiler[0] }}-${{ matrix.type }}-${{ hashFiles('conanfile.py') }}
           restore-keys: ${{ runner.os }}-builder-${{ env.cache-name }}-${{ matrix.compiler[0] }}-${{ matrix.type }}-
+      - name: Prepare ccache timestamp
+        id: ccache_cache_timestamp
+        shell: cmake -P {0}
+        run: |
+          string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
+          message("::set-output name=timestamp::${current_date}")
+      - name: ccache Cache
+        uses: actions/cache@v1
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: ${{ runner.os }}-ccache-${{ matrix.compiler[0] }}-${{ matrix.type }}-${{ steps.ccache_cache_timestamp.outputs.timestamp }}
+          restore-keys: |
+            ${{ runner.os }}-ccache-${{ matrix.compiler[0] }}-${{ matrix.type }}-
       - name: Create Celix
         env:
           CC: ${{ matrix.compiler[0] }}
           CXX: ${{ matrix.compiler[1] }}
         run: |
-          conan create . -c tools.cmake.cmaketoolchain:generator=Ninja -b missing -o celix/*:build_all=True  -pr:b default -pr:h default -s:h build_type=${{ matrix.type }} -tf examples/conan_test_package_v2 -o celix/*:celix_cxx17=True -o celix/*:celix_install_deprecated_api=True
+          conan create . -c tools.cmake.cmaketoolchain:generator=Ninja -b missing -o celix/*:build_all=True  -o celix/*:enable_ccache=True -pr:b default -pr:h default -s:h build_type=${{ matrix.type }} -tf examples/conan_test_package_v2 -o celix/*:celix_cxx17=True -o celix/*:celix_install_deprecated_api=True
       - name: Dependency Deduction Test
         env:
           CC: ${{ matrix.compiler[0] }}
           CXX: ${{ matrix.compiler[1] }}
         run: |
-          conan inspect .  | awk 'BEGIN { FS="[\t:]+"; output=0 } /build/ && !/build_all/ { if(output) print $1} /^options/ {output=1} /^options_definitions/ {output=0}' | while read option; do conan build . -c tools.cmake.cmaketoolchain:generator=Ninja -b missing -o celix/*:${option}=True  -pr:b default -pr:h default -s:h build_type=${{ matrix.type }} -of  ${option}_dir -o celix/*:celix_cxx17=True -o celix/*:celix_install_deprecated_api=True || exit 1; done
+          conan inspect .  | awk 'BEGIN { FS="[\t:]+"; output=0 } /build/ && !/build_all/ { if(output) print $1} /^options/ {output=1} /^options_definitions/ {output=0}' | while read option; do conan build . -c tools.cmake.cmaketoolchain:generator=Ninja -b missing -o celix/*:${option}=True  -pr:b default -pr:h default -s:h build_type=${{ matrix.type }} -of  ${option}_dir -o celix/*:celix_cxx17=True -o celix/*:enable_ccache=True -o celix/*:celix_install_deprecated_api=True || exit 1; done
       - name: Remove Celix
         run: |
           conan remove -c celix/* 
@@ -85,12 +100,25 @@ jobs:
           path: ${{ env.CONAN_USER_HOME }}
           key: ${{ runner.os }}-builder-${{ env.cache-name }}-${{ hashFiles('conanfile.py') }}
           restore-keys: ${{ runner.os }}-builder-${{ env.cache-name }}-
+      - name: Prepare ccache timestamp
+        id: ccache_cache_timestamp
+        shell: cmake -P {0}
+        run: |
+          string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
+          message("::set-output name=timestamp::${current_date}")
+      - name: ccache Cache
+        uses: actions/cache@v1
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: ${{ runner.os }}-ccache-Release-${{ steps.ccache_cache_timestamp.outputs.timestamp }}
+          restore-keys: |
+            ${{ runner.os }}-ccache-Release-
       - name: Create Celix
         run: |
-          conan create . -c tools.cmake.cmaketoolchain:generator=Ninja -b missing -o celix:build_all=True  -pr:b default -pr:h default -tf examples/conan_test_package -tbf test-build -o celix:celix_cxx17=True -o celix:celix_install_deprecated_api=True --require-override=libcurl/7.64.1 --require-override=openssl/1.1.1s --require-override=zlib/1.2.13
+          conan create . -c tools.cmake.cmaketoolchain:generator=Ninja -b missing -o celix:build_all=True  -o celix:enable_ccache=True -pr:b default -pr:h default -tf examples/conan_test_package -tbf test-build -o celix:celix_cxx17=True -o celix:celix_install_deprecated_api=True --require-override=libcurl/7.64.1 --require-override=openssl/1.1.1s --require-override=zlib/1.2.13
       - name: Dependency Deduction Test
         run: |
-          conan inspect . -a options | awk 'BEGIN { FS="[\t:]+" } /build/ && !/build_all/ { print $1}' | while read option; do conan install . -c tools.cmake.cmaketoolchain:generator=Ninja -b missing -o celix:${option}=True  -pr:b default -pr:h default -if ${option}_dir -o celix:celix_cxx17=True -o celix:celix_install_deprecated_api=True --require-override=libcurl/7.64.1 --require-override=openssl/1.1.1s --require-override=zlib/1.2.13 || exit 1; conan build . -bf ${option}_dir || exit 1; done
+          conan inspect . -a options | awk 'BEGIN { FS="[\t:]+" } /build/ && !/build_all/ { print $1}' | while read option; do conan install . -c tools.cmake.cmaketoolchain:generator=Ninja -b missing -o celix:${option}=True  -pr:b default -pr:h default -if ${option}_dir -o celix:celix_cxx17=True -o celix:celix_install_deprecated_api=True -o celix:enable_ccache=True --require-override=libcurl/7.64.1 --require-override=openssl/1.1.1s --require-override=zlib/1.2.13 || exit 1; conan build . -bf ${option}_dir || exit 1; done
       - name: Remove Celix
         run: |
           conan remove -f 'celix/*'

--- a/.github/workflows/conan_create.yml
+++ b/.github/workflows/conan_create.yml
@@ -91,7 +91,7 @@ jobs:
         run: |
           conan profile new default --detect
           conan profile update settings.build_type=Release default
-      - name: Using the builtin GitHub Cache Action for .conan
+      - name: Conan Cache
         id: cache-conan
         uses: actions/cache@v1
         env:

--- a/.github/workflows/conan_create.yml
+++ b/.github/workflows/conan_create.yml
@@ -5,7 +5,6 @@ on:
   pull_request:
   schedule:
     - cron:  '0 0 * * *'
-  workflow_dispatch:
 
 env:
   CONAN_USER_HOME: "${{ github.workspace }}/release/"
@@ -51,10 +50,10 @@ jobs:
           restore-keys: ${{ runner.os }}-builder-${{ env.cache-name }}-${{ matrix.compiler[0] }}-${{ matrix.type }}-
       - name: Prepare ccache timestamp
         id: ccache_cache_timestamp
-        shell: cmake -P {0}
+        shell: cmake -P {0} >> $GITHUB_OUTPUT
         run: |
           string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
-          message("::set-output name=timestamp::${current_date}")
+          message("timestamp=${current_date}")
       - name: ccache Cache
         uses: actions/cache@v1
         with:
@@ -103,10 +102,10 @@ jobs:
           restore-keys: ${{ runner.os }}-builder-${{ env.cache-name }}-
       - name: Prepare ccache timestamp
         id: ccache_cache_timestamp
-        shell: cmake -P {0}
+        shell: cmake -P {0} >> $GITHUB_OUTPUT
         run: |
           string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
-          message("::set-output name=timestamp::${current_date}")
+          message("timestamp=${current_date}")
       - name: ccache Cache
         uses: actions/cache@v1
         with:

--- a/.github/workflows/conan_create.yml
+++ b/.github/workflows/conan_create.yml
@@ -52,6 +52,9 @@ jobs:
           CXX: ${{ matrix.compiler[1] }}
         run: |
           conan inspect .  | awk 'BEGIN { FS="[\t:]+"; output=0 } /build/ && !/build_all/ { if(output) print $1} /^options/ {output=1} /^options_definitions/ {output=0}' | while read option; do conan create . -c tools.cmake.cmaketoolchain:generator=Ninja -b missing -o celix/*:${option}=True  -pr:b default -pr:h default -s:h build_type=${{ matrix.type }} -tf examples/conan_test_package_v2 -o celix/*:celix_cxx17=True -o celix/*:celix_install_deprecated_api=True || exit 1; done
+      - name: Remove Celix
+        run: |
+          conan remove -c celix/* 
 
   mac-build:
     runs-on: macOS-11
@@ -79,3 +82,6 @@ jobs:
       - name: Create Celix
         run: |
           conan inspect . -a options | awk 'BEGIN { FS="[\t:]+" } /build/ && !/build_all/ { print $1}' | while read option; do conan create . -c tools.cmake.cmaketoolchain:generator=Ninja -b missing -o celix:${option}=True  -pr:b default -pr:h default -tf examples/conan_test_package -tbf test-build -o celix:celix_cxx17=True -o celix:celix_install_deprecated_api=True --require-override=libcurl/7.64.1 --require-override=openssl/1.1.1s --require-override=zlib/1.2.13 || exit 1; done
+      - name: Remove Celix
+        run: |
+          conan remove -f 'celix/*'

--- a/.github/workflows/conan_create.yml
+++ b/.github/workflows/conan_create.yml
@@ -5,6 +5,11 @@ on:
   pull_request:
   schedule:
     - cron:  '0 0 * * *'
+  workflow_dispatch:
+
+env:
+  CONAN_USER_HOME: "${{ github.workspace }}/release/"
+  CONAN_USER_HOME_SHORT: "${{ github.workspace }}/release/short"
 
 jobs:
 
@@ -30,6 +35,15 @@ jobs:
         run: |
           # build profile
           conan profile detect -f
+      - name: Using the builtin GitHub Cache Action for .conan
+        id: cache-conan
+        uses: actions/cache@v1
+        env:
+          cache-name: cache-conan2-modules
+        with:
+          path: ${{ env.CONAN_USER_HOME }}
+          key: ${{ runner.os }}-builder-${{ env.cache-name }}-${{ matrix.compiler[0] }}-${{ matrix.type }}-${{ hashFiles('conanfile.py') }}
+          restore-keys: ${{ runner.os }}-builder-${{ env.cache-name }}-${{ matrix.compiler[0] }}-${{ matrix.type }}-
       - name: Create Celix
         env:
           CC: ${{ matrix.compiler[0] }}
@@ -51,6 +65,15 @@ jobs:
         run: |
           conan profile new default --detect
           conan profile update settings.build_type=Release default
+      - name: Using the builtin GitHub Cache Action for .conan
+        id: cache-conan
+        uses: actions/cache@v1
+        env:
+          cache-name: cache-conan2-modules
+        with:
+          path: ${{ env.CONAN_USER_HOME }}
+          key: ${{ runner.os }}-builder-${{ env.cache-name }}-${{ matrix.compiler[0] }}-${{ matrix.type }}-${{ hashFiles('conanfile.py') }}
+          restore-keys: ${{ runner.os }}-builder-${{ env.cache-name }}-${{ matrix.compiler[0] }}-${{ matrix.type }}-
       - name: Create Celix
         env:
           CC: ${{ matrix.compiler[0] }}

--- a/.github/workflows/conan_create.yml
+++ b/.github/workflows/conan_create.yml
@@ -10,6 +10,8 @@ on:
 env:
   CONAN_USER_HOME: "${{ github.workspace }}/release/"
   CONAN_USER_HOME_SHORT: "${{ github.workspace }}/release/short"
+  CONAN_HOME: "${{ github.workspace }}/release/"
+
 
 jobs:
 
@@ -41,7 +43,7 @@ jobs:
         env:
           cache-name: cache-conan2-modules
         with:
-          path: ${{ env.CONAN_USER_HOME }}
+          path: ${{ env.CONAN_HOME }}
           key: ${{ runner.os }}-builder-${{ env.cache-name }}-${{ matrix.compiler[0] }}-${{ matrix.type }}-${{ hashFiles('conanfile.py') }}
           restore-keys: ${{ runner.os }}-builder-${{ env.cache-name }}-${{ matrix.compiler[0] }}-${{ matrix.type }}-
       - name: Create Celix
@@ -69,14 +71,11 @@ jobs:
         id: cache-conan
         uses: actions/cache@v1
         env:
-          cache-name: cache-conan2-modules
+          cache-name: cache-conan-modules
         with:
           path: ${{ env.CONAN_USER_HOME }}
-          key: ${{ runner.os }}-builder-${{ env.cache-name }}-${{ matrix.compiler[0] }}-${{ matrix.type }}-${{ hashFiles('conanfile.py') }}
-          restore-keys: ${{ runner.os }}-builder-${{ env.cache-name }}-${{ matrix.compiler[0] }}-${{ matrix.type }}-
+          key: ${{ runner.os }}-builder-${{ env.cache-name }}-${{ hashFiles('conanfile.py') }}
+          restore-keys: ${{ runner.os }}-builder-${{ env.cache-name }}-
       - name: Create Celix
-        env:
-          CC: ${{ matrix.compiler[0] }}
-          CXX: ${{ matrix.compiler[1] }}
         run: |
           conan inspect . -a options | awk 'BEGIN { FS="[\t:]+" } /build/ && !/build_all/ { print $1}' | while read option; do conan create . -c tools.cmake.cmaketoolchain:generator=Ninja -b missing -o celix:${option}=True  -pr:b default -pr:h default -tf examples/conan_test_package -tbf test-build -o celix:celix_cxx17=True -o celix:celix_install_deprecated_api=True --require-override=libcurl/7.64.1 --require-override=openssl/1.1.1s --require-override=zlib/1.2.13 || exit 1; done

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -2,6 +2,13 @@ name: Celix Coverage
 
 on: [push, pull_request]
 
+env:
+  CONAN_USER_HOME: "${{ github.workspace }}/release/"
+  CONAN_USER_HOME_SHORT: "${{ github.workspace }}/release/short"
+  CONAN_HOME: "${{ github.workspace }}/release/"
+  CCACHE_DIR: "${{ github.workspace }}/.ccache"
+  CCACHE_SLOPPINESS: include_file_ctime,include_file_mtime
+
 jobs:
   coverage:
     runs-on: ubuntu-20.04
@@ -19,6 +26,28 @@ jobs:
           conan profile update settings.build_type=Debug default
           #Note no backwards compatiblity for gcc5 needed, setting libcxx to c++11.
           conan profile update settings.compiler.libcxx=libstdc++11 default
+      - name: Conan Cache
+        id: cache-conan
+        uses: actions/cache@v1
+        env:
+          cache-name: cache-conan2-modules
+        with:
+          path: ${{ env.CONAN_HOME }}
+          key: ${{ runner.os }}-gcov-builder-${{ env.cache-name }}-${{ hashFiles('conanfile.py') }}
+          restore-keys: ${{ runner.os }}-gcov-builder-${{ env.cache-name }}-
+      - name: Prepare ccache timestamp
+        id: ccache_cache_timestamp
+        shell: cmake -P {0} >> $GITHUB_OUTPUT
+        run: |
+          string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
+          message("timestamp=${current_date}")
+      - name: ccache Cache
+        uses: actions/cache@v1
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: ${{ runner.os }}-gcov-ccache-${{ steps.ccache_cache_timestamp.outputs.timestamp }}
+          restore-keys: |
+            ${{ runner.os }}-gcov-ccache-
       - name: Install Dependencies
         env:
           CONAN_BUILD_OPTIONS: |
@@ -28,6 +57,7 @@ jobs:
             -o celix:enable_testing_for_cxx14=True
             -o celix:enable_testing_dependency_manager_for_cxx11=True
             -o celix:enable_testing_on_ci=True
+            -o celix:enable_ccache=True
         run: |
           #force require libcurl 7.64.1, due to a sha256 verify issue in libcurl/7.87.0
           conan install . celix/ci -pr:b default -pr:h default -if build ${CONAN_BUILD_OPTIONS} -b missing -b cpputest --require-override=libcurl/7.64.1 --require-override=openssl/1.1.1s

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -37,10 +37,10 @@ jobs:
           restore-keys: ${{ runner.os }}-gcov-builder-${{ env.cache-name }}-
       - name: Prepare ccache timestamp
         id: ccache_cache_timestamp
-        shell: cmake -P {0} >> $GITHUB_OUTPUT
+        shell: cmake -P {0}
         run: |
           string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
-          message("timestamp=${current_date}")
+          message("::set-output name=timestamp::${current_date}")
       - name: ccache Cache
         uses: actions/cache@v1
         with:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -37,10 +37,8 @@ jobs:
           restore-keys: ${{ runner.os }}-gcov-builder-${{ env.cache-name }}-
       - name: Prepare ccache timestamp
         id: ccache_cache_timestamp
-        shell: cmake -P {0}
         run: |
-          string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
-          message("::set-output name=timestamp::${current_date}")
+          echo timestamp=`date +"%Y-%m-%d-%H;%M;%S"` >> $GITHUB_OUTPUT
       - name: ccache Cache
         uses: actions/cache@v1
         with:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -6,6 +6,13 @@ on:
   schedule:
     - cron:  '0 0 * * *'
 
+env:
+  CONAN_USER_HOME: "${{ github.workspace }}/release/"
+  CONAN_USER_HOME_SHORT: "${{ github.workspace }}/release/short"
+  CONAN_HOME: "${{ github.workspace }}/release/"
+  CCACHE_DIR: "${{ github.workspace }}/.ccache"
+  CCACHE_SLOPPINESS: include_file_ctime,include_file_mtime
+
 jobs:
 
   macos-build-conan:
@@ -22,6 +29,28 @@ jobs:
         run: |
           conan profile new default --detect
           conan profile update settings.build_type=Release default
+      - name: Conan Cache
+        id: cache-conan
+        uses: actions/cache@v1
+        env:
+          cache-name: cache-conan-modules
+        with:
+          path: ${{ env.CONAN_USER_HOME }}
+          key: ${{ runner.os }}-test-builder-${{ env.cache-name }}-${{ hashFiles('conanfile.py') }}
+          restore-keys: ${{ runner.os }}-test-builder-${{ env.cache-name }}-
+      - name: Prepare ccache timestamp
+        id: ccache_cache_timestamp
+        shell: cmake -P {0} >> $GITHUB_OUTPUT
+        run: |
+          string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
+          message("timestamp=${current_date}")
+      - name: ccache Cache
+        uses: actions/cache@v1
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: ${{ runner.os }}-test-ccache-Release-${{ steps.ccache_cache_timestamp.outputs.timestamp }}
+          restore-keys: |
+            ${{ runner.os }}-test-ccache-Release-
       - name: Install Dependencies
         env:
           CONAN_BUILD_OPTIONS: |
@@ -33,6 +62,7 @@ jobs:
             -o celix:enable_cmake_warning_tests=True
             -o celix:enable_testing_on_ci=True
             -o celix:framework_curlinit=False
+            -o celix:enable_ccache=True
         run: |
           #force require libcurl 7.64.1, due to a sha256 verify issue in libcurl/7.87.0
           conan install . celix/ci -c tools.cmake.cmaketoolchain:generator=Ninja -pr:b default -pr:h default -if build ${CONAN_BUILD_OPTIONS} -b missing -b cpputest --require-override=libcurl/7.64.1 --require-override=openssl/1.1.1s
@@ -56,7 +86,20 @@ jobs:
       - name: Install dependencies
         run: |
           brew update
-          brew install lcov zeromq czmq cpputest jansson rapidjson libzip
+          brew install lcov zeromq czmq cpputest jansson rapidjson libzip ccache
+      - name: Prepare ccache timestamp
+        id: ccache_cache_timestamp
+        shell: cmake -P {0} >> $GITHUB_OUTPUT
+        run: |
+          string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
+          message("timestamp=${current_date}")
+      - name: ccache Cache
+        uses: actions/cache@v1
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: ${{ runner.os }}-brew-test-ccache-Release-${{ steps.ccache_cache_timestamp.outputs.timestamp }}
+          restore-keys: |
+            ${{ runner.os }}-brew-test-ccache-Release-
       - name: Build
         env:
           BUILD_OPTIONS: |
@@ -66,6 +109,7 @@ jobs:
             -DENABLE_ADDRESS_SANITIZER=ON
             -DENABLE_TESTING_ON_CI=ON
             -DCMAKE_BUILD_TYPE=Release
+            -DENABLE_CCACHE=ON
         run: |
           mkdir build install
           cd build

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -40,10 +40,10 @@ jobs:
           restore-keys: ${{ runner.os }}-test-builder-${{ env.cache-name }}-
       - name: Prepare ccache timestamp
         id: ccache_cache_timestamp
-        shell: cmake -P {0} >> $GITHUB_OUTPUT
+        shell: cmake -P {0}
         run: |
           string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
-          message("timestamp=${current_date}")
+          message("::set-output name=timestamp::${current_date}")
       - name: ccache Cache
         uses: actions/cache@v1
         with:
@@ -89,10 +89,10 @@ jobs:
           brew install lcov zeromq czmq cpputest jansson rapidjson libzip ccache
       - name: Prepare ccache timestamp
         id: ccache_cache_timestamp
-        shell: cmake -P {0} >> $GITHUB_OUTPUT
+        shell: cmake -P {0}
         run: |
           string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
-          message("timestamp=${current_date}")
+          message("::set-output name=timestamp::${current_date}")
       - name: ccache Cache
         uses: actions/cache@v1
         with:

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -83,7 +83,6 @@ jobs:
         uses: actions/checkout@v3.3.0
       - name: Install dependencies
         run: |
-          brew update
           brew install lcov zeromq czmq cpputest jansson rapidjson libzip ccache
       - name: Prepare ccache timestamp
         id: ccache_cache_timestamp

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -40,10 +40,8 @@ jobs:
           restore-keys: ${{ runner.os }}-test-builder-${{ env.cache-name }}-
       - name: Prepare ccache timestamp
         id: ccache_cache_timestamp
-        shell: cmake -P {0}
         run: |
-          string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
-          message("::set-output name=timestamp::${current_date}")
+          echo timestamp=`date +"%Y-%m-%d-%H;%M;%S"` >> $GITHUB_OUTPUT
       - name: ccache Cache
         uses: actions/cache@v1
         with:
@@ -89,10 +87,8 @@ jobs:
           brew install lcov zeromq czmq cpputest jansson rapidjson libzip ccache
       - name: Prepare ccache timestamp
         id: ccache_cache_timestamp
-        shell: cmake -P {0}
         run: |
-          string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
-          message("::set-output name=timestamp::${current_date}")
+          echo timestamp=`date +"%Y-%m-%d-%H;%M;%S"` >> $GITHUB_OUTPUT
       - name: ccache Cache
         uses: actions/cache@v1
         with:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -58,10 +58,10 @@ jobs:
           restore-keys: ${{ runner.os }}-test-builder-${{ env.cache-name }}-${{ matrix.compiler[0] }}-${{ matrix.type }}-
       - name: Prepare ccache timestamp
         id: ccache_cache_timestamp
-        shell: cmake -P {0} >> $GITHUB_OUTPUT
+        shell: cmake -P {0}
         run: |
           string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
-          message("timestamp=${current_date}")
+          message("::set-output name=timestamp::${current_date}")
       - name: ccache Cache
         uses: actions/cache@v1
         with:
@@ -129,10 +129,10 @@ jobs:
           ccache
     - name: Prepare ccache timestamp
       id: ccache_cache_timestamp
-      shell: cmake -P {0} >> $GITHUB_OUTPUT
+      shell: cmake -P {0}
       run: |
         string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
-        message("timestamp=${current_date}")
+        message("::set-output name=timestamp::${current_date}")
     - name: ccache Cache
       uses: actions/cache@v1
       with:

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -6,6 +6,13 @@ on:
   schedule:
     - cron:  '0 0 * * *'
 
+env:
+  CONAN_USER_HOME: "${{ github.workspace }}/release/"
+  CONAN_USER_HOME_SHORT: "${{ github.workspace }}/release/short"
+  CONAN_HOME: "${{ github.workspace }}/release/"
+  CCACHE_DIR: "${{ github.workspace }}/.ccache"
+  CCACHE_SLOPPINESS: include_file_ctime,include_file_mtime
+
 jobs:
 
   linux-build-conan:
@@ -40,6 +47,28 @@ jobs:
           #Note no backwards compatibility for gcc5 needed, setting libcxx to c++11.
           conan profile update settings.compiler.libcxx=libstdc++11 default
           conan profile show default
+      - name: Conan Cache
+        id: cache-conan
+        uses: actions/cache@v1
+        env:
+          cache-name: cache-conan2-modules
+        with:
+          path: ${{ env.CONAN_HOME }}
+          key: ${{ runner.os }}-test-builder-${{ env.cache-name }}-${{ matrix.compiler[0] }}-${{ matrix.type }}-${{ hashFiles('conanfile.py') }}
+          restore-keys: ${{ runner.os }}-test-builder-${{ env.cache-name }}-${{ matrix.compiler[0] }}-${{ matrix.type }}-
+      - name: Prepare ccache timestamp
+        id: ccache_cache_timestamp
+        shell: cmake -P {0} >> $GITHUB_OUTPUT
+        run: |
+          string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
+          message("timestamp=${current_date}")
+      - name: ccache Cache
+        uses: actions/cache@v1
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: ${{ runner.os }}-test-ccache-${{ matrix.compiler[0] }}-${{ matrix.type }}-${{ steps.ccache_cache_timestamp.outputs.timestamp }}
+          restore-keys: |
+            ${{ runner.os }}-test-ccache-${{ matrix.compiler[0] }}-${{ matrix.type }}-
       - name: Configure and install dependencies
         env:
           CC: ${{ matrix.compiler[0] }}
@@ -53,6 +82,7 @@ jobs:
             -o celix:enable_cmake_warning_tests=True
             -o celix:enable_testing_on_ci=True
             -o celix:framework_curlinit=False
+            -o celix:enable_ccache=True
         run: |
           #force require libcurl 7.64.1, due to a sha256 verify issue in libcurl/7.87.0
           conan install . celix/ci -c tools.cmake.cmaketoolchain:generator=Ninja -pr:b release -pr:h default -if build ${CONAN_BUILD_OPTIONS} -b missing  -b cpputest --require-override=libcurl/7.64.1 --require-override=openssl/1.1.1s
@@ -95,7 +125,21 @@ jobs:
           rapidjson-dev \
           libavahi-compat-libdnssd-dev \
           libcivetweb-dev \
-          civetweb
+          civetweb \
+          ccache
+    - name: Prepare ccache timestamp
+      id: ccache_cache_timestamp
+      shell: cmake -P {0} >> $GITHUB_OUTPUT
+      run: |
+        string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
+        message("timestamp=${current_date}")
+    - name: ccache Cache
+      uses: actions/cache@v1
+      with:
+        path: ${{ env.CCACHE_DIR }}
+        key: ${{ runner.os }}-apt-test-ccache-gcc-Debug-${{ steps.ccache_cache_timestamp.outputs.timestamp }}
+        restore-keys: |
+          ${{ runner.os }}-apt-test-ccache-gcc-Debug-
     - name: Build
       env:
         BUILD_OPTIONS: |
@@ -109,6 +153,7 @@ jobs:
           -DSHELL_BONJOUR=ON
           -DENABLE_TESTING_ON_CI=ON
           -DCMAKE_BUILD_TYPE=Debug
+          -DENABLE_CCACHE=ON
       run: |
         mkdir build install
         cd build

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -58,10 +58,8 @@ jobs:
           restore-keys: ${{ runner.os }}-test-builder-${{ env.cache-name }}-${{ matrix.compiler[0] }}-${{ matrix.type }}-
       - name: Prepare ccache timestamp
         id: ccache_cache_timestamp
-        shell: cmake -P {0}
         run: |
-          string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
-          message("::set-output name=timestamp::${current_date}")
+          echo timestamp=`date +"%Y-%m-%d-%H;%M;%S"` >> $GITHUB_OUTPUT
       - name: ccache Cache
         uses: actions/cache@v1
         with:
@@ -129,10 +127,8 @@ jobs:
           ccache
     - name: Prepare ccache timestamp
       id: ccache_cache_timestamp
-      shell: cmake -P {0}
       run: |
-        string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
-        message("::set-output name=timestamp::${current_date}")
+        echo timestamp=`date +"%Y-%m-%d-%H;%M;%S"` >> $GITHUB_OUTPUT
     - name: ccache Cache
       uses: actions/cache@v1
       with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,16 @@ if (ENABLE_TESTING)
     endif()
 endif ()
 
+
+option(ENABLE_CCACHE "Enabled building with ccache" FALSE)
+if (ENABLE_CCACHE)
+    find_program(CCACHE_EXECUTABLE ccache)
+    if(CCACHE_EXECUTABLE)
+        set(CMAKE_C_COMPILER_LAUNCHER ${CCACHE_EXECUTABLE})
+        set(CMAKE_CXX_COMPILER_LAUNCHER ${CCACHE_EXECUTABLE})
+    endif()
+endif ()
+
 # Set C specific flags
 set(CMAKE_C_FLAGS "-D_GNU_SOURCE -std=gnu99 -fPIC ${CMAKE_C_FLAGS}")
 set(CMAKE_C_FLAGS "-Wall -Werror -Wformat -Wno-error=deprecated-declarations ${CMAKE_C_FLAGS}")

--- a/bundles/shell/shell/src/quit_command.c
+++ b/bundles/shell/shell/src/quit_command.c
@@ -17,10 +17,11 @@
  *under the License.
  */
 
+#include "std_commands.h"
 #include "celix_bundle_context.h"
 #include "celix_compiler.h"
 
-bool quitCommand_execute(void *_ptr, char *command_line_str CELIX_UNUSED, FILE *sout, FILE *serr CELIX_UNUSED) {
+bool quitCommand_execute(void *_ptr, const char *command_line_str CELIX_UNUSED, FILE *sout, FILE *serr CELIX_UNUSED) {
     bundle_context_t* ctx = _ptr;
     fprintf(sout, "Quitting framework\n");
     return celix_bundleContext_stopBundle(ctx, 0L);

--- a/conanfile.py
+++ b/conanfile.py
@@ -151,13 +151,14 @@ class CelixConan(ConanFile):
         del self.info.options.enable_testing_for_cxx14
         del self.info.options.enable_cmake_warning_tests
         del self.info.options.enable_testing_on_ci
+        del self.options.enable_ccache
 
     def build_requirements(self):
         if self.options.enable_testing:
             self.test_requires("gtest/1.10.0")
             self.test_requires("cpputest/4.0")
         if self.options.enable_ccache:
-            self.build_requires("ccache/4.8.2")
+            self.build_requires("ccache/4.6")
 
     def configure(self):
         # copy options to options, fill in defaults if not set

--- a/conanfile.py
+++ b/conanfile.py
@@ -104,6 +104,7 @@ class CelixConan(ConanFile):
         "enable_cmake_warning_tests": False,
         "enable_testing_on_ci": False,
         "framework_curlinit": True,
+        "enable_ccache": False,
     }
     options = {
         "celix_err_buffer_size": ["ANY"],
@@ -155,6 +156,8 @@ class CelixConan(ConanFile):
         if self.options.enable_testing:
             self.test_requires("gtest/1.10.0")
             self.test_requires("cpputest/4.0")
+        if self.options.enable_ccache:
+            self.build_requires("ccache/4.8.2")
 
     def configure(self):
         # copy options to options, fill in defaults if not set

--- a/conanfile.py
+++ b/conanfile.py
@@ -151,7 +151,7 @@ class CelixConan(ConanFile):
         del self.info.options.enable_testing_for_cxx14
         del self.info.options.enable_cmake_warning_tests
         del self.info.options.enable_testing_on_ci
-        del self.options.enable_ccache
+        del self.info.options.enable_ccache
 
     def build_requirements(self):
         if self.options.enable_testing:

--- a/conanfile.py
+++ b/conanfile.py
@@ -32,7 +32,8 @@ class CelixConan(ConanFile):
     homepage = "https://celix.apache.org"
     url = "https://github.com/apache/celix.git"
     topics = ("conan", "celix", "osgi", "embedded", "linux", "C/C++")
-    exports_sources = "CMakeLists.txt", "bundles*", "cmake*", "!cmake-build*", "examples*", "libs*", "misc*", "LICENSE"
+    exports_sources = ("CMakeLists.txt", "bundles*", "cmake*", "!cmake-build*", "examples*", "libs*", "misc*",
+                       "LICENSE", "!examples/conan_test_package*")
     generators = "CMakeDeps", "VirtualRunEnv"
     settings = "os", "arch", "compiler", "build_type"
     license = " Apache-2.0"


### PR DESCRIPTION
This PR addresses #615 and part of #614 by adding Conan cache support.
Apt cache is doable, but the need is not urgent now.

`brew update` fails frequently, as can be seen: https://github.com/apache/celix/actions/runs/6026084782/job/16348926446?pr=628
Unfortunately, I don't know how brew cache should be implemented. 
This PR removes `brew update` to avoid these intermittent failures.