### PR TITLE
#632: Update changes.md for coming Apache Celix 2.4.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,9 @@ limitations under the License.
 - Celix error library for printing errors when no framework is available.
 - Scope-based Resource Management (RAII-light for C).
 - Rust Proof of Concept (PoC) for Apache Celix.
+- Support for uncompressed bundle deployment, which enables multiple frameworks to share the bundle resources by
+  using unzipped bundle dirs instead of a zip files as BUNDLES arguments in `add_celix_container`.
+
 
 ## Improvements
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -40,7 +40,7 @@ limitations under the License.
 - Support for Conan 2.
 - Support for uclibc (not tested in CI yet).
 - Support for C++14 in addition to C++17.
-- Deprecated `snprintf` usage; transitioned to `snprintf` or `aprintf`.
+- Deprecated `sprintf` usage; transitioned to `snprintf` or `aprintf`.
 - Refactored the bundle cache to support retention of unchanged bundles on disk.
 - Automatic scan for project build options using CMake.
 - Use of upstream `civetweb` dependency instead of embedded sources.
@@ -99,7 +99,7 @@ limitations under the License.
 
 ## Fixes
 
-- Fixes etcdlib CMake setup to that etcdlib can be build as a separate project
+- Fixes etcdlib CMake setup to that etcdlib can be built as a separate project
 
 # Noteworthy changes for 2.2.0 (2020-01-06)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,39 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 
+# Noteworthy Changes for 2.4.0 (TBD)
+
+## New Features
+
+- V2 Shared memory for remote service admin.
+- Zeroconf discovery of remote services.
+- Symbol visibility support: Bundle symbols are now hidden by default, except for the bundle activator.
+- Error injection library (for testing).
+- Coding convention documentation.
+- Celix error library for printing errors when no framework is available.
+- Scope-based Resource Management (RAII-light for C).
+- Rust Proof of Concept (PoC) for Apache Celix.
+
+## Improvements
+
+- Support for Conan 2.
+- Support for uclibc (not tested in CI yet).
+- Support for C++14 in addition to C++17.
+- Deprecated `snprintf` usage; transitioned to `snprintf` or `aprintf`.
+- Refactored the bundle cache to support retention of unchanged bundles on disk.
+- Automatic scan for project build options using CMake.
+- Use of upstream `civetweb` dependency instead of embedded sources.
+- Applied attribute format for printf-like functions.
+- Removed the busy loop mechanism from the pubsub admin websocket.
+- Improved cleanup procedures during bundle uninstallation to conform to the OSGi specification.
+- Improved `INSTALL_RPATH` to use `$ORIGIN` during installation.
+- Corrected bundle update behavior when updating bundles from different sources.
+- Enhanced `libcurl` initialization procedures and made `libcurl` optional.
+
+## Fixes
+
+- Numerous minor fixes, especially concerning multi-threading issues and error handling.
+
 # Noteworthy changes for 2.3.0 (2022-07-10)
 
 ## New Features

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-cmake_minimum_required (VERSION 3.18)
+cmake_minimum_required (VERSION 3.19)
 cmake_policy(SET CMP0012 NEW)
 cmake_policy(SET CMP0042 NEW)
 cmake_policy(SET CMP0068 NEW)


### PR DESCRIPTION
This PR updates the changes.md for the coming release.

I based the changes on the pull requests between 2.3.0 and now. 
Please let me know if I missed anything.
 