### PR TITLE
#659: Relax timing on scheduled event tests for local testing

### DIFF
--- a/libs/framework/gtest/src/ScheduledEventTestSuite.cc
+++ b/libs/framework/gtest/src/ScheduledEventTestSuite.cc
@@ -25,12 +25,10 @@
 
 class ScheduledEventTestSuite : public ::testing::Test {
   public:
-#if defined(__APPLE__) && defined(TESTING_ON_CI)
-    const int ALLOWED_ERROR_MARGIN_IN_MS = 1500;
-#elif TESTING_ON_CI
-    const int ALLOWED_ERROR_MARGIN_IN_MS = 1000;
+#if defined(__APPLE__) || defined(TESTING_ON_CI)
+    const int ALLOWED_ERROR_MARGIN_IN_MS = 2000;
 #else
-    const int ALLOWED_ERROR_MARGIN_IN_MS = 100;
+    const int ALLOWED_ERROR_MARGIN_IN_MS = 1000;
 #endif
 
     const double ALLOWED_PROCESSING_TIME_IN_SECONDS = 0.1;


### PR DESCRIPTION
This PR relaxes the error margin for the scheduled events tests as mentioned in #659.

@rlenferink Could you test if this also fixes the flaky tests for you?

I think this is good enough for the 2.4.0 release. 

Maybe after this can be furthered improved by simulating time and timeouts using `--wrap` to mock functions or even redesign the scheduled event / framework to allow time and timeout simulation. But this is considerable more effort and IMO something for after the 2.4.0 release.

 