### PR TITLE
Feature/509 remove service lang support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,6 +33,7 @@ limitations under the License.
 - pubsub_serializer.h is removed and no longer supported. Use pubsub_message_serialization_service.h instead.
 - C++11 support for dm is removed. C++14 is now the minimum required version.
 - C++17 string_view support is removed from the utils and framework lib.
+- Support and usage of "service.lang" service property is removed. 
 
 # Noteworthy Changes for 2.4.0 (2023-09-27)
 

--- a/bundles/pubsub/examples/pubsub/publisher/private/src/ps_pub_activator.c
+++ b/bundles/pubsub/examples/pubsub/publisher/private/src/ps_pub_activator.c
@@ -70,7 +70,6 @@ static int pub_start(struct publisherActivator *act, celix_bundle_context_t *ctx
         opts.removeWithProperties = publisher_publishSvcRemoved;
         opts.filter.serviceName = PUBSUB_PUBLISHER_SERVICE_NAME;
         opts.filter.filter = filter;
-        opts.filter.ignoreServiceLanguage = true;
         long trackerId = celix_bundleContext_trackServicesWithOptions(ctx, &opts);
 
         celix_arrayList_addLong(act->trackerList,trackerId);

--- a/bundles/pubsub/examples/pubsub/pubsub_websocket/private/src/ps_websocket_activator.c
+++ b/bundles/pubsub/examples/pubsub/pubsub_websocket/private/src/ps_websocket_activator.c
@@ -90,7 +90,6 @@ static int pubsub_start(struct ps_websocketActivator *act, celix_bundle_context_
         opts.removeWithProperties = publisher_publishSvcRemoved;
         opts.filter.serviceName = PUBSUB_PUBLISHER_SERVICE_NAME;
         opts.filter.filter = filter;
-        opts.filter.ignoreServiceLanguage = true;
         long trackerId = celix_bundleContext_trackServicesWithOptions(ctx, &opts);
 
         celix_arrayList_addLong(act->trackerList,trackerId);

--- a/bundles/pubsub/pubsub_admin_tcp/src/psa_activator.c
+++ b/bundles/pubsub/pubsub_admin_tcp/src/psa_activator.c
@@ -59,7 +59,6 @@ int psa_tcp_start(psa_tcp_activator_t *act, celix_bundle_context_t *ctx) {
     if (status == CELIX_SUCCESS) {
         celix_service_tracking_options_t opts = CELIX_EMPTY_SERVICE_TRACKING_OPTIONS;
         opts.filter.serviceName = PUBSUB_PROTOCOL_SERVICE_NAME;
-        opts.filter.ignoreServiceLanguage = true;
         opts.callbackHandle = act->admin;
         opts.addWithProperties = pubsub_tcpAdmin_addProtocolSvc;
         opts.removeWithProperties = pubsub_tcpAdmin_removeProtocolSvc;

--- a/bundles/pubsub/pubsub_admin_tcp/src/pubsub_tcp_topic_receiver.c
+++ b/bundles/pubsub/pubsub_admin_tcp/src/pubsub_tcp_topic_receiver.c
@@ -235,7 +235,6 @@ pubsub_tcp_topic_receiver_t *pubsub_tcpTopicReceiver_create(celix_bundle_context
         char buf[size + 1];
         snprintf(buf, (size_t) size + 1, "(%s=%s)", PUBSUB_SUBSCRIBER_TOPIC, topic);
         celix_service_tracking_options_t opts = CELIX_EMPTY_SERVICE_TRACKING_OPTIONS;
-        opts.filter.ignoreServiceLanguage = true;
         opts.filter.serviceName = PUBSUB_SUBSCRIBER_SERVICE_NAME;
         opts.filter.filter = buf;
         opts.callbackHandle = receiver;

--- a/bundles/pubsub/pubsub_admin_websocket/src/pubsub_websocket_topic_receiver.c
+++ b/bundles/pubsub/pubsub_admin_websocket/src/pubsub_websocket_topic_receiver.c
@@ -173,7 +173,6 @@ pubsub_websocket_topic_receiver_t* pubsub_websocketTopicReceiver_create(celix_bu
         char buf[size+1];
         snprintf(buf, (size_t)size+1, "(%s=%s)", PUBSUB_SUBSCRIBER_TOPIC, topic);
         celix_service_tracking_options_t opts = CELIX_EMPTY_SERVICE_TRACKING_OPTIONS;
-        opts.filter.ignoreServiceLanguage = true;
         opts.filter.serviceName = PUBSUB_SUBSCRIBER_SERVICE_NAME;
         opts.filter.filter = buf;
         opts.callbackHandle = receiver;

--- a/bundles/pubsub/pubsub_admin_zmq/src/psa_activator.c
+++ b/bundles/pubsub/pubsub_admin_zmq/src/psa_activator.c
@@ -60,7 +60,6 @@ int psa_zmq_start(psa_zmq_activator_t *act, celix_bundle_context_t *ctx) {
     if (status == CELIX_SUCCESS) {
         celix_service_tracking_options_t opts = CELIX_EMPTY_SERVICE_TRACKING_OPTIONS;
         opts.filter.serviceName = PUBSUB_PROTOCOL_SERVICE_NAME;
-        opts.filter.ignoreServiceLanguage = true;
         opts.callbackHandle = act->admin;
         opts.addWithProperties = pubsub_zmqAdmin_addProtocolSvc;
         opts.removeWithProperties = pubsub_zmqAdmin_removeProtocolSvc;

--- a/bundles/pubsub/pubsub_admin_zmq/src/pubsub_zmq_topic_receiver.c
+++ b/bundles/pubsub/pubsub_admin_zmq/src/pubsub_zmq_topic_receiver.c
@@ -234,7 +234,6 @@ pubsub_zmq_topic_receiver_t* pubsub_zmqTopicReceiver_create(celix_bundle_context
         char buf[size+1];
         snprintf(buf, (size_t)size+1, "(%s=%s)", PUBSUB_SUBSCRIBER_TOPIC, topic);
         celix_service_tracking_options_t opts = CELIX_EMPTY_SERVICE_TRACKING_OPTIONS;
-        opts.filter.ignoreServiceLanguage = true;
         opts.filter.serviceName = PUBSUB_SUBSCRIBER_SERVICE_NAME;
         opts.filter.filter = buf;
         opts.callbackHandle = receiver;

--- a/bundles/pubsub/pubsub_spi/src/pubsub_interceptors_handler.c
+++ b/bundles/pubsub/pubsub_spi/src/pubsub_interceptors_handler.c
@@ -60,7 +60,6 @@ pubsub_interceptors_handler_t* pubsubInterceptorsHandler_create(celix_bundle_con
     // Create service tracker here, and not in the activator
     celix_service_tracking_options_t opts = CELIX_EMPTY_SERVICE_TRACKING_OPTIONS;
     opts.filter.serviceName = PUBSUB_INTERCEPTOR_SERVICE_NAME;
-    opts.filter.ignoreServiceLanguage = true;
     opts.callbackHandle = handler;
     opts.addWithProperties = pubsubInterceptorsHandler_addInterceptor;
     opts.removeWithProperties = pubsubInterceptorsHandler_removeInterceptor;

--- a/bundles/pubsub/pubsub_topology_manager/src/pstm_activator.c
+++ b/bundles/pubsub/pubsub_topology_manager/src/pstm_activator.c
@@ -79,7 +79,6 @@ static int pstm_start(pstm_activator_t *act, celix_bundle_context_t *ctx) {
         opts.removeWithProperties = pubsub_topologyManager_psaRemoved;
         opts.callbackHandle = act->manager;
         opts.filter.serviceName = PUBSUB_ADMIN_SERVICE_NAME;
-        opts.filter.ignoreServiceLanguage = true;
         act->pubsubAdminTrackerId = celix_bundleContext_trackServicesWithOptions(ctx, &opts);
     }
 
@@ -90,7 +89,6 @@ static int pstm_start(pstm_activator_t *act, celix_bundle_context_t *ctx) {
         opts.removeWithOwner = pubsub_topologyManager_subscriberRemoved;
         opts.callbackHandle = act->manager;
         opts.filter.serviceName = PUBSUB_SUBSCRIBER_SERVICE_NAME;
-        opts.filter.ignoreServiceLanguage = true;
         act->pubsubSubscribersTrackerId = celix_bundleContext_trackServicesWithOptions(ctx, &opts);
     }
 

--- a/bundles/pubsub/pubsub_utils/src/pubsub_matching.c
+++ b/bundles/pubsub/pubsub_utils/src/pubsub_matching.c
@@ -118,7 +118,6 @@ static long getPSProtocol(celix_bundle_context_t *ctx, const char *requested_pro
     } else {
         celix_service_filter_options_t opts = CELIX_EMPTY_SERVICE_FILTER_OPTIONS;
         opts.serviceName = PUBSUB_PROTOCOL_SERVICE_NAME;
-        opts.ignoreServiceLanguage = true;
 
         //note findService will automatically return the highest ranking service id
         svcId = celix_bundleContext_findServiceWithOptions(ctx, &opts);

--- a/bundles/remote_services/remote_service_admin_dfi/gtest/src/rsa_client_server_tests.cc
+++ b/bundles/remote_services/remote_service_admin_dfi/gtest/src/rsa_client_server_tests.cc
@@ -285,7 +285,6 @@ typedef struct rsa_dfi_exception_test_service {
         celix_service_use_options_t opts{};
         opts.filter.serviceName = RSA_DIF_EXCEPTION_TEST_SERVICE;
         opts.use = testExceptionServiceCallback;
-        opts.filter.ignoreServiceLanguage = true;
         opts.waitTimeoutInSeconds = 2;
         bool called = celix_bundleContext_useServiceWithOptions(clientContext, &opts);
         ASSERT_TRUE(called);
@@ -297,7 +296,6 @@ static void test(F&& f) {
     celix_service_use_options_t opts{};
     opts.filter.serviceName = TST_SERVICE_NAME;
     opts.use = f;
-    opts.filter.ignoreServiceLanguage = true;
     opts.waitTimeoutInSeconds = 2;
     bool called = celix_bundleContext_useServiceWithOptions(clientContext, &opts);
     ASSERT_TRUE(called);

--- a/bundles/remote_services/remote_service_admin_dfi/gtest/src/rsa_tests.cc
+++ b/bundles/remote_services/remote_service_admin_dfi/gtest/src/rsa_tests.cc
@@ -76,7 +76,6 @@ extern "C" {
         celix_service_use_options_t opts{};
         opts.filter.serviceName = OSGI_RSA_REMOTE_SERVICE_ADMIN;
         opts.use = testServicesCallback;
-        opts.filter.ignoreServiceLanguage = true;
         opts.waitTimeoutInSeconds = 0.25;
         bool called = celix_bundleContext_useServiceWithOptions(context, &opts);
         ASSERT_TRUE(called);
@@ -104,7 +103,6 @@ extern "C" {
         celix_service_use_options_t opts{};
         opts.filter.serviceName = OSGI_RSA_REMOTE_SERVICE_ADMIN;
         opts.use = testExportServiceCallback;
-        opts.filter.ignoreServiceLanguage = true;
         opts.waitTimeoutInSeconds = 0.25;
         bool called = celix_bundleContext_useServiceWithOptions(context, &opts);
         ASSERT_TRUE(called);
@@ -141,7 +139,6 @@ extern "C" {
         celix_service_use_options_t opts{};
         opts.filter.serviceName = OSGI_RSA_REMOTE_SERVICE_ADMIN;
         opts.use = testImportServiceCallback;
-        opts.filter.ignoreServiceLanguage = true;
         opts.waitTimeoutInSeconds = 0.25;
 
         //first call -> init

--- a/bundles/remote_services/remote_service_admin_dfi/gtest/src/tst_activator.c
+++ b/bundles/remote_services/remote_service_admin_dfi/gtest/src/tst_activator.c
@@ -347,7 +347,6 @@ static celix_status_t bndStart(struct activator *act, celix_bundle_context_t* ct
         opts.set = bndSetCalc;
         opts.callbackHandle = act;
         opts.filter.serviceName = CALCULATOR_SERVICE;
-        opts.filter.ignoreServiceLanguage = true;
         act->trackerId1 = celix_bundleContext_trackServicesWithOptions(ctx, &opts);
     }
     {
@@ -355,7 +354,6 @@ static celix_status_t bndStart(struct activator *act, celix_bundle_context_t* ct
         opts.set = bndSetRemoteExample;
         opts.callbackHandle = act;
         opts.filter.serviceName = REMOTE_EXAMPLE_NAME;
-        opts.filter.ignoreServiceLanguage = true;
         act->trackerId2 = celix_bundleContext_trackServicesWithOptions(ctx, &opts);
     }
 

--- a/bundles/remote_services/remote_service_admin_dfi/src/export_registration_dfi.c
+++ b/bundles/remote_services/remote_service_admin_dfi/src/export_registration_dfi.c
@@ -277,7 +277,6 @@ celix_status_t exportRegistration_start(export_registration_t *reg) {
     celix_service_tracking_options_t opts = CELIX_EMPTY_SERVICE_TRACKING_OPTIONS;
     opts.filter.filter = reg->filter;
     opts.filter.serviceName = "*";
-    opts.filter.ignoreServiceLanguage = true;
     opts.callbackHandle = reg;
     opts.add = exportRegistration_addServ;
     opts.remove = exportRegistration_removeServ;

--- a/bundles/remote_services/remote_service_admin_shm_v2/rsa_shm/src/rsa_shm_export_registration.c
+++ b/bundles/remote_services/remote_service_admin_shm_v2/rsa_shm/src/rsa_shm_export_registration.c
@@ -142,7 +142,6 @@ celix_status_t exportRegistration_create(celix_bundle_context_t *context,
     opts.filter.filter = filter;
     opts.filter.serviceName = RSA_RPC_FACTORY_NAME;
     opts.filter.versionRange = RSA_RPC_FACTORY_USE_RANGE;
-    opts.filter.ignoreServiceLanguage = true;
     opts.callbackHandle = export;
     opts.add = exportRegistration_addRpcFac;
     opts.remove = exportRegistration_removeRpcFac;

--- a/bundles/remote_services/rsa_common/src/remote_interceptors_handler.c
+++ b/bundles/remote_services/rsa_common/src/remote_interceptors_handler.c
@@ -65,7 +65,6 @@ celix_status_t remoteInterceptorsHandler_create(celix_bundle_context_t *ctx, rem
             // Create service tracker here, and not in the activator
             celix_service_tracking_options_t opts = CELIX_EMPTY_SERVICE_TRACKING_OPTIONS;
             opts.filter.serviceName = REMOTE_INTERCEPTOR_SERVICE_NAME;
-            opts.filter.ignoreServiceLanguage = true;
             opts.callbackHandle = *handler;
             opts.addWithProperties = remoteInterceptorsHandler_addInterceptor;
             opts.removeWithProperties = remoteInterceptorsHandler_removeInterceptor;

--- a/bundles/shell/shell/src/c_shell_activator.c
+++ b/bundles/shell/shell/src/c_shell_activator.c
@@ -105,7 +105,6 @@ celix_status_t celix_bundleActivator_start(void *activatorData, celix_bundle_con
         opts.callbackHandle = activator->shell;
         opts.addWithProperties = (void*) shell_addCommand;
         opts.removeWithProperties = (void*) shell_removeCommand;
-        opts.filter.ignoreServiceLanguage = true;
         opts.filter.serviceName = CELIX_SHELL_COMMAND_SERVICE_NAME;
         activator->trackerId = celix_bundleContext_trackServicesWithOptions(ctx, &opts);
     }

--- a/libs/framework/gtest/src/DependencyManagerTestSuite.cc
+++ b/libs/framework/gtest/src/DependencyManagerTestSuite.cc
@@ -404,7 +404,6 @@ TEST_F(DependencyManagerTestSuite, BuildSvcProvide) {
 
     opts.serviceName = "TestService";
     opts.filter = "(key1=value)";
-    opts.ignoreServiceLanguage = true;
     svcId = celix_bundleContext_findServiceWithOptions(ctx, &opts);
     EXPECT_GT(svcId, -1); //found, so properties present
 
@@ -575,7 +574,6 @@ TEST_F(DependencyManagerTestSuite, RequiredDepsAreInjectedDuringStartStop) {
     celix_service_registration_options opts{};
     opts.svc = &svc;
     opts.serviceName = svcName.c_str();
-    opts.serviceLanguage = CELIX_FRAMEWORK_SERVICE_CXX_LANGUAGE;
     long svcId = celix_bundleContext_registerServiceWithOptions(dm.bundleContext(), &opts);
     EXPECT_GE(svcId, 0);
 
@@ -867,7 +865,6 @@ TEST_F(DependencyManagerTestSuite, DepsAreInjectedAsSharedPointers) {
     celix_service_registration_options opts{};
     opts.svc = &svc;
     opts.serviceName = svcName.c_str();
-    opts.serviceLanguage = CELIX_FRAMEWORK_SERVICE_CXX_LANGUAGE;
     long svcId = celix_bundleContext_registerServiceWithOptions(dm.bundleContext(), &opts);
     EXPECT_GE(svcId, 0);
 
@@ -929,7 +926,6 @@ TEST_F(DependencyManagerTestSuite, DepsNoPropsAreInjectedAsSharedPointers) {
     celix_service_registration_options opts{};
     opts.svc = &svc;
     opts.serviceName = svcName.c_str();
-    opts.serviceLanguage = CELIX_FRAMEWORK_SERVICE_CXX_LANGUAGE;
     long svcId = celix_bundleContext_registerServiceWithOptions(dm.bundleContext(), &opts);
     EXPECT_GE(svcId, 0);
 
@@ -987,7 +983,6 @@ TEST_F(DependencyManagerTestSuite, UnneededSuspendIsPrevented) {
     celix_service_registration_options opts{};
     opts.svc = &svc;
     opts.serviceName = svcName.c_str();
-    opts.serviceLanguage = CELIX_FRAMEWORK_SERVICE_CXX_LANGUAGE;
     long svcId = celix_bundleContext_registerServiceWithOptions(dm.bundleContext(), &opts);
     EXPECT_GE(svcId, 0);
 

--- a/libs/framework/include/celix/UseServiceBuilder.h
+++ b/libs/framework/include/celix/UseServiceBuilder.h
@@ -146,7 +146,6 @@ namespace celix {
         std::size_t build() {
             celix_service_use_options_t opts{};
             opts.filter.serviceName = name.empty() ? nullptr : name.c_str();
-            opts.filter.ignoreServiceLanguage = true;
             opts.filter.filter = filter.empty() ? nullptr : filter.getFilterCString();
             opts.filter.versionRange = versionRange.empty() ? nullptr : versionRange.c_str();
             opts.waitTimeoutInSeconds = timeoutInSeconds;

--- a/libs/framework/include/celix/dm/ServiceDependency.h
+++ b/libs/framework/include/celix/dm/ServiceDependency.h
@@ -221,12 +221,6 @@ namespace celix { namespace dm {
         );
 
         /**
-         * Specify if the service dependency should add a service.lang filter part if it is not already present
-         * For C service dependencies 'service.lang=C' will be added.
-         */
-        CServiceDependency<T,I>& setAddLanguageFilter(bool addLang);
-
-        /**
          * "Build" the service dependency.
          * When build the service dependency is active and the service tracker is created.
          *
@@ -421,16 +415,6 @@ namespace celix { namespace dm {
          * @return the service dependency reference for chaining (fluent API)
          */
         ServiceDependency<T,I>& setStrategy(DependencyUpdateStrategy strategy);
-
-        /**
-         * Specify if the service dependency should add a service.lang filter part if it is not already present
-         * For C++ service dependencies 'service.lang=C++' will be added.
-         * Should be called before
-         *
-         * @return the service dependency reference for chaining (fluent API)
-         */
-        ServiceDependency<T,I>& setAddLanguageFilter(bool addLang);
-
 
         /**
          * "Build" the service dependency.

--- a/libs/framework/include/celix/dm/ServiceDependency_Impl.h
+++ b/libs/framework/include/celix/dm/ServiceDependency_Impl.h
@@ -113,13 +113,6 @@ void CServiceDependency<T,I>::setupService() {
 }
 
 template<class T, typename I>
-CServiceDependency<T,I>& CServiceDependency<T,I>::setAddLanguageFilter(bool addLang) {
-    celix_serviceDependency_setAddCLanguageFilter(this->cServiceDependency(), addLang);
-    this->setupService();
-    return *this;
-}
-
-template<class T, typename I>
 CServiceDependency<T,I>& CServiceDependency<T,I>::setRequired(bool req) {
     celix_dmServiceDependency_setRequired(this->cServiceDependency(), req);
     return *this;
@@ -306,14 +299,6 @@ ServiceDependency<T,I>& ServiceDependency<T,I>::setFilter(const std::string &_fi
 template<class T, class I>
 ServiceDependency<T,I>& ServiceDependency<T,I>::setVersionRange(const std::string &_versionRange) {
     versionRange = _versionRange;
-    setupService();
-    return *this;
-}
-
-
-template<class T, class I>
-ServiceDependency<T,I>& ServiceDependency<T,I>::setAddLanguageFilter(bool addLang) {
-    this->addCxxLanguageFilter = addLang;
     setupService();
     return *this;
 }

--- a/libs/framework/include/celix_bundle_context.h
+++ b/libs/framework/include/celix_bundle_context.h
@@ -170,13 +170,6 @@ typedef struct celix_service_registration_options {
     celix_properties_t *properties CELIX_OPTS_INIT;
 
     /**
-     * @brief The optional service language.
-     *
-     * If this is NULL, CELIX_FRAMEWORK_SERVICE_LANGUAGE_C is used.
-     */
-    const char* serviceLanguage CELIX_OPTS_INIT;
-
-    /**
      * @brief The optional service version (in the form of <MAJOR>.<MINOR>.<MICRO>.<QUALIFIER>).
      *
      * If present consumer of the service can specific which service version range of
@@ -212,7 +205,6 @@ typedef struct celix_service_registration_options {
     .factory = NULL, \
     .serviceName = NULL, \
     .properties = NULL, \
-    .serviceLanguage = NULL, \
     .serviceVersion = NULL, \
     .asyncData = NULL, \
     .asyncCallback = NULL }
@@ -373,26 +365,13 @@ typedef struct celix_service_filter_options {
      * The filter will be applied to all the user provided and framework provided service properties.
      */
     const char* filter CELIX_OPTS_INIT;
-
-    /**
-     * @deprecated This value is not used any more. If a service language filter is still required add it to the
-     * filter.
-     */
-    const char* serviceLanguage CELIX_OPTS_INIT;
-
-
-    /**
-     * @deprecated This value is not used any more. If a service language filter is still required add it to the
-     * filter.
-     */
-    bool ignoreServiceLanguage CELIX_OPTS_INIT;
 } celix_service_filter_options_t;
 
 #ifndef __cplusplus
 /*!
  * @brief C Macro to create a empty celix_service_filter_options_t type.
  */
-#define CELIX_EMPTY_SERVICE_FILTER_OPTIONS {.serviceName = NULL, .versionRange = NULL, .filter = NULL, .serviceLanguage = NULL, .ignoreServiceLanguage = false}
+#define CELIX_EMPTY_SERVICE_FILTER_OPTIONS {.serviceName = NULL, .versionRange = NULL, .filter = NULL}
 #endif
 
 /**
@@ -602,8 +581,6 @@ typedef struct celix_service_tracking_options {
 #define CELIX_EMPTY_SERVICE_TRACKING_OPTIONS { .filter.serviceName = NULL, \
     .filter.versionRange = NULL, \
     .filter.filter = NULL, \
-    .filter.serviceLanguage = NULL, \
-    .filter.ignoreServiceLanguage = false, \
     .callbackHandle = NULL, \
     .set = NULL, \
     .add = NULL, \
@@ -820,7 +797,6 @@ typedef struct celix_service_use_options {
 #define CELIX_EMPTY_SERVICE_USE_OPTIONS {.filter.serviceName = NULL, \
     .filter.versionRange = NULL, \
     .filter.filter = NULL, \
-    .filter.serviceLanguage = NULL, \
     .waitTimeoutInSeconds = 0.0F, \
     .callbackHandle = NULL, \
     .use = NULL, \
@@ -1187,7 +1163,7 @@ CELIX_FRAMEWORK_EXPORT size_t celix_bundleContext_useBundles(
  */
 typedef struct celix_service_tracker_info {
     /**
-     * @brief The parsed service filter, e.g. parsed "(&(objectClass=example_calc)(service.language=C)(meta.info=foo))"
+     * @brief The parsed service filter, e.g. parsed "(&(objectClass=example_calc)(meta.info=foo))"
      */
     celix_filter_t *filter;
 
@@ -1195,12 +1171,6 @@ typedef struct celix_service_tracker_info {
      * @brief The service name filter attribute parsed from the service filter (i.e. the value of the objectClass attribute key)
      */
     const char* serviceName;
-
-    /**
-     * @deprecated
-     * Deprecated. the value will be NULL.
-     */
-    const char* serviceLanguage;
 
     /**
      * @brief Bundle id of the owner of the service tracker.

--- a/libs/framework/include/celix_constants.h
+++ b/libs/framework/include/celix_constants.h
@@ -118,14 +118,6 @@ extern "C" {
  */
 #define CELIX_FRAMEWORK_SERVICE_VERSION "service.version"
 
-/**
- * The service language property and values are deprecated
- */
-#define CELIX_FRAMEWORK_SERVICE_LANGUAGE "service.lang"
-#define CELIX_FRAMEWORK_SERVICE_C_LANGUAGE "C"
-#define CELIX_FRAMEWORK_SERVICE_CXX_LANGUAGE "C++"
-#define CELIX_FRAMEWORK_SERVICE_SHARED_LANGUAGE "shared" //e.g. marker services
-
 #define CELIX_FRAMEWORK_BUNDLE_ACTIVATOR "Bundle-Activator"
 #define OSGI_FRAMEWORK_BUNDLE_ACTIVATOR CELIX_FRAMEWORK_BUNDLE_ACTIVATOR
 

--- a/libs/framework/include/celix_dm_service_dependency.h
+++ b/libs/framework/include/celix_dm_service_dependency.h
@@ -87,12 +87,6 @@ CELIX_FRAMEWORK_EXPORT void celix_dmServiceDependency_destroy(celix_dm_service_d
 CELIX_FRAMEWORK_EXPORT celix_status_t celix_dmServiceDependency_setRequired(celix_dm_service_dependency_t *dependency, bool required);
 
 /**
- * Specify if the service dependency should add a C language filter for this dependency if no "service.lang" part is found the in the provided filter.
- * Default is false
- */
-CELIX_FRAMEWORK_DEPRECATED_EXPORT celix_status_t celix_dmServiceDependency_setAddCLanguageFilter(celix_dm_service_dependency_t *dependency, bool addCLangFilter);
-
-/**
  * Specify if the service dependency update strategy.
  *
  * The DM_SERVICE_DEPENDENCY_STRATEGY_LOCKING strategy notifies the component in case the dependencies set

--- a/libs/framework/include_deprecated/dm_service_dependency.h
+++ b/libs/framework/include_deprecated/dm_service_dependency.h
@@ -76,12 +76,6 @@ CELIX_FRAMEWORK_DEPRECATED_EXPORT celix_status_t serviceDependency_destroy(celix
 CELIX_FRAMEWORK_DEPRECATED_EXPORT celix_status_t serviceDependency_setRequired(celix_dm_service_dependency_t *dependency, bool required);
 
 /**
- * Specify if the service dependency should add a C language filter for this dependency if no "service.lang" part is found the in the provided filter.
- * Default is false
- */
-CELIX_FRAMEWORK_DEPRECATED_EXPORT celix_status_t serviceDependency_setAddCLanguageFilter(celix_dm_service_dependency_t *dependency, bool addCLangFilter);
-
-/**
  * Specify if the service dependency update strategy.
  *
  * The DM_SERVICE_DEPENDENCY_STRATEGY_LOCKING strategy notifies the component in case the dependencies set

--- a/libs/framework/include_deprecated/service_registry.h
+++ b/libs/framework/include_deprecated/service_registry.h
@@ -140,8 +140,6 @@ CELIX_FRAMEWORK_EXPORT void celix_serviceRegistry_unregisterService(celix_servic
  * @param serviceName       The optional service name
  * @param versionRange      The optional version range
  * @param filter            The optional filter
- * @param serviceLanguage   The optional service lang. if NULL, lang C will be used.
- * @param ignoreServiceLanguage   The whether the service lang filter needs to be added to the filter.
  * @return a LDAP filter. Caller is responsible for freeing the filter.
  */
 CELIX_FRAMEWORK_EXPORT char* celix_serviceRegistry_createFilterFor(

--- a/libs/framework/src/dm_component_impl.c
+++ b/libs/framework/src/dm_component_impl.c
@@ -906,7 +906,6 @@ static celix_status_t celix_dmComponent_registerServices(celix_dm_component_t *c
             opts.properties = regProps;
             opts.svc = (void*)interface->service;
             opts.serviceName = interface->serviceName;
-            opts.serviceLanguage = celix_properties_get(regProps, CELIX_FRAMEWORK_SERVICE_LANGUAGE, NULL);
             celix_bundleContext_log(component->context, CELIX_LOG_LEVEL_TRACE,
                    "Async registering service %s for component %s (uuid=%s)",
                    interface->serviceName,

--- a/libs/framework/src/dm_service_dependency_impl.h
+++ b/libs/framework/src/dm_service_dependency_impl.h
@@ -35,32 +35,31 @@ extern "C" {
 #include "dm_component.h"
 
 struct celix_dm_service_dependency_svc_entry {
-    void *svc;
+    void* svc;
     const celix_properties_t* props;
 };
 
 struct celix_dm_service_dependency {
-	celix_dm_service_update_fp set;
-	celix_dm_service_update_fp add;
-	celix_dm_service_update_fp remove;
+    celix_dm_service_update_fp set;
+    celix_dm_service_update_fp add;
+    celix_dm_service_update_fp remove;
 
-	celix_dm_service_update_with_props_fp setWithProperties;
-	celix_dm_service_update_with_props_fp addWithProperties;
-	celix_dm_service_update_with_props_fp remWithProperties;
+    celix_dm_service_update_with_props_fp setWithProperties;
+    celix_dm_service_update_with_props_fp addWithProperties;
+    celix_dm_service_update_with_props_fp remWithProperties;
 
-	char *serviceName;
-    char *filter;
-    char *versionRange;
+    char* serviceName;
+    char* filter;
+    char* versionRange;
     bool required;
     dm_service_dependency_strategy_t strategy;
-    bool addCLanguageFilter;
-    celix_dm_component_t *component;
+    celix_dm_component_t* component;
 
-    celix_thread_mutex_t mutex; //protects below
-    long svcTrackerId; //active tracker id
-    size_t nrOfActiveStoppingTrackers; //nr of async stop tracker still active (should be 0 or 1)
+    celix_thread_mutex_t mutex;        // protects below
+    long svcTrackerId;                 // active tracker id
+    size_t nrOfActiveStoppingTrackers; // nr of async stop tracker still active (should be 0 or 1)
     size_t trackedSvcCount;
-    void* callbackHandle; //This handle can be set to be used instead of the component implementation
+    void* callbackHandle; // This handle can be set to be used instead of the component implementation
 };
 
 celix_status_t celix_dmServiceDependency_enable(celix_dm_service_dependency_t *dependency);


### PR DESCRIPTION
Remove support for the "service.lang" service property and its usage. 

The idea behind the "service.lang" property was to distinguish between C or C++ services, but this feature was confusion 
and with a good service naming convention not needed.  
