### PR TITLE
Hotfix/Run error injector tests only for Debug build.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -184,6 +184,12 @@ include(CheckLinkerFlag)
 check_linker_flag(CXX LINKER:--wrap,celix_nonexistent_symbol LINKER_WRAP_SUPPORTED)
 cmake_pop_check_state()
 
+if ("${CMAKE_BUILD_TYPE}" STREQUAL "Debug" AND LINKER_WRAP_SUPPORTED)
+    set(EI_TESTS ON)
+else ()
+    set(EI_TESTS OFF)
+endif()
+
 # avoid unknown export "celix" error when building nothing
 add_library(celix INTERFACE)
 add_library(Celix::celix ALIAS celix)

--- a/bundles/components_ready_check/gtest/CMakeLists.txt
+++ b/bundles/components_ready_check/gtest/CMakeLists.txt
@@ -38,7 +38,7 @@ celix_target_bundle_set_definition(test_components_ready NAME INACTIVE_CMP_TEST_
 add_test(NAME test_components_ready COMMAND test_components_ready)
 setup_target_for_coverage(test_components_ready SCAN_DIR ..)
 
-if (LINKER_WRAP_SUPPORTED)
+if (EI_TESTS)
     add_executable(test_components_ready_with_ei src/ComponentsReadyWithErrorInjectionTestSuite.cc)
     target_link_libraries(test_components_ready_with_ei PRIVATE
             framework_cut

--- a/bundles/logging/log_helper/CMakeLists.txt
+++ b/bundles/logging/log_helper/CMakeLists.txt
@@ -48,7 +48,7 @@ if (LOG_HELPER)
     add_library(Celix::log_helper ALIAS log_helper)
 
     if (ENABLE_TESTING)
-        if (LINKER_WRAP_SUPPORTED)
+        if (EI_TESTS)
             add_subdirectory(error_injector)
         endif ()
         add_subdirectory(gtest)

--- a/bundles/pubsub/pubsub_protocol/pubsub_protocol_lib/gtest/CMakeLists.txt
+++ b/bundles/pubsub/pubsub_protocol/pubsub_protocol_lib/gtest/CMakeLists.txt
@@ -22,7 +22,7 @@ target_link_libraries(celix_pswp_common_tests PRIVATE celix_pubsub_protocol_lib 
 add_test(NAME celix_pswp_common_tests COMMAND celix_pswp_common_tests)
 setup_target_for_coverage(celix_pswp_common_tests SCAN_DIR ..)
 
-if (LINKER_WRAP_SUPPORTED)
+if (EI_TESTS)
     add_executable(celix_pswp_common_ei_tests src/PS_WP_common_ei_tests.cc)
     target_include_directories(celix_pswp_common_ei_tests PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../src)
     target_link_libraries(celix_pswp_common_ei_tests PRIVATE celix_pubsub_protocol_lib GTest::gtest Celix::pubsub_spi GTest::gtest_main Celix::malloc_ei Celix::properties_ei)

--- a/bundles/remote_services/discovery_zeroconf/gtest/CMakeLists.txt
+++ b/bundles/remote_services/discovery_zeroconf/gtest/CMakeLists.txt
@@ -40,7 +40,7 @@ target_compile_definitions(integration_test_discovery_zeroconf PRIVATE -DDISCOVE
 add_test(NAME run_integration_test_discovery_zeroconf COMMAND integration_test_discovery_zeroconf)
 setup_target_for_coverage(integration_test_discovery_zeroconf SCAN_DIR ..)
 
-if (LINKER_WRAP_SUPPORTED)
+if (EI_TESTS)
     ####unit test
     add_executable(unit_test_discovery_zeroconf
             src/DiscoveryZeroconfAnnouncerTestSuite.cc

--- a/bundles/remote_services/remote_service_admin_shm_v2/rsa_shm/gtest/CMakeLists.txt
+++ b/bundles/remote_services/remote_service_admin_shm_v2/rsa_shm/gtest/CMakeLists.txt
@@ -39,7 +39,7 @@ add_celix_bundle_dependencies(integration_test_rsa_shm Celix::rsa_shm)
 add_test(NAME run_integration_test_rsa_shm COMMAND integration_test_rsa_shm)
 setup_target_for_coverage(integration_test_rsa_shm SCAN_DIR ..)
 
-if (LINKER_WRAP_SUPPORTED AND BUILD_RSA_JSON_RPC)
+if (EI_TESTS AND BUILD_RSA_JSON_RPC)
     ####unit test
     add_executable(unit_test_rsa_shm
             src/RsaShmImplUnitTestSuite.cc

--- a/bundles/remote_services/remote_service_admin_shm_v2/shm_pool/gtest/CMakeLists.txt
+++ b/bundles/remote_services/remote_service_admin_shm_v2/shm_pool/gtest/CMakeLists.txt
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-if (LINKER_WRAP_SUPPORTED)
+if (EI_TESTS)
     add_executable(test_shm_pool
             src/ShmPoolTestSuite.cc
             src/ShmCacheTestSuite.cc

--- a/bundles/remote_services/rsa_common/gtest/CMakeLists.txt
+++ b/bundles/remote_services/rsa_common/gtest/CMakeLists.txt
@@ -14,7 +14,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-if (LINKER_WRAP_SUPPORTED)
+if (EI_TESTS)
     ####unit test
     add_executable(unit_test_rsa_common
             src/EndpointDescriptionUnitTestSuite.cc

--- a/bundles/remote_services/rsa_rpc_json/gtest/CMakeLists.txt
+++ b/bundles/remote_services/rsa_rpc_json/gtest/CMakeLists.txt
@@ -36,7 +36,7 @@ target_compile_definitions(integration_test_rsa_json_rpc PRIVATE -DRSA_JSON_RPC_
 add_test(NAME run_integration_test_rsa_json_rpc COMMAND integration_test_rsa_json_rpc)
 setup_target_for_coverage(integration_test_rsa_json_rpc SCAN_DIR ..)
 
-if (LINKER_WRAP_SUPPORTED)
+if (EI_TESTS)
     ####unit test
     add_executable(unit_test_rsa_json_rpc
             src/RsaJsonRpcUnitTestSuite.cc

--- a/documents/development/README.md
+++ b/documents/development/README.md
@@ -422,7 +422,7 @@ void celix_foo_destroy(celix_foo_t* foo) {
 ## Error Injection
 
 - Use the Apache Celix error_injector libraries to inject errors in unit tests in a controlled way.
-- Create a separate test suite for error injection tests and place them under a `LINKER_WRAP_SUPPORTED` cmake condition.
+- Create a separate test suite for error injection tests and place them under a `EI_TESTS` cmake condition.
 - Reset error injection setup on the `TearDown` function or destructor of the test fixture.
 - If an - internal or external - function is missing error injection support, add it to the error_injector library.
   - Try to create small error injector libraries for specific functionality.

--- a/libs/CMakeLists.txt
+++ b/libs/CMakeLists.txt
@@ -36,7 +36,7 @@ if (CELIX_CXX14)
 endif ()
 
 # Error Injectors
-if (ENABLE_TESTING AND LINKER_WRAP_SUPPORTED)
+if (ENABLE_TESTING AND EI_TESTS)
     add_subdirectory(error_injector)
 endif ()
 

--- a/libs/dfi/CMakeLists.txt
+++ b/libs/dfi/CMakeLists.txt
@@ -60,7 +60,7 @@ if (CELIX_DFI)
 	#Alias setup to match external usage
 	add_library(Celix::dfi ALIAS dfi)
 
-	if (ENABLE_TESTING AND LINKER_WRAP_SUPPORTED)
+	if (ENABLE_TESTING AND EI_TESTS)
 		add_subdirectory(error_injector)
 	endif ()
 	if (ENABLE_TESTING)

--- a/libs/framework/CMakeLists.txt
+++ b/libs/framework/CMakeLists.txt
@@ -83,7 +83,7 @@ if (FRAMEWORK)
     #Alias setup to match external usage
     add_library(Celix::framework ALIAS framework)
 
-    if (ENABLE_TESTING AND LINKER_WRAP_SUPPORTED)
+    if (ENABLE_TESTING AND EI_TESTS)
         add_subdirectory(error_injector)
     endif ()
     if (ENABLE_TESTING AND CELIX_CXX17) #framework tests are C++17

--- a/libs/framework/gtest/CMakeLists.txt
+++ b/libs/framework/gtest/CMakeLists.txt
@@ -131,7 +131,7 @@ endif ()
 add_test(NAME test_framework COMMAND test_framework)
 setup_target_for_coverage(test_framework SCAN_DIR ..)
 
-if (LINKER_WRAP_SUPPORTED)
+if (EI_TESTS)
     add_executable(test_framework_with_ei
             src/BundleArchiveWithErrorInjectionTestSuite.cc
             src/CelixFrameworkUtilsErrorInjectionTestSuite.cc

--- a/libs/rcm/gtest/CMakeLists.txt
+++ b/libs/rcm/gtest/CMakeLists.txt
@@ -25,7 +25,7 @@ target_link_libraries(test_rcm PRIVATE Celix::rcm GTest::gtest GTest::gtest_main
 add_test(NAME test_rcm COMMAND test_rcm)
 setup_target_for_coverage(test_rcm SCAN_DIR ..)
 
-if (LINKER_WRAP_SUPPORTED)
+if (EI_TESTS)
     add_executable(test_rcm_with_error_injection
         src/RequirementCapabilityModelWithErrorInjectionTestSuite.cc
     )

--- a/libs/utils/CMakeLists.txt
+++ b/libs/utils/CMakeLists.txt
@@ -112,7 +112,7 @@ if (UTILS)
     #Alias setup to match external usage
     add_library(Celix::utils ALIAS utils)
 
-    if (ENABLE_TESTING AND LINKER_WRAP_SUPPORTED)
+    if (ENABLE_TESTING AND EI_TESTS)
         add_subdirectory(error_injector)
     endif ()
 
@@ -163,7 +163,7 @@ if (UTILS)
             target_link_libraries(version_test CppUTest utils_cut pthread)
 
 
-            if (LINKER_WRAP_SUPPORTED)
+            if (EI_TESTS)
                 add_executable(version_ei_test private/test/version_ei_test.cc)
                 target_include_directories(version_ei_test PRIVATE include_deprecated)
                 target_link_libraries(version_ei_test CppUTest utils_cut Celix::malloc_ei Celix::utils_ei pthread)

--- a/libs/utils/gtest/CMakeLists.txt
+++ b/libs/utils/gtest/CMakeLists.txt
@@ -82,7 +82,7 @@ add_test(NAME test_utils COMMAND test_utils)
 setup_target_for_coverage(test_utils SCAN_DIR ..)
 
 
-if (LINKER_WRAP_SUPPORTED)
+if (EI_TESTS)
     add_executable(test_utils_with_ei
             src/FileUtilsErrorInjectionTestSuite.cc
             src/ConvertUtilsErrorInjectionTestSuite.cc


### PR DESCRIPTION
Fix testing issue for non-debug build following the suggestion given [here](https://lists.apache.org/thread/6vlx9f5865433cnndd7op598bdj460pn).

Note that for `cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DENABLE_TESTING=ON ..; make -j 8; ctest`, there is still a test failure left:

```
The following tests FAILED:
         49 - test_cxx_remote_services_integration (SEGFAULT)
``` 

A separate issue is raised: #653 