### PR TITLE
Hotfix/conan macos

### DIFF
--- a/.github/workflows/conan_create.yml
+++ b/.github/workflows/conan_create.yml
@@ -84,20 +84,19 @@ jobs:
       - name: Install build dependencies
         run: |
           brew install python ninja
-          pip3 install -U conan==1.61.0
+          pip3 install -U conan
       - name: Setup Conan Profile
         run: |
-          conan profile new default --detect
-          conan profile update settings.build_type=Release default
+          conan profile detect -f
       - name: Conan Cache
         id: cache-conan
         uses: actions/cache@v3
         env:
-          cache-name: cache-conan-modules
+          cache-name: cache-conan2-modules
         with:
-          path: ${{ env.CONAN_USER_HOME }}
-          key: ${{ runner.os }}-builder-${{ env.cache-name }}-${{ hashFiles('conanfile.py') }}
-          restore-keys: ${{ runner.os }}-builder-${{ env.cache-name }}-
+          path: ${{ env.CONAN_HOME }}
+          key: ${{ runner.os }}-builder-${{ env.cache-name }}-Release-${{ hashFiles('conanfile.py') }}
+          restore-keys: ${{ runner.os }}-builder-${{ env.cache-name }}-Release-
       - name: Prepare ccache timestamp
         id: ccache_cache_timestamp
         run: |
@@ -111,10 +110,10 @@ jobs:
             ${{ runner.os }}-ccache-Release-
       - name: Create Celix
         run: |
