### PR TITLE
[#643] Create destination directory before performing decompression.

### DIFF
--- a/libs/utils/gtest/src/FileUtilsTestSuite.cc
+++ b/libs/utils/gtest/src/FileUtilsTestSuite.cc
@@ -189,9 +189,16 @@ TEST_F(FileUtilsTestSuite, ExtractZipFileTest) {
     EXPECT_EQ(celix_properties_getAsLong(props, "level", 0), 2);
     celix_properties_destroy(props);
 
+    //Given a test zip file, extract to file is a error
+    const char* error = nullptr;
+    status = celix_utils_extractZipFile(TEST_ZIP_LOCATION, file1, &error);
+    EXPECT_NE(status, CELIX_SUCCESS);
+    EXPECT_NE(error, nullptr);
+
+
     //Given a incorrect path extractZipFile returns a error
     const char* invalidPath = "does-not-exists.zip";
-    const char* error = nullptr;
+    error = nullptr;
     EXPECT_FALSE(celix_utils_fileExists(invalidPath));
     status = celix_utils_extractZipFile(invalidPath, extractLocation, &error);
     EXPECT_NE(status, CELIX_SUCCESS);

--- a/libs/utils/src/celix_file_utils.c
+++ b/libs/utils/src/celix_file_utils.c
@@ -214,6 +214,11 @@ static celix_status_t celix_utils_extractZipInternal(zip_t *zip, const char* ext
     char buf[5120];
     size_t bufSize = 5112;
 
+    status = celix_utils_createDirectory(extractToDir, false, errorOut);
+    if (status != CELIX_SUCCESS) {
+        return status;
+    }
+
     for (zip_int64_t i = 0; status == CELIX_SUCCESS && i < nrOfEntries; ++i) {
         zip_stat_t st;
         if(zip_stat_index(zip, i, 0, &st) == -1) {


### PR DESCRIPTION
Bundle produced by zip does not necessarily begin with META-INF. It fixes #643.
This is needed to be included in 2.4.0.