### PR TITLE
Hotfix/ubuntu clang compilation

### DIFF
--- a/libs/framework/gtest/src/DependencyManagerTestSuite.cc
+++ b/libs/framework/gtest/src/DependencyManagerTestSuite.cc
@@ -20,6 +20,7 @@
 #include <gtest/gtest.h>
 #include <atomic>
 #include <condition_variable>
+#include <cstdint>
 
 #include "celix/dm/DependencyManager.h"
 #include "celix_framework_factory.h"

--- a/libs/framework/include/celix/Bundle.h
+++ b/libs/framework/include/celix/Bundle.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include <cstdlib>
+#include <cstdint>
 #include <memory>
 
 #include "celix_bundle.h"

--- a/libs/framework/include/celix/ServiceRegistration.h
+++ b/libs/framework/include/celix/ServiceRegistration.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <memory>
 #include <mutex>
 #include <vector>

--- a/libs/framework/include/celix/Trackers.h
+++ b/libs/framework/include/celix/Trackers.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <memory>
 #include <mutex>
 #include <atomic>

--- a/libs/framework/include/celix/dm/Component.h
+++ b/libs/framework/include/celix/dm/Component.h
@@ -23,6 +23,7 @@
 #include <string>
 #include <vector>
 #include <atomic>
+#include <cstdint>
 #include <mutex>
 #include <memory>
 #include <iostream>

--- a/libs/pushstreams/api/celix/PushEvent.h
+++ b/libs/pushstreams/api/celix/PushEvent.h
@@ -19,6 +19,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include "celix/IllegalStateException.h"
 
 namespace celix {

--- a/libs/pushstreams/api/celix/PushStream.h
+++ b/libs/pushstreams/api/celix/PushStream.h
@@ -22,6 +22,7 @@
 #include <optional>
 #include <iostream>
 #include <queue>
+#include <cstdint>
 
 #include "celix/IAutoCloseable.h"
 


### PR DESCRIPTION
I didn't know why this failure suddenly happens ([1]). 
It turns out that we're missing some standard header includes.

[1] https://github.com/apache/celix/actions/runs/6661101259/job/18105263663