-          conan create . -c tools.cmake.cmaketoolchain:generator=Ninja -b missing -o celix:build_all=True  -o celix:enable_ccache=True -pr:b default -pr:h default -tf examples/conan_test_package -tbf test-build -o celix:celix_cxx17=True -o celix:celix_install_deprecated_api=True --require-override=libcurl/7.64.1 --require-override=openssl/1.1.1s --require-override=zlib/1.2.13
+          conan create . -c tools.cmake.cmaketoolchain:generator=Ninja -b missing -o celix/*:build_all=True  -o celix/*:enable_ccache=True -pr:b default -pr:h default -s:b build_type=Release -s:h build_type=Release -tf examples/conan_test_package_v2 -o celix/*:celix_cxx17=True -o celix/*:celix_install_deprecated_api=True
       - name: Dependency Deduction Test
         run: |
-          conan inspect . -a options | awk 'BEGIN { FS="[\t:]+" } /build/ && !/build_all/ { print $1}' | while read option; do conan install . -c tools.cmake.cmaketoolchain:generator=Ninja -b missing -o celix:${option}=True  -pr:b default -pr:h default -if ${option}_dir -o celix:celix_cxx17=True -o celix:celix_install_deprecated_api=True -o celix:enable_ccache=True --require-override=libcurl/7.64.1 --require-override=openssl/1.1.1s --require-override=zlib/1.2.13 || exit 1; conan build . -bf ${option}_dir || exit 1; done
+          conan inspect .  | awk 'BEGIN { FS="[\t:]+"; output=0 } /build/ && !/build_all/ { if(output) print $1} /^options/ {output=1} /^options_definitions/ {output=0}' | while read option; do conan build . -c tools.cmake.cmaketoolchain:generator=Ninja -b missing -o celix/*:${option}=True  -pr:b default -pr:h default -s:b build_type=Release -s:h build_type=Release -of  ${option}_dir -o celix/*:celix_cxx17=True -o celix/*:enable_ccache=True -o celix/*:celix_install_deprecated_api=True || exit 1; done
       - name: Remove Celix
         run: |
           conan remove -f 'celix/*'

--- a/.github/workflows/conan_create.yml
+++ b/.github/workflows/conan_create.yml
@@ -84,7 +84,7 @@ jobs:
       - name: Install build dependencies
         run: |
           brew install python ninja
-          pip3 install -U conan==1.59.0
+          pip3 install -U conan==1.61.0
       - name: Setup Conan Profile
         run: |
           conan profile new default --detect

--- a/.github/workflows/conan_create.yml
+++ b/.github/workflows/conan_create.yml
@@ -113,7 +113,7 @@ jobs:
           conan create . -c tools.cmake.cmaketoolchain:generator=Ninja -b missing -o celix/*:build_all=True  -o celix/*:enable_ccache=True -pr:b default -pr:h default -s:b build_type=Release -s:h build_type=Release -tf examples/conan_test_package_v2 -o celix/*:celix_cxx17=True -o celix/*:celix_install_deprecated_api=True
       - name: Dependency Deduction Test
         run: |
-          conan inspect .  | awk 'BEGIN { FS="[\t:]+"; output=0 } /build/ && !/build_all/ { if(output) print $1} /^options/ {output=1} /^options_definitions/ {output=0}' | while read option; do conan build . -c tools.cmake.cmaketoolchain:generator=Ninja -b missing -o celix/*:${option}=True  -pr:b default -pr:h default -s:b build_type=Release -s:h build_type=Release -of  ${option}_dir -o celix/*:celix_cxx17=True -o celix/*:enable_ccache=True -o celix/*:celix_install_deprecated_api=True || exit 1; done
+          conan inspect .  | awk 'BEGIN { FS="[\t:]+"; output=0 } /build/ && !/build_all/ && !/build_rsa_remote_service_admin_shm_v2/ && !/build_rsa_discovery_zeroconf/ { if(output) print $1} /^options/ {output=1} /^options_definitions/ {output=0}' | while read option; do conan build . -c tools.cmake.cmaketoolchain:generator=Ninja -b missing -o celix/*:${option}=True  -pr:b default -pr:h default -s:b build_type=Release -s:h build_type=Release -of  ${option}_dir -o celix/*:celix_cxx17=True -o celix/*:enable_ccache=True -o celix/*:celix_install_deprecated_api=True || exit 1; done
       - name: Remove Celix
         run: |
           conan remove -f 'celix/*'

--- a/.github/workflows/conan_create.yml
+++ b/.github/workflows/conan_create.yml
@@ -116,4 +116,4 @@ jobs:
           conan inspect .  | awk 'BEGIN { FS="[\t:]+"; output=0 } /build/ && !/build_all/ && !/build_rsa_remote_service_admin_shm_v2/ && !/build_rsa_discovery_zeroconf/ { if(output) print $1} /^options/ {output=1} /^options_definitions/ {output=0}' | while read option; do conan build . -c tools.cmake.cmaketoolchain:generator=Ninja -b missing -o celix/*:${option}=True  -pr:b default -pr:h default -s:b build_type=Release -s:h build_type=Release -of  ${option}_dir -o celix/*:celix_cxx17=True -o celix/*:enable_ccache=True -o celix/*:celix_install_deprecated_api=True || exit 1; done
       - name: Remove Celix
         run: |
-          conan remove -f 'celix/*'
+          conan remove -c celix/* 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -60,7 +60,7 @@ jobs:
             -o celix/*:enable_ccache=True
         run: |
           #force require libcurl 7.64.1, due to a sha256 verify issue in libcurl/7.87.0
-          conan build . celix/ci -c tools.cmake.cmaketoolchain:generator=Ninja -pr:b default -pr:h default -s:b build_type=Release -s:h build_type=Release -of build ${CONAN_BUILD_OPTIONS} -b missing -b cpputest
+          conan build .  -c tools.cmake.cmaketoolchain:generator=Ninja -pr:b default -pr:h default -s:b build_type=Release -s:h build_type=Release -of build ${CONAN_BUILD_OPTIONS} -b missing -b cpputest
       - name: Test
         run: |
           cd build

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -24,20 +24,19 @@ jobs:
       - name: Install conan
         run: |
           brew install python ninja
-          pip3 install -U conan==1.61.0
+          pip3 install -U conan
       - name: Setup Conan Profile
         run: |
-          conan profile new default --detect
-          conan profile update settings.build_type=Release default
+          conan profile detect -f
       - name: Conan Cache
         id: cache-conan
         uses: actions/cache@v3
         env:
-          cache-name: cache-conan-modules
+          cache-name: cache-conan2-modules
         with:
-          path: ${{ env.CONAN_USER_HOME }}
-          key: ${{ runner.os }}-test-builder-${{ env.cache-name }}-${{ hashFiles('conanfile.py') }}
-          restore-keys: ${{ runner.os }}-test-builder-${{ env.cache-name }}-
+          path: ${{ env.CONAN_HOME }}
+          key: ${{ runner.os }}-test-builder-${{ env.cache-name }}-Release-${{ hashFiles('conanfile.py') }}
+          restore-keys: ${{ runner.os }}-test-builder-${{ env.cache-name }}-Release-
       - name: Prepare ccache timestamp
         id: ccache_cache_timestamp
         run: |
@@ -49,23 +48,19 @@ jobs:
           key: ${{ runner.os }}-test-ccache-Release-${{ steps.ccache_cache_timestamp.outputs.timestamp }}
           restore-keys: |
             ${{ runner.os }}-test-ccache-Release-
-      - name: Install Dependencies
+      - name: Install Dependencies and Build
         env:
           CONAN_BUILD_OPTIONS: |
-            -o celix:enable_testing=True
-            -o celix:enable_address_sanitizer=True
-            -o celix:build_all=True
-            -o celix:enable_cmake_warning_tests=True
-            -o celix:enable_testing_on_ci=True
-            -o celix:framework_curlinit=False
-            -o celix:enable_ccache=True
+            -o celix/*:enable_testing=True
+            -o celix/*:enable_address_sanitizer=True
+            -o celix/*:build_all=True
+            -o celix/*:enable_cmake_warning_tests=True
+            -o celix/*:enable_testing_on_ci=True
+            -o celix/*:framework_curlinit=False
+            -o celix/*:enable_ccache=True
         run: |
           #force require libcurl 7.64.1, due to a sha256 verify issue in libcurl/7.87.0
-          conan install . celix/ci -c tools.cmake.cmaketoolchain:generator=Ninja -pr:b default -pr:h default -if build ${CONAN_BUILD_OPTIONS} -b missing -b cpputest --require-override=libcurl/7.64.1 --require-override=openssl/1.1.1s
-      - name: Build
-        run: |
-          conan build . -bf build
-
+          conan build . celix/ci -c tools.cmake.cmaketoolchain:generator=Ninja -pr:b default -pr:h default -s:b build_type=Release -s:h build_type=Release -of build ${CONAN_BUILD_OPTIONS} -b missing -b cpputest
       - name: Test
         run: |
           cd build

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install conan
         run: |
           brew install python ninja
-          pip3 install -U conan==1.59.0
+          pip3 install -U conan==1.61.0
       - name: Setup Conan Profile
         run: |
           conan profile new default --detect


### PR DESCRIPTION
Conan for all macOS build is upgraded to Conan2 to fix https://github.com/apache/celix/actions/runs/6739579802/job/18322834602

```
Run brew install python ninja
Warning: python@3.11 3.11.6 is already installed and up-to-date.
To reinstall 3.11.6, run:
  brew reinstall python@3.11
Warning: ninja 1.11.1 is already installed and up-to-date.
To reinstall 1.11.1, run:
  brew reinstall ninja
Collecting conan==1.59.0
  Downloading conan-1.59.0.tar.gz (780 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 781.0/781.0 kB 7.4 MB/s eta 0:00:00
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'done'
  Preparing metadata (pyproject.toml): started
  Preparing metadata (pyproject.toml): finished with status 'done'
Collecting requests<3.0.0,>=2.25 (from conan==1.59.0)
  Downloading requests-2.31.0-py3-none-any.whl.metadata (4.6 kB)
Collecting urllib3<1.27,>=1.26.6 (from conan==1.59.0)
  Downloading urllib3-1.26.18-py2.py3-none-any.whl.metadata (48 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 48.9/48.9 kB 6.7 MB/s eta 0:00:00
Collecting colorama<0.5.0,>=0.3.3 (from conan==1.59.0)
  Downloading colorama-0.4.6-py2.py3-none-any.whl (25 kB)
Collecting PyYAML<=6.0,>=3.11 (from conan==1.59.0)
  Downloading PyYAML-6.0.tar.gz (124 kB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 125.0/125.0 kB 9.0 MB/s eta 0:00:00
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'error'
  error: subprocess-exited-with-error
  
  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [54 lines of output]
      running egg_info
      writing lib/PyYAML.egg-info/PKG-INFO
      writing dependency_links to lib/PyYAML.egg-info/dependency_links.txt
      writing top-level names to lib/PyYAML.egg-info/top_level.txt
      Traceback (most recent call last):
        File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
          main()
        File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 335, in main
          json_out['return_val'] = hook(**hook_input['kwargs'])
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 118, in get_requires_for_build_wheel
          return hook(config_settings)
                 ^^^^^^^^^^^^^^^^^^^^^
        File "/private/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/pip-build-env-7ihjyex2/overlay/lib/python3.12/site-packages/setuptools/build_meta.py", line 355, in get_requires_for_build_wheel
          return self._get_build_requires(config_settings, requirements=['wheel'])
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/private/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/pip-build-env-7ihjyex2/overlay/lib/python3.12/site-packages/setuptools/build_meta.py", line 325, in _get_build_requires
          self.run_setup()
        File "/private/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/pip-build-env-7ihjyex2/overlay/lib/python3.12/site-packages/setuptools/build_meta.py", line 341, in run_setup
          exec(code, locals())
        File "<string>", line 288, in <module>
        File "/private/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/pip-build-env-7ihjyex2/overlay/lib/python3.12/site-packages/setuptools/__init__.py", line 103, in setup
          return distutils.core.setup(**attrs)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/private/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/pip-build-env-7ihjyex2/overlay/lib/python3.12/site-packages/setuptools/_distutils/core.py", line 185, in setup
          return run_commands(dist)
                 ^^^^^^^^^^^^^^^^^^
        File "/private/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/pip-build-env-7ihjyex2/overlay/lib/python3.12/site-packages/setuptools/_distutils/core.py", line 201, in run_commands
          dist.run_commands()
        File "/private/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/pip-build-env-7ihjyex2/overlay/lib/python3.12/site-packages/setuptools/_distutils/dist.py", line 969, in run_commands
          self.run_command(cmd)
        File "/private/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/pip-build-env-7ihjyex2/overlay/lib/python3.12/site-packages/setuptools/dist.py", line 989, in run_command
          super().run_command(command)
        File "/private/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/pip-build-env-7ihjyex2/overlay/lib/python3.12/site-packages/setuptools/_distutils/dist.py", line 988, in run_command
          cmd_obj.run()
        File "/private/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/pip-build-env-7ihjyex2/overlay/lib/python3.12/site-packages/setuptools/command/egg_info.py", line 318, in run
          self.find_sources()
        File "/private/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/pip-build-env-7ihjyex2/overlay/lib/python3.12/site-packages/setuptools/command/egg_info.py", line 326, in find_sources
          mm.run()
        File "/private/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/pip-build-env-7ihjyex2/overlay/lib/python3.12/site-packages/setuptools/command/egg_info.py", line 548, in run
          self.add_defaults()
        File "/private/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/pip-build-env-7ihjyex2/overlay/lib/python3.12/site-packages/setuptools/command/egg_info.py", line 586, in add_defaults
          sdist.add_defaults(self)
        File "/private/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/pip-build-env-7ihjyex2/overlay/lib/python3.12/site-packages/setuptools/command/sdist.py", line 113, in add_defaults
          super().add_defaults()
        File "/private/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/pip-build-env-7ihjyex2/overlay/lib/python3.12/site-packages/setuptools/_distutils/command/sdist.py", line 251, in add_defaults
          self._add_defaults_ext()
        File "/private/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/pip-build-env-7ihjyex2/overlay/lib/python3.12/site-packages/setuptools/_distutils/command/sdist.py", line 336, in _add_defaults_ext
          self.filelist.extend(build_ext.get_source_files())
                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "<string>", line 204, in get_source_files
        File "/private/var/folders/24/8k48jl6d249_n_qfxwsl6xvm0000gn/T/pip-build-env-7ihjyex2/overlay/lib/python3.12/site-packages/setuptools/_distutils/cmd.py", line 107, in __getattr__
          raise AttributeError(attr)
      AttributeError: cython_sources
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error

× Getting requirements to build wheel did not run successfully.
│ exit code: 1
╰─> See above for output.

note: This error originates from a subprocess, and is likely not a problem with pip.
Error: Process completed with exit code 1.
```