### PR TITLE
Feature/674 use properties type in filter

### DIFF
--- a/documents/services.md
+++ b/documents/services.md
@@ -37,6 +37,45 @@ Also note that for Celix - in contrast with Java OSGi - it is only possible to r
 per service registration in the Apache Celix Framework. This restriction was added because C does not 
 (natively) supports multiple interfaces (struct with function pointers) on a single object/pointer.  
 
+## Service Properties
+As mentioned, a service is always registered with a set of properties (metadata). 
+The service properties are represented as a `celix_properties_t` for C and as a `celix::Properties` for C++.
+Service properties are used to classify and select services.
+
+Apache Celix properties store key/value pairs and the key is always a string, but the value can be a string,
+a long, a double, a bool or `celix_version_t` (`celix::Version` for C++). Next to the actual typed value a property
+entry always stores a string representation of the value.
+
+The following C functions can be used to create and manipulate properties:
+- `celix_properties_create` - Create a new properties object.
+- `celix_properties_destroy` - Destroy a properties object.
+- `celix_properties_set` - Set a string property value.
+- `celix_properties_setLong` - Set a long property value.
+- `celix_properties_setDouble` - Set a double property value.
+- `celix_properties_setBool` - Set a bool property value.
+- `celix_properties_setVersion` - Set a version property value.
+- `celix_properties_get` - Get a string or string representation of the property value.
+- `celix_properties_getAsLong` - Get a long property value or string value parsed as long.
+- `celix_properties_getAsDouble` - Get a double property value or string value parsed as double.
+- `celix_properties_getAsBool` - Get a bool property value or string value parsed as bool.
+- `celix_properties_getAsVersion` - Get a version property value or string value parsed as version.
+
+The following C++ methods can be used to create and manipulate properties:
+- `celix::Properties::Properties` - Construct a new properties object.
+- `celix::Properties::set` - Set a string property value. Uses template argument deduction to determine the type.
+- `celix::Properties::get` - Get a string or string representation of the property value.
+- `celix::Properties::getAsLong` - Get a long property value or string value parsed as long.
+- `celix::Properties::getAsDouble` - Get a double property value or string value parsed as double.
+- `celix::Properties::getAsBool` - Get a bool property value or string value parsed as bool.
+- `celix::Properties::getAsVersion` - Get a version property value or string value parsed as version.
+
+The following service properties are set by the Celix framework when registering a service:
+- `objectClass` - The service name.
+- `service.id` - The service id (long).
+- `service.bundleid` - The bundle id (long) of the bundle registering the service.
+- `service.scope` - The service scope (string, "singleton", "prototype" or "bundle").
+- `service.version` - The service version (celix_version_t), if provided by the user.
+
 ## A C service example
 As mentioned an Apache Celix C service is a registered pointer to a struct with function pointers. 
 This struct ideally contains a handle pointer, a set of function pointers and should be well documented to
@@ -358,9 +397,16 @@ Services can be used directly using the bundle context C functions or C++ method
 - `celix::BundleContext::useService`
 - `celix::BundleContext::useServices`
 
-These functions and methods work by providing a callback function which will be called by the Celix framework with the 
-matching service or services.
-when a "use service" function/method returns the callback function can can be safely deallocated. 
+These functions and methods work by providing a serviceName, optional filter and callback function which will be 
+called by the Celix framework with the matching service or services.
+
+An Apache Celix filter is an [LDAP filter](https://tools.ietf.org/html/rfc4515) and can be used to select services based
+on their properties.
+The filter can be provided as a string and the Celix framework will parse the string to a `celix_filter_t` or (for C++)
+a `celix::Filter` object. For example the filter `(command.name=my_command)` will match all services with a
+`command.name` property with value `my_command`.
+
+When a "use service" function/method returns the callback function can can be safely deallocated. 
 A "use service" function/method return value will indicate if a matching service is found or how many matching services 
 are found.
 

--- a/documents/services.md
+++ b/documents/services.md
@@ -58,7 +58,10 @@ The following C functions can be used to create and manipulate properties:
 - `celix_properties_getAsLong` - Get a long property value or string value parsed as long.
 - `celix_properties_getAsDouble` - Get a double property value or string value parsed as double.
 - `celix_properties_getAsBool` - Get a bool property value or string value parsed as bool.
-- `celix_properties_getAsVersion` - Get a version property value or string value parsed as version.
+- `celix_properties_getVersion` - Get a pointer to the version property if the property value is a version or was
+                                  parsable as a version. Note there is also a `celix_properties_getAsVersion` 
+                                  function which return a new version object, but this is less efficient and
+                                  requires a memory allocation.
 
 The following C++ methods can be used to create and manipulate properties:
 - `celix::Properties::Properties` - Construct a new properties object.

--- a/libs/error_injector/stdio/CMakeLists.txt
+++ b/libs/error_injector/stdio/CMakeLists.txt
@@ -30,5 +30,6 @@ target_link_options(stdio_ei INTERFACE
         LINKER:--wrap,fread
         LINKER:--wrap,fputc
         LINKER:--wrap,fputs
+        LINKER:--wrap,fclose
         )
 add_library(Celix::stdio_ei ALIAS stdio_ei)

--- a/libs/error_injector/stdio/include/stdio_ei.h
+++ b/libs/error_injector/stdio/include/stdio_ei.h
@@ -44,6 +44,8 @@ CELIX_EI_DECLARE(fputc, int);
 
 CELIX_EI_DECLARE(fputs, int);
 
+CELIX_EI_DECLARE(fclose, int);
+
 #ifdef __cplusplus
 }
 #endif

--- a/libs/error_injector/stdio/src/stdio_ei.cc
+++ b/libs/error_injector/stdio/src/stdio_ei.cc
@@ -101,8 +101,11 @@ int __wrap_fputs(const char* __s, FILE* __stream) {
 int __real_fclose(FILE* __stream);
 CELIX_EI_DEFINE(fclose, int)
 int __wrap_fclose(FILE* __stream) {
+    int rc = __real_fclose(__stream); //note always call real fclose to ensure the stream is closed.
+    errno = ENOSPC;
     CELIX_EI_IMPL(fclose);
-    return __real_fclose(__stream);
+    errno = 0;
+    return rc;
 }
 
 }

--- a/libs/error_injector/stdio/src/stdio_ei.cc
+++ b/libs/error_injector/stdio/src/stdio_ei.cc
@@ -98,4 +98,11 @@ int __wrap_fputs(const char* __s, FILE* __stream) {
     return __real_fputs(__s, __stream);
 }
 
+int __real_fclose(FILE* __stream);
+CELIX_EI_DEFINE(fclose, int)
+int __wrap_fclose(FILE* __stream) {
+    CELIX_EI_IMPL(fclose);
+    return __real_fclose(__stream);
+}
+
 }

--- a/libs/framework/src/bundle_context.c
+++ b/libs/framework/src/bundle_context.c
@@ -43,7 +43,7 @@
 #include "celix_array_list.h"
 #include "celix_convert_utils.h"
 
-static celix_status_t bundleContext_bundleChanged(void *handle, bundle_event_t *event);
+static celix_status_t bundleContext_bundleChanged(void* listenerSvc, bundle_event_t* event);
 static void bundleContext_cleanupBundleTrackers(bundle_context_t *ct);
 static void bundleContext_cleanupServiceTrackers(bundle_context_t *ctx);
 static void bundleContext_cleanupServiceTrackerTrackers(bundle_context_t *ctx);
@@ -147,7 +147,10 @@ celix_status_t bundleContext_installBundle(bundle_context_pt context, const char
     return bundleContext_installBundle2(context, location, NULL, bundle);
 }
 
-celix_status_t bundleContext_installBundle2(bundle_context_pt context, const char *location, const char *inputFile, bundle_pt *bundle) {
+celix_status_t bundleContext_installBundle2(bundle_context_pt context,
+                                            const char* location,
+                                            const char* inputFile __attribute__((unused)),
+                                            bundle_pt* bundle) {
     celix_status_t status = CELIX_SUCCESS;
     long id = -1L;
     if (context == NULL || location == NULL || bundle == NULL) {
@@ -389,15 +392,23 @@ static long celix_bundleContext_registerServiceWithOptionsInternal(bundle_contex
     }
 
     //set properties
-    celix_properties_t *props = opts->properties;
+    celix_autoptr(celix_properties_t) props = opts->properties;
     if (props == NULL) {
         props = celix_properties_create();
     }
+
     if (opts->serviceVersion != NULL && strncmp("", opts->serviceVersion, 1) != 0) {
-        celix_properties_set(props, CELIX_FRAMEWORK_SERVICE_VERSION, opts->serviceVersion);
+        celix_version_t* version = celix_version_createVersionFromString(opts->serviceVersion);
+        if (!version) {
+            celix_framework_logTssErrors(ctx->framework->logger, CELIX_LOG_LEVEL_ERROR);
+            fw_log(
+                ctx->framework->logger, CELIX_LOG_LEVEL_ERROR, "Cannot parse service version %s", opts->serviceVersion);
+            return -1;
+        }
+        celix_properties_setVersionWithoutCopy(props, CELIX_FRAMEWORK_SERVICE_VERSION, version);
     }
 
-    long svcId = -1;
+    long svcId;
     if (!async && celix_framework_isCurrentThreadTheEventLoop(ctx->framework)) {
         /*
          * Note already on event loop, cannot register the service async, because we cannot wait a future event (the
@@ -407,20 +418,17 @@ static long celix_bundleContext_registerServiceWithOptionsInternal(bundle_contex
          * registrations versions on the event loop thread
          */
 
-        svcId = celix_framework_registerService(ctx->framework, ctx->bundle, opts->serviceName, opts->svc, opts->factory, props);
+        svcId = celix_framework_registerService(ctx->framework, ctx->bundle, opts->serviceName, opts->svc, opts->factory, celix_steal_ptr(props));
     } else {
         void (*asyncCallback)(void *data, long serviceId) = async ? opts->asyncCallback : NULL; //NOTE for not async call do not use the callback.
-        svcId = celix_framework_registerServiceAsync(ctx->framework, ctx->bundle, opts->serviceName, opts->svc, opts->factory, props, opts->asyncData, asyncCallback, NULL, NULL);
+        svcId = celix_framework_registerServiceAsync(ctx->framework, ctx->bundle, opts->serviceName, opts->svc, opts->factory, celix_steal_ptr(props), opts->asyncData, asyncCallback, NULL, NULL);
         if (!async && svcId >= 0) {
             //note on event loop thread, but in a sync call, so waiting till service registration is concluded
             celix_bundleContext_waitForAsyncRegistration(ctx, svcId);
         }
     }
 
-
-    if (svcId < 0) {
-        properties_destroy(props);
-    } else {
+    if (svcId >= 0) {
         celixThreadMutex_lock(&ctx->mutex);
         celix_arrayList_addLong(ctx->svcRegistrations, svcId);
         celixThreadMutex_unlock(&ctx->mutex);
@@ -519,19 +527,18 @@ celix_dependency_manager_t* celix_bundleContext_getDependencyManager(bundle_cont
     return result;
 }
 
-static celix_status_t bundleContext_bundleChanged(void *listenerSvc, bundle_event_t *event) {
-    celix_status_t status = CELIX_SUCCESS;
-    bundle_listener_t *listener = listenerSvc;
-    celix_bundle_context_bundle_tracker_entry_t *tracker = listener->handle;
+static celix_status_t bundleContext_bundleChanged(void* listenerSvc, bundle_event_t* event) {
+    bundle_listener_t* listener = listenerSvc;
+    celix_bundle_context_bundle_tracker_entry_t* tracker = listener->handle;
 
     bool handleEvent = true;
     long bndId = celix_bundle_getId(event->bnd);
-    if (bndId == 0 /*framework bundle*/)  {
+    if (bndId == 0 /*framework bundle*/) {
         handleEvent = tracker->opts.includeFrameworkBundle;
     }
 
     if (handleEvent) {
-        void *callbackHandle = tracker->opts.callbackHandle;
+        void* callbackHandle = tracker->opts.callbackHandle;
 
         if (event->type == OSGI_FRAMEWORK_BUNDLE_EVENT_INSTALLED && tracker->opts.onInstalled != NULL) {
             tracker->opts.onInstalled(callbackHandle, event->bnd);
@@ -545,7 +552,7 @@ static celix_status_t bundleContext_bundleChanged(void *listenerSvc, bundle_even
             tracker->opts.onBundleEvent(callbackHandle, event);
         }
     }
-    return status;
+    return CELIX_SUCCESS;
 }
 
 void celix_bundleContext_trackBundlesWithOptionsCallback(void *data) {
@@ -571,7 +578,6 @@ static long celix_bundleContext_trackBundlesWithOptionsInternal(
         bundle_context_t* ctx,
         const celix_bundle_tracking_options_t *opts,
         bool async) {
-    long trackerId = -1;
     celix_bundle_context_bundle_tracker_entry_t *entry = calloc(1, sizeof(*entry));
     memcpy(&entry->opts, opts, sizeof(*opts));
     entry->ctx = ctx;
@@ -582,7 +588,7 @@ static long celix_bundleContext_trackBundlesWithOptionsInternal(
     celixThreadMutex_lock(&ctx->mutex);
     entry->trackerId = ctx->nextTrackerId++;
     hashMap_put(ctx->bundleTrackers, (void*)(entry->trackerId), entry);
-    trackerId = entry->trackerId;
+    long trackerId = entry->trackerId;
     celixThreadMutex_unlock(&ctx->mutex);
 
     if (!async) { //note only using the async callback if this is a async call.

--- a/libs/framework/src/service_registration.c
+++ b/libs/framework/src/service_registration.c
@@ -21,52 +21,66 @@
 #include <stdio.h>
 #include <string.h>
 
-#include "service_registration_private.h"
-#include "celix_constants.h"
 #include "celix_build_assert.h"
+#include "celix_constants.h"
+#include "celix_err.h"
+#include "service_registration_private.h"
 
 static bool serviceRegistration_destroy(struct celix_ref *);
-static celix_status_t serviceRegistration_initializeProperties(service_registration_pt registration, properties_pt properties);
-static celix_status_t serviceRegistration_createInternal(registry_callback_t callback, bundle_pt bundle, const char* serviceName, unsigned long serviceId,
-        const void * serviceObject, properties_pt dictionary, enum celix_service_type svcType, service_registration_pt *registration);
+static celix_status_t serviceRegistration_initializeProperties(service_registration_t*registration,
+                                                               celix_properties_t* props);
 
-service_registration_pt serviceRegistration_create(registry_callback_t callback, bundle_pt bundle, const char* serviceName, unsigned long serviceId, const void * serviceObject, properties_pt dictionary) {
+static celix_status_t serviceRegistration_createInternal(registry_callback_t callback,
+                                                         celix_bundle_t* bundle,
+                                                         const char* serviceName,
+                                                         long serviceId,
+                                                         const void* serviceObject,
+                                                         celix_properties_t* dictionary,
+                                                         enum celix_service_type svcType,
+                                                         service_registration_t** out);
+
+service_registration_pt serviceRegistration_create(registry_callback_t callback, bundle_pt bundle, const char* serviceName, long serviceId, const void * serviceObject, properties_pt dictionary) {
     service_registration_pt registration = NULL;
 	serviceRegistration_createInternal(callback, bundle, serviceName, serviceId, serviceObject, dictionary, CELIX_PLAIN_SERVICE, &registration);
 	return registration;
 }
 
-service_registration_pt serviceRegistration_createServiceFactory(registry_callback_t callback, bundle_pt bundle, const char* serviceName, unsigned long serviceId, const void * serviceObject, properties_pt dictionary) {
+service_registration_pt serviceRegistration_createServiceFactory(registry_callback_t callback, bundle_pt bundle, const char* serviceName, long serviceId, const void * serviceObject, properties_pt dictionary) {
     service_registration_pt registration = NULL;
     serviceRegistration_createInternal(callback, bundle, serviceName, serviceId, serviceObject, dictionary, CELIX_DEPRECATED_FACTORY_SERVICE, &registration);
     return registration;
 }
 
-static celix_status_t serviceRegistration_createInternal(registry_callback_t callback, bundle_pt bundle, const char* serviceName, unsigned long serviceId,
-                                                         const void * serviceObject, properties_pt dictionary, enum celix_service_type svcType, service_registration_pt *out) {
-
+static celix_status_t serviceRegistration_createInternal(registry_callback_t callback,
+                                                         celix_bundle_t* bundle,
+                                                         const char* serviceName,
+                                                         long serviceId,
+                                                         const void* serviceObject,
+                                                         celix_properties_t* dictionary,
+                                                         enum celix_service_type svcType,
+                                                         service_registration_t** out) {
     celix_status_t status = CELIX_SUCCESS;
-	service_registration_pt  reg = calloc(1, sizeof(*reg));
+    service_registration_pt reg = calloc(1, sizeof(*reg));
     if (reg) {
         celix_ref_init(&reg->refCount);
         reg->callback = callback;
-		reg->svcType = svcType;
-		reg->className = strndup(serviceName, 1024*10);
+        reg->svcType = svcType;
+        reg->className = strndup(serviceName, 1024 * 10);
         reg->bundle = bundle;
-		reg->serviceId = serviceId;
-	    reg->svcObj = serviceObject;
-		reg->isUnregistering = false;
-		celixThreadRwlock_create(&reg->lock, NULL);
-		serviceRegistration_initializeProperties(reg, dictionary);
-	} else {
-		status = CELIX_ENOMEM;
-	}
+        reg->serviceId = serviceId;
+        reg->svcObj = serviceObject;
+        reg->isUnregistering = false;
+        celixThreadRwlock_create(&reg->lock, NULL);
+        serviceRegistration_initializeProperties(reg, dictionary);
+    } else {
+        status = CELIX_ENOMEM;
+    }
 
-	if (status == CELIX_SUCCESS) {
-		*out = reg;
-	}
+    if (status == CELIX_SUCCESS) {
+        *out = reg;
+    }
 
-	return status;
+    return status;
 }
 
 void serviceRegistration_retain(service_registration_pt registration) {
@@ -91,24 +105,26 @@ static bool serviceRegistration_destroy(struct celix_ref *refCount) {
     return true;
 }
 
-static celix_status_t serviceRegistration_initializeProperties(service_registration_pt registration, properties_pt dictionary) {
-    char sId[32];
+static celix_status_t serviceRegistration_initializeProperties(service_registration_t*registration,
+                                                               celix_properties_t* props) {
+    if (!props) {
+        props = celix_properties_create();
+    }
+    if (!props) {
+        return CELIX_ENOMEM;
+    }
 
-	if (dictionary == NULL) {
-		dictionary = properties_create();
-	}
+    celix_status_t status = celix_properties_setLong(props, CELIX_FRAMEWORK_SERVICE_ID, registration->serviceId);
+    CELIX_DO_IF(status, status = celix_properties_set(props, CELIX_FRAMEWORK_SERVICE_NAME, registration->className));
 
+    if (status == CELIX_SUCCESS) {
+        registration->properties = props;
+    } else {
+        celix_err_push("Cannot initialize service registration properties");
+        properties_destroy(props);
+    }
 
-	snprintf(sId, 32, "%lu", registration->serviceId);
-	properties_set(dictionary, (char *) CELIX_FRAMEWORK_SERVICE_ID, sId);
-
-	if (properties_get(dictionary, (char *) CELIX_FRAMEWORK_SERVICE_NAME) == NULL) {
-		properties_set(dictionary, (char *) CELIX_FRAMEWORK_SERVICE_NAME, registration->className);
-	}
-
-	registration->properties = dictionary;
-
-	return CELIX_SUCCESS;
+    return CELIX_SUCCESS;
 }
 
 void serviceRegistration_invalidate(service_registration_pt registration) {

--- a/libs/framework/src/service_registration_private.h
+++ b/libs/framework/src/service_registration_private.h
@@ -35,25 +35,25 @@ struct serviceRegistration {
     struct celix_ref refCount;
     registry_callback_t callback; // read-only
 
-	char * className; // read-only
-	bundle_pt bundle; // read-only
-	properties_pt properties; // read-only
-	unsigned long serviceId; // read-only
+    char* className;          // read-only
+    bundle_pt bundle;         // read-only
+    properties_pt properties; // read-only
+    long serviceId;           // read-only
 
     bool isUnregistering;
 
     enum celix_service_type svcType; // read-only
     union {
-        const void * svcObj;
+        const void* svcObj;
         service_factory_pt deprecatedFactory;
-        celix_service_factory_t *factory;
+        celix_service_factory_t* factory;
     };
 
     celix_thread_rwlock_t lock; // protects the service object
 };
 
-service_registration_pt serviceRegistration_create(registry_callback_t callback, bundle_pt bundle, const char* serviceName, unsigned long serviceId, const void * serviceObject, properties_pt dictionary);
-service_registration_pt serviceRegistration_createServiceFactory(registry_callback_t callback, bundle_pt bundle, const char* serviceName, unsigned long serviceId, const void * serviceObject, properties_pt dictionary);
+service_registration_pt serviceRegistration_create(registry_callback_t callback, bundle_pt bundle, const char* serviceName, long serviceId, const void * serviceObject, properties_pt dictionary);
+service_registration_pt serviceRegistration_createServiceFactory(registry_callback_t callback, bundle_pt bundle, const char* serviceName, long serviceId, const void * serviceObject, properties_pt dictionary);
 
 void serviceRegistration_retain(service_registration_pt registration);
 void serviceRegistration_release(service_registration_pt registration);

--- a/libs/framework/src/service_registry.c
+++ b/libs/framework/src/service_registry.c
@@ -976,6 +976,7 @@ celix_status_t celix_serviceRegistry_addServiceListener(celix_service_registry_t
         filter = celix_filter_create(stringFilter);
         if (filter == NULL) {
             fw_log(registry->framework->logger, CELIX_LOG_LEVEL_ERROR, "Cannot add service listener filter '%s' is invalid", stringFilter);
+            celix_framework_logTssErrors(registry->framework->logger, CELIX_LOG_LEVEL_ERROR);
             return CELIX_ILLEGAL_ARGUMENT;
         }
     }

--- a/libs/utils/benchmark/CMakeLists.txt
+++ b/libs/utils/benchmark/CMakeLists.txt
@@ -40,4 +40,11 @@ if (UTILS_BENCHMARK)
     target_link_libraries(celix_long_hashmap_benchmark PRIVATE Celix::utils benchmark::benchmark)
     target_compile_options(celix_long_hashmap_benchmark PRIVATE -Wno-unused-function)
     celix_deprecated_utils_headers(celix_long_hashmap_benchmark)
+
+    add_executable(celix_filter_benchmark
+            src/BenchmarkMain.cc
+            src/FilterBenchmark.cc
+    )
+    target_link_libraries(celix_filter_benchmark PRIVATE Celix::utils benchmark::benchmark)
+    target_compile_options(celix_filter_benchmark PRIVATE -Wno-unused-function)
 endif ()

--- a/libs/utils/benchmark/src/FilterBenchmark.cc
+++ b/libs/utils/benchmark/src/FilterBenchmark.cc
@@ -176,10 +176,16 @@ static void FilterBenchmark_versionRangeFilter(benchmark::State& state) {
     benchmark.testFilter(state, filter, true);
 }
 
+static void FilterBenchmark_substringFilter(benchmark::State& state) {
+    FilterBenchmark benchmark{state};
+    celix::Filter filter{"(&(version_key1>=1.0.0)(version_key1<2.0.0))"};
+    benchmark.testFilter(state, filter, true);
+}
+
+
 static void FilterBenchmark_complexFilter(benchmark::State& state) {
     FilterBenchmark benchmark{state};
-    celix::Filter filter{"(&(version_key1>=1.0.0)(version_key1<2.0.0)(str_key1=str_value1)(long_key1=1)(double_key1>=0."
-                         "9)(bool_key1=true))"};
+    celix::Filter filter{"(str_key1=*value1)"};
     benchmark.testFilter(state, filter, true);
 }
 
@@ -206,4 +212,5 @@ CELIX_BENCHMARK(FilterBenchmark_versionGreaterEqualFilter);
 
 //Specials
 CELIX_BENCHMARK(FilterBenchmark_versionRangeFilter);
+CELIX_BENCHMARK(FilterBenchmark_substringFilter);
 CELIX_BENCHMARK(FilterBenchmark_complexFilter);

--- a/libs/utils/benchmark/src/FilterBenchmark.cc
+++ b/libs/utils/benchmark/src/FilterBenchmark.cc
@@ -1,0 +1,209 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <benchmark/benchmark.h>
+#include <memory>
+#include <iostream>
+#include <random>
+#include <climits>
+
+#include "celix/Filter.h"
+#include "celix/Properties.h"
+#include "celix_properties_internal.h"
+
+class FilterBenchmark {
+public:
+    explicit FilterBenchmark(benchmark::State& state) : props{createTestProperties()} {
+        int64_t additionalPropertyEntries = state.range(0);
+        fillProperties(additionalPropertyEntries);
+    }
+
+    static celix::Properties createTestProperties() {
+        celix::Properties props{};
+        props.set("str_key1", "str_value1");
+        props.set("long_key1", 1L);
+        props.set("double_key1", 1.0);
+        props.set("bool_key1", true);
+        props.set("version_key1", celix::Version{1,2,3});
+        props.set("version_key2", celix::Version{1,2,3, "qualifier"});
+        return props;
+    }
+
+    void testFilter(benchmark::State& state, const celix::Filter& filter, bool expectedMatch) {
+        for (auto _ : state) {
+            // This code gets timed
+            auto match = filter.match(props);
+            if (match != expectedMatch) {
+                std::cerr << "ERROR: unexpected match result" << std::endl;
+            }
+        }
+        addStateCounters(state);
+    }
+
+    void testCFilter(benchmark::State& state, const celix::Filter& filter, bool expectedMatch) {
+        auto* cFilter = filter.getCFilter();
+        auto* cProps = props.getCProperties();
+        for (auto _ : state) {
+            // This code gets timed
+            auto match = celix_filter_match(cFilter, cProps);
+            if (match != expectedMatch) {
+                std::cerr << "ERROR: unexpected match result" << std::endl;
+            }
+
+        }
+        addStateCounters(state);
+    }
+
+    void addStateCounters(benchmark::State& state) {
+        state.SetItemsProcessed(state.iterations());
+        auto stats = celix_properties_getStatistics(props.getCProperties());
+        //state.counters["nrOfProperties"] = (double)stats.mapStatistics.nrOfEntries;
+        //state.counters["nrOfBuckets"] = (double)stats.mapStatistics.nrOfBuckets;
+        //state.counters["resizeCount"] = (double)stats.mapStatistics.resizeCount;
+        //state.counters["averageNrOfEntriesPerBucket"] = stats.mapStatistics.averageNrOfEntriesPerBucket;
+        //state.counters["stdDeviationNrOfEntriesPerBucket"] = stats.mapStatistics.stdDeviationNrOfEntriesPerBucket;
+        //state.counters["averageSizeOfKeysAndStringValues"] = (double)stats.averageSizeOfKeysAndStringValues;
+        //state.counters["sizeOfKeysAndStringValues"] = (double)stats.sizeOfKeysAndStringValues;
+        state.counters["fillStringOptimizationBufferPercentage"] = stats.fillStringOptimizationBufferPercentage;
+        state.counters["fillEntriesOptimizationBufferPercentage"] = stats.fillEntriesOptimizationBufferPercentage;
+    }
+
+    std::string randomString() {
+        std::string result{};
+        int len = lenDistribution(generator);
+        result.reserve(len);
+        for (int i = 0; i < len-1; ++i) {
+            result[i] = (char)charDistribution(generator);
+        }
+        result[len-1] = '\0';
+        return result;
+    }
+
+    void fillProperties(int64_t additionalPropertyEntries) {
+        for (auto i = 0; i < additionalPropertyEntries; ++i) {
+            props.set(randomString(), randomString());
+        }
+    }
+
+  private:
+    celix::Properties props{};
+
+    const int MAX_LEN = 100;
+    std::default_random_engine generator{};
+    std::uniform_int_distribution<int> lenDistribution{2,MAX_LEN};
+    std::uniform_int_distribution<int> charDistribution{'a','z'};
+};
+
+static void FilterBenchmark_testStringCFilter(benchmark::State& state) {
+    FilterBenchmark benchmark{state};
+    celix::Filter filter{"(str_key1=str_value1)"};
+    benchmark.testCFilter(state, filter, true);
+}
+
+static void FilterBenchmark_testStringFilter(benchmark::State& state) {
+    FilterBenchmark benchmark{state};
+    celix::Filter filter{"(str_key1=str_value1)"};
+    benchmark.testFilter(state, filter, true);
+}
+
+static void FilterBenchmark_testStringGreaterEqualFilter(benchmark::State& state) {
+    FilterBenchmark benchmark{state};
+    celix::Filter filter{"(str_key1>=str_value)"};
+    benchmark.testFilter(state, filter, true);
+}
+
+static void FilterBenchmark_testLongFilter(benchmark::State& state) {
+    FilterBenchmark benchmark{state};
+    celix::Filter filter{"(long_key1=1)"};
+    benchmark.testFilter(state, filter, true);
+}
+
+static void FilterBenchmark_testLongGreaterEqualFilter(benchmark::State& state) {
+    FilterBenchmark benchmark{state};
+    celix::Filter filter{"(long_key1>=1)"};
+    benchmark.testFilter(state, filter, true);
+}
+
+static void FilterBenchmark_testDoubleGreaterEqualFilter(benchmark::State& state) {
+    FilterBenchmark benchmark{state};
+    celix::Filter filter{"(double_key1>=0.9)"};
+    benchmark.testFilter(state, filter, true);
+}
+
+static void FilterBenchmark_testBoolFilter(benchmark::State& state) {
+    FilterBenchmark benchmark{state};
+    celix::Filter filter{"(bool_key1=true)"};
+    benchmark.testFilter(state, filter, true);
+}
+
+static void FilterBenchmark_testVersionFilter(benchmark::State& state) {
+    FilterBenchmark benchmark{state};
+    celix::Filter filter{"(version_key1=1.2.3)"};
+    benchmark.testFilter(state, filter, true);
+}
+
+static void FilterBenchmark_testVersionWithQualifierFilter(benchmark::State& state) {
+    FilterBenchmark benchmark{state};
+    celix::Filter filter{"(version_key2=1.2.3.qualifier)"};
+    benchmark.testFilter(state, filter, true);
+}
+
+static void FilterBenchmark_versionGreaterEqualFilter(benchmark::State& state) {
+    FilterBenchmark benchmark{state};
+    celix::Filter filter{"(version_key1>=1.0.0)"};
+    benchmark.testFilter(state, filter, true);
+}
+
+static void FilterBenchmark_versionRangeFilter(benchmark::State& state) {
+    FilterBenchmark benchmark{state};
+    celix::Filter filter{"(&(version_key1>=1.0.0)(version_key1<2.0.0))"};
+    benchmark.testFilter(state, filter, true);
+}
+
+static void FilterBenchmark_complexFilter(benchmark::State& state) {
+    FilterBenchmark benchmark{state};
+    celix::Filter filter{"(&(version_key1>=1.0.0)(version_key1<2.0.0)(str_key1=str_value1)(long_key1=1)(double_key1>=0."
+                         "9)(bool_key1=true))"};
+    benchmark.testFilter(state, filter, true);
+}
+
+#define CELIX_BENCHMARK(name) \
+    BENCHMARK(name)->MeasureProcessCPUTime()->UseRealTime()->Unit(benchmark::kNanosecond) \
+        ->RangeMultiplier(100)->Range(1, 10000)
+
+CELIX_BENCHMARK(FilterBenchmark_testStringCFilter); //done on C API, to check if C++ api does not have a big overhead
+
+//Operator =
+CELIX_BENCHMARK(FilterBenchmark_testStringFilter);
+CELIX_BENCHMARK(FilterBenchmark_testLongFilter);
+//note no double = test
+CELIX_BENCHMARK(FilterBenchmark_testBoolFilter);
+CELIX_BENCHMARK(FilterBenchmark_testVersionFilter);
+CELIX_BENCHMARK(FilterBenchmark_testVersionWithQualifierFilter);
+
+//Operator >=
+CELIX_BENCHMARK(FilterBenchmark_testStringGreaterEqualFilter);
+CELIX_BENCHMARK(FilterBenchmark_testLongGreaterEqualFilter);
+CELIX_BENCHMARK(FilterBenchmark_testDoubleGreaterEqualFilter);
+//note no bool >= test
+CELIX_BENCHMARK(FilterBenchmark_versionGreaterEqualFilter);
+
+//Specials
+CELIX_BENCHMARK(FilterBenchmark_versionRangeFilter);
+CELIX_BENCHMARK(FilterBenchmark_complexFilter);

--- a/libs/utils/gtest/CMakeLists.txt
+++ b/libs/utils/gtest/CMakeLists.txt
@@ -99,6 +99,7 @@ if (EI_TESTS)
             src/PropertiesErrorInjectionTestSuite.cc
             src/VersionErrorInjectionTestSuite.cc
             src/HashMapErrorInjectionTestSuite.cc
+            src/FilterErrorInjectionTestSuite.cc
     )
     target_link_libraries(test_utils_with_ei PRIVATE
             Celix::zip_ei
@@ -114,6 +115,7 @@ if (EI_TESTS)
             Celix::string_hash_map_ei
             Celix::long_hash_map_ei
             Celix::version_ei
+            Celix::array_list_ei
             GTest::gtest GTest::gtest_main
     )
     target_include_directories(test_utils_with_ei PRIVATE ../src) #for version_private (needs refactoring of test)

--- a/libs/utils/gtest/src/ConvertUtilsErrorInjectionTestSuite.cc
+++ b/libs/utils/gtest/src/ConvertUtilsErrorInjectionTestSuite.cc
@@ -28,14 +28,6 @@ public:
     }
 };
 
-TEST_F(ConvertUtilsWithErrorInjectionTestSuite, CovertToBoolTest) {
-    bool converted;
-    celix_ei_expect_celix_utils_writeOrCreateString(CELIX_EI_UNKNOWN_CALLER, 0, nullptr);
-    bool result = celix_utils_convertStringToBool("true", false, &converted);
-    EXPECT_EQ(false, result);
-    EXPECT_FALSE(converted);
-}
-
 TEST_F(ConvertUtilsWithErrorInjectionTestSuite, ConvertToVersionTest) {
     celix_version_t* defaultVersion = celix_version_create(1, 2, 3, "B");
     celix_ei_expect_celix_utils_writeOrCreateString(CELIX_EI_UNKNOWN_CALLER, 0, nullptr);

--- a/libs/utils/gtest/src/ConvertUtilsTestSuite.cc
+++ b/libs/utils/gtest/src/ConvertUtilsTestSuite.cc
@@ -201,6 +201,15 @@ TEST_F(ConvertUtilsTestSuite, ConvertToBoolTest) {
     result = celix_utils_convertStringToBool("\t false \t\n", 0, &converted);
     EXPECT_FALSE(result);
     EXPECT_TRUE(converted);
+
+    //test for a convert with nullptr for the val parameter
+    result = celix_utils_convertStringToBool(nullptr, true, &converted);
+    EXPECT_TRUE(result);
+    EXPECT_FALSE(converted);
+
+    result = celix_utils_convertStringToBool(nullptr, false, &converted);
+    EXPECT_FALSE(result);
+    EXPECT_FALSE(converted);
 }
 
 TEST_F(ConvertUtilsTestSuite, ConvertToVersionTest) {

--- a/libs/utils/gtest/src/CxxFilterTestSuite.cc
+++ b/libs/utils/gtest/src/CxxFilterTestSuite.cc
@@ -28,15 +28,10 @@ public:
 
 TEST_F(CxxFilterTestSuite, CreateDestroy) {
     celix::Filter filter{};
-    EXPECT_TRUE(filter.empty());
-    EXPECT_TRUE(filter.getCFilter() == nullptr);
-    EXPECT_TRUE(filter.getFilterString().empty());
+    EXPECT_EQ(filter.getFilterString(), "(|)"); //match all filter
 }
 
 TEST_F(CxxFilterTestSuite, FilterString) {
-    celix::Filter filter1{};
-    EXPECT_EQ(std::string{}, filter1.getFilterString());
-
     celix::Filter filter2{"(key=value)"};
     EXPECT_FALSE(filter2.empty());
     EXPECT_EQ(std::string{"(key=value)"}, filter2.getFilterString());

--- a/libs/utils/gtest/src/FilterErrorInjectionTestSuite.cc
+++ b/libs/utils/gtest/src/FilterErrorInjectionTestSuite.cc
@@ -132,6 +132,14 @@ TEST_F(FilterErrorInjectionTestSuite, ErrorWithCallocTest) {
     //Then the filter creation should fail, because it cannot calloc mem for an internal struct (converted types)
     filter = celix_filter_create(filterStr);
     EXPECT_EQ(nullptr, filter);
+
+    //Given an error injection for calloc
+    celix_ei_expect_calloc((void*)celix_filter_create, 2, nullptr);
+    //When creating a filter withAND filter node
+    filterStr = "(&(key1=value1)(key2=value2))";
+    //Then the filter creation should fail, cecause it cannot calloc mem for an internal struct (converted types)
+    filter = celix_filter_create(filterStr);
+    EXPECT_EQ(nullptr, filter);
 }
 
 TEST_F(FilterErrorInjectionTestSuite, ErrorMemStreamTest) {

--- a/libs/utils/gtest/src/FilterErrorInjectionTestSuite.cc
+++ b/libs/utils/gtest/src/FilterErrorInjectionTestSuite.cc
@@ -194,6 +194,14 @@ TEST_F(FilterErrorInjectionTestSuite, ErrorStrdupTest) {
     //Then the filter creation should fail, because it strdup the filter string
     celix_filter_t* filter = celix_filter_create(filterStr);
     EXPECT_EQ(nullptr, filter);
+
+    //Given an error injection for celix_utils_strdup
+    celix_ei_expect_celix_utils_strdup((void*)celix_filter_create, 4, nullptr);
+    //When creating a filter with an empty attribute value
+    filterStr = "(key1=)";
+    //Then the filter creation should fail, because it strdup the filter string
+    filter = celix_filter_create(filterStr);
+    EXPECT_EQ(nullptr, filter);
 }
 
 

--- a/libs/utils/gtest/src/FilterErrorInjectionTestSuite.cc
+++ b/libs/utils/gtest/src/FilterErrorInjectionTestSuite.cc
@@ -32,7 +32,7 @@ class FilterErrorInjectionTestSuite : public ::testing::Test {
   public:
     FilterErrorInjectionTestSuite() {
         celix_err_resetErrors();
-        celix_ei_expect_celix_arrayList_create(nullptr, 0, nullptr);
+        celix_ei_expect_celix_arrayList_createWithOptions(nullptr, 0, nullptr);
         celix_ei_expect_celix_arrayList_add(nullptr, 0, 0);
         celix_ei_expect_calloc(nullptr, 0, nullptr);
         celix_ei_expect_open_memstream(nullptr, 0, nullptr);
@@ -48,7 +48,7 @@ class FilterErrorInjectionTestSuite : public ::testing::Test {
 
 TEST_F(FilterErrorInjectionTestSuite, ErrorWithArrayListCreateTest) {
     //Given an error injection for celix_arrayList_create
-    celix_ei_expect_celix_arrayList_create((void*)celix_filter_create, 3, nullptr);
+    celix_ei_expect_celix_arrayList_createWithOptions((void*)celix_filter_create, 3, nullptr);
     //When creating a filter with a AND filter node
     const char* filterStr = "(&(key1=value1)(key2=value2))";
     //Then the filter creation should fail, because it cannot create a children list for the AND filter node
@@ -56,7 +56,7 @@ TEST_F(FilterErrorInjectionTestSuite, ErrorWithArrayListCreateTest) {
     EXPECT_EQ(nullptr, filter);
 
     //Given an error injection for celix_arrayList_create
-    celix_ei_expect_celix_arrayList_create((void*)celix_filter_create, 3, nullptr);
+    celix_ei_expect_celix_arrayList_createWithOptions((void*)celix_filter_create, 3, nullptr);
     //When creating a filter with a NOT filter node
     filterStr = "(!(key1=value1))";
     //Then the filter creation should fail, because it cannot create a children list for the NOT filter node

--- a/libs/utils/gtest/src/FilterErrorInjectionTestSuite.cc
+++ b/libs/utils/gtest/src/FilterErrorInjectionTestSuite.cc
@@ -24,6 +24,7 @@
 #include "celix_err.h"
 
 #include "celix_array_list_ei.h"
+#include "celix_utils_ei.h"
 #include "malloc_ei.h"
 #include "stdio_ei.h"
 
@@ -35,6 +36,8 @@ class FilterErrorInjectionTestSuite : public ::testing::Test {
         celix_ei_expect_calloc(nullptr, 0, nullptr);
         celix_ei_expect_open_memstream(nullptr, 0, nullptr);
         celix_ei_expect_fclose(nullptr, 0, 0);
+        celix_ei_expect_celix_utils_strdup(nullptr, 0, nullptr);
+        celix_ei_expect_fputc(nullptr, 0, 0);
     }
 
     ~FilterErrorInjectionTestSuite() override {
@@ -137,6 +140,17 @@ TEST_F(FilterErrorInjectionTestSuite, ErrorFcloseTest) {
     filter = celix_filter_create(filterStr);
     EXPECT_EQ(nullptr, filter);
 }
+
+TEST_F(FilterErrorInjectionTestSuite, ErrorStrdupTest) {
+    //Given an error injection for celix_utils_strdup
+    celix_ei_expect_celix_utils_strdup((void*)celix_filter_create, 0, nullptr);
+    //When creating a filter
+    const char* filterStr = "(key1=value1)";
+    //Then the filter creation should fail, because it strdup the filter string
+    celix_filter_t* filter = celix_filter_create(filterStr);
+    EXPECT_EQ(nullptr, filter);
+}
+
 
 TEST_F(FilterErrorInjectionTestSuite, ErrorFputcTest) {
     // Given an error injection for fputc

--- a/libs/utils/gtest/src/FilterErrorInjectionTestSuite.cc
+++ b/libs/utils/gtest/src/FilterErrorInjectionTestSuite.cc
@@ -1,0 +1,165 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <gtest/gtest.h>
+
+#include "celix_filter.h"
+#include "celix_utils.h"
+#include "celix_err.h"
+
+#include "celix_array_list_ei.h"
+#include "malloc_ei.h"
+#include "stdio_ei.h"
+
+class FilterErrorInjectionTestSuite : public ::testing::Test {
+  public:
+    FilterErrorInjectionTestSuite() {
+        celix_err_resetErrors();
+        celix_ei_expect_celix_arrayList_create(nullptr, 0, nullptr);
+        celix_ei_expect_calloc(nullptr, 0, nullptr);
+        celix_ei_expect_open_memstream(nullptr, 0, nullptr);
+        celix_ei_expect_fclose(nullptr, 0, 0);
+    }
+
+    ~FilterErrorInjectionTestSuite() override {
+        celix_err_printErrors(stderr, nullptr, nullptr);
+    }
+};
+
+TEST_F(FilterErrorInjectionTestSuite, ErrorWithArrayListCreateTest) {
+    //Given an error injection for celix_arrayList_create
+    celix_ei_expect_celix_arrayList_create((void*)celix_filter_create, 3, nullptr);
+    //When creating a filter with a AND filter node
+    const char* filterStr = "(&(key1=value1)(key2=value2))";
+    //Then the filter creation should fail, because it cannot create a children list for the AND filter node
+    celix_filter_t* filter = celix_filter_create(filterStr);
+    EXPECT_EQ(nullptr, filter);
+
+    //Given an error injection for celix_arrayList_create
+    celix_ei_expect_celix_arrayList_create((void*)celix_filter_create, 3, nullptr);
+    //When creating a filter with a NOT filter node
+    filterStr = "(!(key1=value1))";
+    //Then the filter creation should fail, because it cannot create a children list for the NOT filter node
+    filter = celix_filter_create(filterStr);
+    EXPECT_EQ(nullptr, filter);
+
+    //Given an error injection for celix_arrayList_create
+    celix_ei_expect_celix_arrayList_create((void*)celix_filter_create, 4, nullptr);
+    //When creating a filter with a substring
+    filterStr = "(key1=*val*)";
+    //Then the filter creation should fail, because it cannot create a children list for the substring filter node
+    filter = celix_filter_create(filterStr);
+    EXPECT_EQ(nullptr, filter);
+}
+
+TEST_F(FilterErrorInjectionTestSuite, ErrorWithCallocTest) {
+    //Given an error injection for calloc
+    celix_ei_expect_calloc((void*)celix_filter_create, 3, nullptr);
+    //When creating a filter with a AND filter node
+    const char* filterStr = "(&(key1=value1)(key2=value2))";
+    //Then the filter creation should fail, because it cannot calloc mem for a filter node
+    celix_filter_t* filter = celix_filter_create(filterStr);
+    EXPECT_EQ(nullptr, filter);
+
+    //Given an error injection for calloc
+    celix_ei_expect_calloc((void*)celix_filter_create, 3, nullptr);
+    //When creating a filter with a NOT filter node
+    filterStr = "(!(key1=value1))";
+    //Then the filter creation should fail, because it cannot calloc mem for a filter node
+    filter = celix_filter_create(filterStr);
+    EXPECT_EQ(nullptr, filter);
+
+    //Given an error injection for calloc
+    celix_ei_expect_calloc((void*)celix_filter_create, 3, nullptr);
+    //When creating a filter with a no compound filter node
+    filterStr = "(key1=value1)";
+    //Then the filter creation should fail, because it cannot calloc mem for a filter node
+    filter = celix_filter_create(filterStr);
+    EXPECT_EQ(nullptr, filter);
+
+    //Given an error injection for calloc
+    celix_ei_expect_calloc((void*)celix_filter_create, 1, nullptr);
+    //When creating a filter with
+    filterStr = "(key1=value1)";
+    //Then the filter creation should fail, because it cannot calloc mem for an internal struct (converted types)
+    filter = celix_filter_create(filterStr);
+    EXPECT_EQ(nullptr, filter);
+}
+
+TEST_F(FilterErrorInjectionTestSuite, ErrorMemStreamTest) {
+    //Given an error injection for open_memstream
+    celix_ei_expect_open_memstream((void*)celix_filter_create, 4, nullptr);
+    //When creating a filter with a parseable attribute (or attr value)
+    const char* filterStr = "(key1=value1)";
+    //Then the filter creation should fail, because it cannot open a memstream to create the attribute string.
+    celix_filter_t* filter = celix_filter_create(filterStr);
+    EXPECT_EQ(nullptr, filter);
+
+    //Given an error injection for open_memstream
+    celix_ei_expect_open_memstream((void*)celix_filter_create, 5, nullptr);
+    //When creating a filter with a sub string with an any part
+    filterStr = "(key1=*val*)";
+    //Then the filter creation should fail, because it cannot open a memstream to create an any part
+    filter = celix_filter_create(filterStr);
+    EXPECT_EQ(nullptr, filter);
+}
+
+TEST_F(FilterErrorInjectionTestSuite, ErrorFcloseTest) {
+    //Given an error injection for fclose
+    celix_ei_expect_fclose((void*)celix_filter_create, 4, EOF);
+    //When creating a filter with a parseable attribute (or attr value)
+    const char* filterStr = "(key1=value1)";
+    //Then the filter creation should fail, because it cannot close the (mem)stream.
+    celix_filter_t* filter = celix_filter_create(filterStr);
+    EXPECT_EQ(nullptr, filter);
+
+    //Given an error injection for fclose
+    celix_ei_expect_fclose((void*)celix_filter_create, 5, EOF);
+    //When creating a filter with a sub string with an any part
+    filterStr = "(key1=*val*)";
+    //Then the filter creation should fail, because it cannot close the (mem)stream.
+    filter = celix_filter_create(filterStr);
+    EXPECT_EQ(nullptr, filter);
+}
+
+TEST_F(FilterErrorInjectionTestSuite, ErrorFputcTest) {
+    // Given an error injection for fputc
+    celix_ei_expect_fputc((void*)celix_filter_create, 4, EOF);
+    // When creating a filter with a parseable attribute (or attr value)
+    const char* filterStr = "(k=value1)";
+    // Then the filter creation should fail, because it cannot fputc a char to the (mem)stream.
+    celix_filter_t* filter = celix_filter_create(filterStr);
+    EXPECT_EQ(nullptr, filter);
+
+    // Given an error injection for fputc with ordinal 2
+    celix_ei_expect_fputc((void*)celix_filter_create, 4, EOF, 2);
+    // When creating a filter with a parseable attribute (or attr value)
+    filterStr = "(k=value1)";
+    // Then the filter creation should fail, because it cannot fputc a '\0' char to the (mem)stream.
+    filter = celix_filter_create(filterStr);
+    EXPECT_EQ(nullptr, filter);
+
+    //Given an error injection for fclose
+    celix_ei_expect_fputc((void*)celix_filter_create, 5, EOF);
+    //When creating a filter with a sub string with an any part
+    filterStr = "(key1=*val*)";
+    //Then the filter creation should fail, because it cannot close the (mem)stream.
+    filter = celix_filter_create(filterStr);
+    EXPECT_EQ(nullptr, filter);
+}

--- a/libs/utils/gtest/src/FilterErrorInjectionTestSuite.cc
+++ b/libs/utils/gtest/src/FilterErrorInjectionTestSuite.cc
@@ -73,12 +73,29 @@ TEST_F(FilterErrorInjectionTestSuite, ErrorWithArrayListCreateTest) {
 }
 
 TEST_F(FilterErrorInjectionTestSuite, ErrorWithArrayListAddTest) {
+    //Given an error injection for celix_arrayList_add
+    celix_ei_expect_celix_arrayList_add((void*)celix_filter_create, 3, CELIX_ENOMEM);
+    //When creating a filter with a And filter node
+    const char* filterStr = "(&(key1=value1)(key2=value2))";
+    //Then the filter creation should fail, because it cannot add a children to the AND filter node
+    celix_filter_t* filter = celix_filter_create(filterStr);
+    EXPECT_EQ(nullptr, filter);
+
+    //Given an error injection for celix_arrayList_add
+    celix_ei_expect_celix_arrayList_add((void*)celix_filter_create, 3, CELIX_ENOMEM);
+    //When creating a filter with a NOT filter node
+    filterStr = "(!(key1=value1))";
+    //Then the filter creation should fail, because it cannot add a children to the NOT filter node
+    filter = celix_filter_create(filterStr);
+    EXPECT_EQ(nullptr, filter);
+
     for (int i = 0; i < 3; ++i) {
+        //Given an error injection for celix_arrayList_add
         celix_ei_expect_celix_arrayList_add((void*)celix_filter_create, 4, CELIX_ENOMEM, i+1);
         //When creating a filter with a substring
-        const char* filterStr = "(key1=*val*)";
+        filterStr = "(key1=*val*)";
         //Then the filter creation should fail, because it cannot add a children to the substring filter node
-        celix_filter_t* filter = celix_filter_create(filterStr);
+        filter = celix_filter_create(filterStr);
         EXPECT_EQ(nullptr, filter);
     }
 }

--- a/libs/utils/gtest/src/FilterTestSuite.cc
+++ b/libs/utils/gtest/src/FilterTestSuite.cc
@@ -42,6 +42,7 @@ TEST_F(FilterTestSuite, CreateDestroyTest) {
     ASSERT_TRUE(filter != nullptr);
 
     celix_filter_destroy(filter);
+    celix_filter_destroy(nullptr);
 }
 
 TEST_F(FilterTestSuite, MissingOpenBracketsCreateTest) {
@@ -144,14 +145,29 @@ TEST_F(FilterTestSuite, MiscInvalidCreateTest) {
     ASSERT_STREQ("strWith)inIt", (char*)filter->value);
     celix_filter_destroy(filter);
 
-    // test incomplete substring operator
+    // test parsing incomplete substring operator
     const char* str8 = "(test_attr3=*attr3\\";
     filter = celix_filter_create(str8);
     ASSERT_TRUE(filter == nullptr);
 
-    // test incomplete substring operator
+    // test parsing incomplete substring operator
     const char* str9 = "(test_attr3=*attr3";
     filter = celix_filter_create(str9);
+    ASSERT_TRUE(filter == nullptr);
+
+    // test parsing fiter missing )
+    const char* str10 = "(|(a=b)";
+    filter = celix_filter_create(str10);
+    ASSERT_TRUE(filter == nullptr);
+
+    // test parsing APPROX operator missing value
+    const char* str11 = "(a~=)";
+    filter = celix_filter_create(str11);
+    ASSERT_TRUE(filter == nullptr);
+
+    // test parsing LESS operator missing value
+    const char* str12 = "(a<)";
+    filter = celix_filter_create(str12);
     ASSERT_TRUE(filter == nullptr);
 }
 

--- a/libs/utils/gtest/src/FilterTestSuite.cc
+++ b/libs/utils/gtest/src/FilterTestSuite.cc
@@ -181,187 +181,138 @@ TEST_F(FilterTestSuite, MatchEqualTest) {
 }
 
 TEST_F(FilterTestSuite, MatchTest) {
-    char* str;
     celix_filter_t* filter;
-    celix_properties_t* props = celix_properties_create();
-    char* key = celix_utils_strdup("test_attr1");
-    char* val = celix_utils_strdup("attr1");
-    char* key2 = celix_utils_strdup("test_attr2");
-    char* val2 = celix_utils_strdup("attr2");
-    celix_properties_set(props, key, val);
-    celix_properties_set(props, key2, val2);
+    celix_autoptr(celix_properties_t) props = celix_properties_create();
+    ASSERT_NE(nullptr, props);
+    celix_properties_set(props, "test_attr1", "attr1");
+    celix_properties_set(props, "test_attr2", "attr2");
 
     // Test EQUALS
-    str = celix_utils_strdup("(test_attr1=attr1)");
-    filter = celix_filter_create(str);
+    filter = celix_filter_create("(test_attr1=attr1)");
     bool result = celix_filter_match(filter, props);
     EXPECT_TRUE(result);
+    celix_filter_destroy(filter);
 
     // Test EQUALS false
-    celix_filter_destroy(filter);
-    free(str);
-    str = celix_utils_strdup("(test_attr1=falseString)");
-    filter = celix_filter_create(str);
+    filter = celix_filter_create("(test_attr1=falseString)");
     result = celix_filter_match(filter, props);
     EXPECT_FALSE(result);
-
     celix_filter_destroy(filter);
-    free(str);
-    str = celix_utils_strdup("(test_attr1~=attr1)");
-    filter = celix_filter_create(str);
+
+    filter = celix_filter_create("(test_attr1~=attr1)");
     result = celix_filter_match(filter, props);
     EXPECT_TRUE(result);
-
     celix_filter_destroy(filter);
-    free(str);
-    str = celix_utils_strdup("(test_attr1~=ATTR1)");
-    filter = celix_filter_create(str);
+
+    filter = celix_filter_create("(test_attr1~=ATTR1)");
     result = celix_filter_match(filter, props);
     EXPECT_TRUE(result);
+    celix_filter_destroy(filter);
 
     // Test PRESENT
-    celix_filter_destroy(filter);
-    free(str);
-    str = celix_utils_strdup("(test_attr1=*)");
-    filter = celix_filter_create(str);
+    filter = celix_filter_create("(test_attr1=*)");
     result = celix_filter_match(filter, props);
     EXPECT_TRUE(result);
+    celix_filter_destroy(filter);
 
     // Test NOT PRESENT
-    celix_filter_destroy(filter);
-    free(str);
-    str = celix_utils_strdup("(test_attr3=*)");
-    filter = celix_filter_create(str);
+    filter = celix_filter_create("(test_attr3=*)");
     result = celix_filter_match(filter, props);
     EXPECT_FALSE(result);
+    celix_filter_destroy(filter);
 
     // Test NOT PRESENT
-    celix_filter_destroy(filter);
-    free(str);
-    str = celix_utils_strdup("(!(test_attr3=*))");
-    filter = celix_filter_create(str);
+    filter = celix_filter_create("(!(test_attr3=*))");
     result = celix_filter_match(filter, props);
     EXPECT_TRUE(result);
+    celix_filter_destroy(filter);
 
     // Test LESSEQUAL less
-    celix_filter_destroy(filter);
-    free(str);
-    str = celix_utils_strdup("(test_attr1<=attr5)");
-    filter = celix_filter_create(str);
+    filter = celix_filter_create("(test_attr1<=attr5)");
     result = celix_filter_match(filter, props);
     EXPECT_TRUE(result);
+    celix_filter_destroy(filter);
 
     // Test LESSEQUAL equals
-    celix_filter_destroy(filter);
-    free(str);
-    str = celix_utils_strdup("(test_attr2<=attr2)");
-    filter = celix_filter_create(str);
+    filter = celix_filter_create("(test_attr2<=attr2)");
     result = celix_filter_match(filter, props);
     EXPECT_TRUE(result);
+    celix_filter_destroy(filter);
 
     // test LESSEQUAL false
-    celix_filter_destroy(filter);
-    free(str);
-    str = celix_utils_strdup("(test_attr2<=attr1)");
-    filter = celix_filter_create(str);
+    filter = celix_filter_create("(test_attr2<=attr1)");
     result = celix_filter_match(filter, props);
     EXPECT_FALSE(result);
+    celix_filter_destroy(filter);
 
     // test GREATEREQUAL greater
-    celix_filter_destroy(filter);
-    free(str);
-    str = celix_utils_strdup("(test_attr2>=attr1)");
-    filter = celix_filter_create(str);
+    filter = celix_filter_create("(test_attr2>=attr1)");
     result = celix_filter_match(filter, props);
     EXPECT_TRUE(result);
+    celix_filter_destroy(filter);
 
     // test GREATEREQUAL equals
-    celix_filter_destroy(filter);
-    free(str);
-    str = celix_utils_strdup("(test_attr2>=attr2)");
-    filter = celix_filter_create(str);
+    filter = celix_filter_create("(test_attr2>=attr2)");
     result = celix_filter_match(filter, props);
     EXPECT_TRUE(result);
+    celix_filter_destroy(filter);
 
     // test GREATEREQUAL false
-    celix_filter_destroy(filter);
-    free(str);
-    str = celix_utils_strdup("(test_attr1>=attr5)");
-    filter = celix_filter_create(str);
+    filter = celix_filter_create("(test_attr1>=attr5)");
     result = celix_filter_match(filter, props);
     EXPECT_FALSE(result);
+    celix_filter_destroy(filter);
 
     // test LESS less
-    celix_filter_destroy(filter);
-    free(str);
-    str = celix_utils_strdup("(test_attr1<attr5)");
-    filter = celix_filter_create(str);
+    filter = celix_filter_create("(test_attr1<attr5)");
     result = celix_filter_match(filter, props);
     EXPECT_TRUE(result);
+    celix_filter_destroy(filter);
 
     // test LESS equals
-    celix_filter_destroy(filter);
-    free(str);
-    str = celix_utils_strdup("(test_attr2<attr2)");
-    filter = celix_filter_create(str);
+    filter = celix_filter_create("(test_attr2<attr2)");
     result = celix_filter_match(filter, props);
     EXPECT_FALSE(result);
+    celix_filter_destroy(filter);
 
     // test LESS false
-    celix_filter_destroy(filter);
-    free(str);
-    str = celix_utils_strdup("(test_attr2<attr1)");
-    filter = celix_filter_create(str);
+    filter = celix_filter_create("(test_attr2<attr1)");
     result = celix_filter_match(filter, props);
     EXPECT_FALSE(result);
+    celix_filter_destroy(filter);
+
 
     // test GREATER greater
-    celix_filter_destroy(filter);
-    free(str);
-    str = celix_utils_strdup("(test_attr2>attr1)");
-    filter = celix_filter_create(str);
+    filter = celix_filter_create("(test_attr2>attr1)");
     result = celix_filter_match(filter, props);
     EXPECT_TRUE(result);
+    celix_filter_destroy(filter);
+
 
     // test GREATER equals
-    celix_filter_destroy(filter);
-    free(str);
-    str = celix_utils_strdup("(test_attr2>attr2)");
-    filter = celix_filter_create(str);
+    filter = celix_filter_create("(test_attr2>attr2)");
     result = celix_filter_match(filter, props);
     EXPECT_FALSE(result);
+    celix_filter_destroy(filter);
+
 
     // test GREATER false
-    celix_filter_destroy(filter);
-    free(str);
-    str = celix_utils_strdup("(test_attr1>attr5)");
-    filter = celix_filter_create(str);
+    filter = celix_filter_create("(test_attr1>attr5)");
     result = celix_filter_match(filter, props);
     EXPECT_FALSE(result);
+    celix_filter_destroy(filter);
+
 
     // test SUBSTRING equals
-    celix_filter_destroy(filter);
-    free(str);
-    str = celix_utils_strdup("(test_attr1=attr*)");
-    filter = celix_filter_create(str);
+    filter = celix_filter_create("(test_attr1=attr*)");
     result = celix_filter_match(filter, props);
     EXPECT_TRUE(result);
-
     celix_filter_destroy(filter);
-    free(str);
-    str = celix_utils_strdup("(test_attr1=attr*charsNotPresent)");
-    filter = celix_filter_create(str);
+
+    filter = celix_filter_create("(test_attr1=attr*charsNotPresent)");
     result = celix_filter_match(filter, props);
     EXPECT_FALSE(result);
-
-    // cleanup
-    celix_properties_destroy(props);
     celix_filter_destroy(filter);
-    free(str);
-    free(key);
-    free(key2);
-    free(val);
-    free(val2);
 }
 
 TEST_F(FilterTestSuite, MatchRecursionTest) {
@@ -383,21 +334,20 @@ TEST_F(FilterTestSuite, MatchRecursionTest) {
 
 TEST_F(FilterTestSuite, FalseMatchTest) {
     auto* str = "(&(test_attr1=attr1)(&(test_attr2=attr2)(test_attr3=attr3)))";
-    celix_filter_t* filter = celix_filter_create(str);
-    celix_properties_t* props = celix_properties_create();
+    celix_autoptr(celix_filter_t) filter = celix_filter_create(str);
+    celix_autoptr(celix_properties_t) props = celix_properties_create();
     auto* key = "test_attr1";
     auto* val = "attr1";
     auto* key2 = "test_attr2";
     auto* val2 = "attr2";
     celix_properties_set(props, key, val);
     celix_properties_set(props, key2, val2);
-
     bool result = celix_filter_match(filter, props);
     ASSERT_FALSE(result);
 
-    // cleanup
-    celix_properties_destroy(props);
-    celix_filter_destroy(filter);
+    celix_autoptr(celix_filter_t) filter2 = celix_filter_create("(|(non-existing=false))");
+    result = celix_filter_match(filter2, props);
+    ASSERT_FALSE(result);
 }
 
 TEST_F(FilterTestSuite, GetStringTest) {
@@ -412,14 +362,20 @@ TEST_F(FilterTestSuite, GetStringTest) {
 }
 
 TEST_F(FilterTestSuite, FilterEqualsTest) {
-    auto* f1 = celix_filter_create("(test_attr1=attr1)");
-    auto* f2 = celix_filter_create("(test_attr1=attr1)");
-    auto* f3 = celix_filter_create("(test_attr1=attr2)");
+    celix_autoptr(celix_filter_t) f1 = celix_filter_create("(test_attr1=attr1)");
+    celix_autoptr(celix_filter_t) f2 = celix_filter_create("(test_attr1=attr1)");
+    celix_autoptr(celix_filter_t) f3 = celix_filter_create("(test_attr1>attr1)");
+    celix_autoptr(celix_filter_t) f4 = celix_filter_create("(&(test_attr1=attr1)(test_attr2=attr2))");
+    celix_autoptr(celix_filter_t) f5 = celix_filter_create("(&(test_attr1=attr1)(test_attr2=attr2))");
+    celix_autoptr(celix_filter_t) f6 = celix_filter_create("(&(test_attr1=attr1)(test_attr2=attr2)(test_attr3=attr3))");
+
+
+    EXPECT_TRUE(celix_filter_equals(f1, f1));
+    EXPECT_FALSE(celix_filter_equals(f1, nullptr));
     EXPECT_TRUE(celix_filter_equals(f1, f2));
     EXPECT_FALSE(celix_filter_equals(f1, f3));
-    celix_filter_destroy(f1);
-    celix_filter_destroy(f2);
-    celix_filter_destroy(f3);
+    EXPECT_TRUE(celix_filter_equals(f4, f5));
+    EXPECT_FALSE(celix_filter_equals(f4, f6));
 }
 
 TEST_F(FilterTestSuite, AutoCleanupTest) {
@@ -441,6 +397,8 @@ TEST_F(FilterTestSuite, TypedPropertiesAndFilterTest) {
     celix_properties_setLong(props, "long", 1L);
     celix_properties_setDouble(props, "double", 0.0);
     celix_properties_setBool(props, "bool", true);
+    celix_properties_setBool(props, "bool2", false);
+    celix_properties_set(props, "strBool", "true");
     celix_properties_setVersion(props, "version", version);
 
     celix_autoptr(celix_filter_t) filter1 =
@@ -456,8 +414,11 @@ TEST_F(FilterTestSuite, TypedPropertiesAndFilterTest) {
     EXPECT_TRUE(celix_filter_match(filter3, props));
 
     celix_autoptr(celix_filter_t) filter4 =
-            celix_filter_create("(&(str!=test)(long!=1)(double!=0.0)(bool!=true)(version!=1.2.3))");
+            celix_filter_create("(&(str!=test)(long!=1)(double!=0.0)(bool!=true)(bool2=true)(version!=1.2.3))");
     EXPECT_FALSE(celix_filter_match(filter4, props));
+
+    celix_autoptr(celix_filter_t) filter5 = celix_filter_create("(strBool=true)");
+    EXPECT_TRUE(celix_filter_match(filter5, props));
 }
 
 
@@ -565,6 +526,10 @@ TEST_F(FilterTestSuite, DeprecatedApiTest) {
     status = filter_getString(f1, &str);
     EXPECT_EQ(status, CELIX_SUCCESS);
     EXPECT_STREQ(str, "(test_attr1=attr1)");
+
+    status = filter_match(f1, nullptr, &result);
+    EXPECT_EQ(status, CELIX_SUCCESS);
+    EXPECT_FALSE(result);
 
     filter_destroy(f1);
     filter_destroy(f2);

--- a/libs/utils/gtest/src/FilterTestSuite.cc
+++ b/libs/utils/gtest/src/FilterTestSuite.cc
@@ -18,346 +18,356 @@
  */
 
 #include <gtest/gtest.h>
+
 #include "celix_filter.h"
 #include "celix_utils.h"
+#include "celix_err.h"
 
+class FilterTestSuite : public ::testing::Test {
+  public:
+    FilterTestSuite() {
+        celix_err_resetErrors();
+    }
 
-class FilterTestSuite : public ::testing::Test {};
+    ~FilterTestSuite() override {
+        celix_err_printErrors(stderr, nullptr, nullptr);
+    }
+};
 
-TEST_F(FilterTestSuite, create_destroy){
+TEST_F(FilterTestSuite, CreateDestroyTest) {
     const char* filter_str = "(&(test_attr1=attr1)(|(test_attr2=attr2)(test_attr3=attr3)))";
-    celix_filter_t * get_filter;
+    celix_filter_t* filter;
 
-    get_filter = celix_filter_create(filter_str);
-    ASSERT_TRUE(get_filter != NULL);
+    filter = celix_filter_create(filter_str);
+    ASSERT_TRUE(filter != nullptr);
 
-    celix_filter_destroy(get_filter);
+    celix_filter_destroy(filter);
 }
 
-TEST_F(FilterTestSuite, create_fail_missing_opening_brackets){
-    celix_filter_t * get_filter;
+TEST_F(FilterTestSuite, MissingOpenBracketsCreateTest) {
+    celix_filter_t* filter;
 
-    //test missing opening brackets in main filter
-    const char *filter_str1 = "&(test_attr1=attr1)(|(test_attr2=attr2)(test_attr3=attr3))";
-    get_filter = celix_filter_create(filter_str1);
-    ASSERT_TRUE(get_filter == NULL);
+    // test missing opening brackets in main filter
+    const char* str1 = "&(test_attr1=attr1)(|(test_attr2=attr2)(test_attr3=attr3))";
+    filter = celix_filter_create(str1);
+    ASSERT_TRUE(filter == nullptr);
 
-    //test missing opening brackets in AND comparator
-    const char *filter_str2 = "(&test_attr1=attr1|(test_attr2=attr2)(test_attr3=attr3))";
-    get_filter = celix_filter_create(filter_str2);
-    ASSERT_TRUE(get_filter == NULL);
+    // test missing opening brackets in AND comparator
+    const char* str2 = "(&test_attr1=attr1|(test_attr2=attr2)(test_attr3=attr3))";
+    filter = celix_filter_create(str2);
+    ASSERT_TRUE(filter == nullptr);
 
-    //test missing opening brackets in AND comparator
-    const char *filter_str3 = "(&(test_attr1=attr1)(|test_attr2=attr2(test_attr3=attr3))";
-    get_filter = celix_filter_create(filter_str3);
-    ASSERT_TRUE(get_filter == NULL);
+    // test missing opening brackets in AND comparator
+    const char* str3 = "(&(test_attr1=attr1)(|test_attr2=attr2(test_attr3=attr3))";
+    filter = celix_filter_create(str3);
+    ASSERT_TRUE(filter == nullptr);
 
-    //test missing opening brackets in NOT comparator
-    const char *filter_str4 = "(&(test_attr1=attr1)(!test_attr2=attr2)";
-    get_filter = celix_filter_create(filter_str4);
-    ASSERT_TRUE(get_filter == NULL);
+    // test missing opening brackets in NOT comparator
+    const char* str4 = "(&(test_attr1=attr1)(!test_attr2=attr2)";
+    filter = celix_filter_create(str4);
+    ASSERT_TRUE(filter == nullptr);
 }
 
-TEST_F(FilterTestSuite, create_fail_missing_closing_brackets){
-    char * filter_str;
-    celix_filter_t * get_filter;
-    //test missing closing brackets in substring
-    filter_str = celix_utils_strdup("(&(test_attr1=attr1)(|(test_attr2=attr2)(test_attr3=attr3");
-    get_filter = celix_filter_create(filter_str);
-    ASSERT_TRUE(get_filter == NULL);
-    free(filter_str);
+TEST_F(FilterTestSuite, MissingClosingBracketsCreateTest) {
+    char* str;
+    celix_filter_t* filter;
+    // test missing closing brackets in substring
+    str = celix_utils_strdup("(&(test_attr1=attr1)(|(test_attr2=attr2)(test_attr3=attr3");
+    filter = celix_filter_create(str);
+    ASSERT_TRUE(filter == nullptr);
+    free(str);
 
-    //test missing closing brackets in value
-    filter_str = celix_utils_strdup("(&(test_attr1=attr1)(|(test_attr2=attr2)(test_attr3>=attr3");
-    get_filter = celix_filter_create(filter_str);
-    ASSERT_TRUE(get_filter == NULL);
-    free(filter_str);
+    // test missing closing brackets in value
+    str = celix_utils_strdup("(&(test_attr1=attr1)(|(test_attr2=attr2)(test_attr3>=attr3");
+    filter = celix_filter_create(str);
+    ASSERT_TRUE(filter == nullptr);
+    free(str);
 }
 
-TEST_F(FilterTestSuite, create_fail_invalid_closing_brackets) {
-    char *filter_str;
-    celix_filter_t *get_filter;
+TEST_F(FilterTestSuite, InvalidClosingBracketsCreateTest) {
+    char* str;
+    celix_filter_t* filter;
 
-    //test missing closing brackets in substring
-    filter_str = celix_utils_strdup("(&(test_attr1=attr1)(|(test_attr2=attr2)(test_attr3=at(tr3)))");
-    get_filter = celix_filter_create(filter_str);
-    ASSERT_TRUE(get_filter == NULL);
-    free(filter_str);
+    // test missing closing brackets in substring
+    str = celix_utils_strdup("(&(test_attr1=attr1)(|(test_attr2=attr2)(test_attr3=at(tr3)))");
+    filter = celix_filter_create(str);
+    ASSERT_TRUE(filter == nullptr);
+    free(str);
 
-    //test missing closing brackets in value
-    filter_str = celix_utils_strdup("(&(test_attr1=attr1)(|(test_attr2=attr2)(test_attr3>=att(r3)))");
-    get_filter = celix_filter_create(filter_str);
-    ASSERT_TRUE(get_filter == NULL);
-    free(filter_str);
+    // test missing closing brackets in value
+    str = celix_utils_strdup("(&(test_attr1=attr1)(|(test_attr2=attr2)(test_attr3>=att(r3)))");
+    filter = celix_filter_create(str);
+    ASSERT_TRUE(filter == nullptr);
+    free(str);
 }
 
-TEST_F(FilterTestSuite, create_misc) {
-    celix_filter_t *get_filter;
-    //test trailing chars
-    const char *filter_str1 = "(&(test_attr1=attr1)(|(test_attr2=attr2)(test_attr3=attr3))) oh no! trailing chars";
-    get_filter = celix_filter_create(filter_str1);
-    ASSERT_TRUE(get_filter == NULL);
+TEST_F(FilterTestSuite, MiscInvalidCreateTest) {
+    celix_filter_t* filter;
+    // test trailing chars
+    const char* str1 = "(&(test_attr1=attr1)(|(test_attr2=attr2)(test_attr3=attr3))) oh no! trailing chars";
+    filter = celix_filter_create(str1);
+    ASSERT_TRUE(filter == nullptr);
 
-    //test half APPROX operator (should be "~=", instead is "~")
-    const char *filter_str2 = "(&(test_attr1=attr1)(|(test_attr2=attr2)(test_attr3~attr3)))";
-    get_filter = celix_filter_create(filter_str2);
-    ASSERT_TRUE(get_filter == NULL);
+    // test half APPROX operator (should be "~=", instead is "~")
+    const char* str2 = "(&(test_attr1=attr1)(|(test_attr2=attr2)(test_attr3~attr3)))";
+    filter = celix_filter_create(str2);
+    ASSERT_TRUE(filter == nullptr);
 
-    //test PRESENT operator with trailing chars (should just register as substrings: "*" and "attr3")
-    const char *filter_str3 = "(test_attr3=*attr3)";
-    get_filter = celix_filter_create(filter_str3);
-    ASSERT_TRUE(get_filter != NULL);
-    ASSERT_EQ(CELIX_FILTER_OPERAND_SUBSTRING, get_filter->operand);
-    ASSERT_EQ(2, celix_arrayList_size((celix_array_list_t *) get_filter->children));
-    celix_filter_destroy(get_filter);
+    // test PRESENT operator with trailing chars (should just register as substrings: "*" and "attr3")
+    const char* str3 = "(test_attr3=*attr3)";
+    filter = celix_filter_create(str3);
+    ASSERT_TRUE(filter != nullptr);
+    ASSERT_EQ(CELIX_FILTER_OPERAND_SUBSTRING, filter->operand);
+    ASSERT_EQ(2, celix_arrayList_size((celix_array_list_t*)filter->children));
+    celix_filter_destroy(filter);
 
-    //test parsing a attribute of 0 length
-    const char *filter_str4 = "(>=attr3)";
-    get_filter = celix_filter_create(filter_str4);
-    ASSERT_TRUE(get_filter == NULL);
+    // test parsing an attribute of 0 length
+    const char* str4 = "(>=attr3)";
+    filter = celix_filter_create(str4);
+    ASSERT_TRUE(filter == nullptr);
 
-    //test parsing a value of 0 length
-    const char *filter_str5 = "(test_attr3>=)";
-    get_filter = celix_filter_create(filter_str5);
-    ASSERT_TRUE(get_filter == NULL);
+    // test parsing a value of 0 length
+    const char* str5 = "(test_attr3>=)";
+    filter = celix_filter_create(str5);
+    ASSERT_TRUE(filter == nullptr);
 
-    //test parsing a value with a escaped closing bracket "\)"
-    const char *filter_str6 = "(test_attr3>=strWith\\)inIt)";
-    get_filter = celix_filter_create(filter_str6);
-    ASSERT_TRUE(get_filter != NULL);
-    ASSERT_STREQ("strWith)inIt", (char *) get_filter->value);
-    celix_filter_destroy(get_filter);
+    // test parsing a value with a escaped closing bracket "\)"
+    const char* str6 = "(test_attr3>=strWith\\)inIt)";
+    filter = celix_filter_create(str6);
+    ASSERT_TRUE(filter != nullptr);
+    ASSERT_STREQ("strWith)inIt", (char*)filter->value);
+    celix_filter_destroy(filter);
 
-    //test parsing a substring with a escaped closing bracket "\)"
-    const char *filter_str7 = "(test_attr3=strWith\\)inIt)";
-    get_filter = celix_filter_create(filter_str7);
-    ASSERT_TRUE(get_filter != NULL);
-    ASSERT_STREQ("strWith)inIt", (char *) get_filter->value);
-    celix_filter_destroy(get_filter);
+    // test parsing a substring with an escaped closing bracket "\)"
+    const char* str7 = "(test_attr3=strWith\\)inIt)";
+    filter = celix_filter_create(str7);
+    ASSERT_TRUE(filter != nullptr);
+    ASSERT_STREQ("strWith)inIt", (char*)filter->value);
+    celix_filter_destroy(filter);
 }
 
-TEST_F(FilterTestSuite, match_comparators) {
-    char *filter_str;
-    celix_filter_t *filter;
-    celix_properties_t *props = celix_properties_create();
-    char *key = celix_utils_strdup("test_attr1");
-    char *val = celix_utils_strdup("attr1");
-    char *key2 = celix_utils_strdup("test_attr2");
-    char *val2 = celix_utils_strdup("attr2");
+TEST_F(FilterTestSuite, MatchEqualTest) {
+    char* str;
+    celix_filter_t* filter;
+    celix_properties_t* props = celix_properties_create();
+    char* key = celix_utils_strdup("test_attr1");
+    char* val = celix_utils_strdup("attr1");
+    char* key2 = celix_utils_strdup("test_attr2");
+    char* val2 = celix_utils_strdup("attr2");
     celix_properties_set(props, key, val);
     celix_properties_set(props, key2, val2);
-    //test AND
-    filter_str = celix_utils_strdup("(&(test_attr1=attr1)(|(test_attr2=attr2)(!(test_attr3=attr3))))");
-    filter = celix_filter_create(filter_str);
+    // test AND
+    str = celix_utils_strdup("(&(test_attr1=attr1)(|(test_attr2=attr2)(!(test_attr3=attr3))))");
+    filter = celix_filter_create(str);
     bool result = celix_filter_match(filter, props);
     ASSERT_TRUE(result);
 
-    //test AND false
+    // test AND false
     celix_filter_destroy(filter);
-    free(filter_str);
-    filter_str = celix_utils_strdup("(test_attr1=attr1)(test_attr1=attr2))");
-    filter = celix_filter_create(filter_str);
+    free(str);
+    str = celix_utils_strdup("(test_attr1=attr1)(test_attr1=attr2))");
+    filter = celix_filter_create(str);
     ASSERT_TRUE(filter == nullptr);
     result = celix_filter_match(filter, props);
     ASSERT_TRUE(result);
 
-//cleanup
+    // cleanup
     celix_properties_destroy(props);
     celix_filter_destroy(filter);
-    free(filter_str);
+    free(str);
     free(key);
     free(key2);
     free(val);
     free(val2);
 }
 
-TEST_F(FilterTestSuite, match_operators) {
-    char *filter_str;
-    celix_filter_t *filter;
-    celix_properties_t *props = celix_properties_create();
-    char *key = celix_utils_strdup("test_attr1");
-    char *val = celix_utils_strdup("attr1");
-    char *key2 = celix_utils_strdup("test_attr2");
-    char *val2 = celix_utils_strdup("attr2");
+TEST_F(FilterTestSuite, MatchTest) {
+    char* str;
+    celix_filter_t* filter;
+    celix_properties_t* props = celix_properties_create();
+    char* key = celix_utils_strdup("test_attr1");
+    char* val = celix_utils_strdup("attr1");
+    char* key2 = celix_utils_strdup("test_attr2");
+    char* val2 = celix_utils_strdup("attr2");
     celix_properties_set(props, key, val);
     celix_properties_set(props, key2, val2);
 
     // Test EQUALS
-    filter_str = celix_utils_strdup("(test_attr1=attr1)");
-    filter = celix_filter_create(filter_str);
+    str = celix_utils_strdup("(test_attr1=attr1)");
+    filter = celix_filter_create(str);
     bool result = celix_filter_match(filter, props);
     EXPECT_TRUE(result);
 
     // Test EQUALS false
     celix_filter_destroy(filter);
-    free(filter_str);
-    filter_str = celix_utils_strdup("(test_attr1=falseString)");
-    filter = celix_filter_create(filter_str);
+    free(str);
+    str = celix_utils_strdup("(test_attr1=falseString)");
+    filter = celix_filter_create(str);
     result = celix_filter_match(filter, props);
     EXPECT_FALSE(result);
 
     celix_filter_destroy(filter);
-    free(filter_str);
-    filter_str = celix_utils_strdup("(test_attr1~=attr1)");
-    filter = celix_filter_create(filter_str);
+    free(str);
+    str = celix_utils_strdup("(test_attr1~=attr1)");
+    filter = celix_filter_create(str);
     result = celix_filter_match(filter, props);
     EXPECT_TRUE(result);
 
     celix_filter_destroy(filter);
-    free(filter_str);
-    filter_str = celix_utils_strdup("(test_attr1~=ATTR1)");
-    filter = celix_filter_create(filter_str);
+    free(str);
+    str = celix_utils_strdup("(test_attr1~=ATTR1)");
+    filter = celix_filter_create(str);
     result = celix_filter_match(filter, props);
     EXPECT_TRUE(result);
 
     // Test PRESENT
     celix_filter_destroy(filter);
-    free(filter_str);
-    filter_str = celix_utils_strdup("(test_attr1=*)");
-    filter = celix_filter_create(filter_str);
+    free(str);
+    str = celix_utils_strdup("(test_attr1=*)");
+    filter = celix_filter_create(str);
     result = celix_filter_match(filter, props);
     EXPECT_TRUE(result);
 
     // Test NOT PRESENT
     celix_filter_destroy(filter);
-    free(filter_str);
-    filter_str = celix_utils_strdup("(test_attr3=*)");
-    filter = celix_filter_create(filter_str);
+    free(str);
+    str = celix_utils_strdup("(test_attr3=*)");
+    filter = celix_filter_create(str);
     result = celix_filter_match(filter, props);
     EXPECT_FALSE(result);
 
     // Test NOT PRESENT
     celix_filter_destroy(filter);
-    free(filter_str);
-    filter_str = celix_utils_strdup("(!(test_attr3=*))");
-    filter = celix_filter_create(filter_str);
+    free(str);
+    str = celix_utils_strdup("(!(test_attr3=*))");
+    filter = celix_filter_create(str);
     result = celix_filter_match(filter, props);
     EXPECT_TRUE(result);
 
     // Test LESSEQUAL less
     celix_filter_destroy(filter);
-    free(filter_str);
-    filter_str = celix_utils_strdup("(test_attr1<=attr5)");
-    filter = celix_filter_create(filter_str);
+    free(str);
+    str = celix_utils_strdup("(test_attr1<=attr5)");
+    filter = celix_filter_create(str);
     result = celix_filter_match(filter, props);
     EXPECT_TRUE(result);
 
     // Test LESSEQUAL equals
     celix_filter_destroy(filter);
-    free(filter_str);
-    filter_str = celix_utils_strdup("(test_attr2<=attr2)");
-    filter = celix_filter_create(filter_str);
+    free(str);
+    str = celix_utils_strdup("(test_attr2<=attr2)");
+    filter = celix_filter_create(str);
     result = celix_filter_match(filter, props);
     EXPECT_TRUE(result);
 
-    //test LESSEQUAL false
+    // test LESSEQUAL false
     celix_filter_destroy(filter);
-    free(filter_str);
-    filter_str = celix_utils_strdup("(test_attr2<=attr1)");
-    filter = celix_filter_create(filter_str);
+    free(str);
+    str = celix_utils_strdup("(test_attr2<=attr1)");
+    filter = celix_filter_create(str);
     result = celix_filter_match(filter, props);
     EXPECT_FALSE(result);
 
-    //test GREATEREQUAL greater
+    // test GREATEREQUAL greater
     celix_filter_destroy(filter);
-    free(filter_str);
-    filter_str = celix_utils_strdup("(test_attr2>=attr1)");
-    filter = celix_filter_create(filter_str);
+    free(str);
+    str = celix_utils_strdup("(test_attr2>=attr1)");
+    filter = celix_filter_create(str);
     result = celix_filter_match(filter, props);
     EXPECT_TRUE(result);
 
-    //test GREATEREQUAL equals
+    // test GREATEREQUAL equals
     celix_filter_destroy(filter);
-    free(filter_str);
-    filter_str = celix_utils_strdup("(test_attr2>=attr2)");
-    filter = celix_filter_create(filter_str);
+    free(str);
+    str = celix_utils_strdup("(test_attr2>=attr2)");
+    filter = celix_filter_create(str);
     result = celix_filter_match(filter, props);
     EXPECT_TRUE(result);
 
-    //test GREATEREQUAL false
+    // test GREATEREQUAL false
     celix_filter_destroy(filter);
-    free(filter_str);
-    filter_str = celix_utils_strdup("(test_attr1>=attr5)");
-    filter = celix_filter_create(filter_str);
+    free(str);
+    str = celix_utils_strdup("(test_attr1>=attr5)");
+    filter = celix_filter_create(str);
     result = celix_filter_match(filter, props);
     EXPECT_FALSE(result);
 
-    //test LESS less
+    // test LESS less
     celix_filter_destroy(filter);
-    free(filter_str);
-    filter_str = celix_utils_strdup("(test_attr1<attr5)");
-    filter = celix_filter_create(filter_str);
+    free(str);
+    str = celix_utils_strdup("(test_attr1<attr5)");
+    filter = celix_filter_create(str);
     result = celix_filter_match(filter, props);
     EXPECT_TRUE(result);
 
-    //test LESS equals
+    // test LESS equals
     celix_filter_destroy(filter);
-    free(filter_str);
-    filter_str = celix_utils_strdup("(test_attr2<attr2)");
-    filter = celix_filter_create(filter_str);
+    free(str);
+    str = celix_utils_strdup("(test_attr2<attr2)");
+    filter = celix_filter_create(str);
     result = celix_filter_match(filter, props);
     EXPECT_FALSE(result);
 
-    //test LESS false
+    // test LESS false
     celix_filter_destroy(filter);
-    free(filter_str);
-    filter_str = celix_utils_strdup("(test_attr2<attr1)");
-    filter = celix_filter_create(filter_str);
+    free(str);
+    str = celix_utils_strdup("(test_attr2<attr1)");
+    filter = celix_filter_create(str);
     result = celix_filter_match(filter, props);
     EXPECT_FALSE(result);
 
-    //test GREATER greater
+    // test GREATER greater
     celix_filter_destroy(filter);
-    free(filter_str);
-    filter_str = celix_utils_strdup("(test_attr2>attr1)");
-    filter = celix_filter_create(filter_str);
+    free(str);
+    str = celix_utils_strdup("(test_attr2>attr1)");
+    filter = celix_filter_create(str);
     result = celix_filter_match(filter, props);
     EXPECT_TRUE(result);
 
-    //test GREATER equals
+    // test GREATER equals
     celix_filter_destroy(filter);
-    free(filter_str);
-    filter_str = celix_utils_strdup("(test_attr2>attr2)");
-    filter = celix_filter_create(filter_str);
+    free(str);
+    str = celix_utils_strdup("(test_attr2>attr2)");
+    filter = celix_filter_create(str);
     result = celix_filter_match(filter, props);
     EXPECT_FALSE(result);
 
-    //test GREATER false
+    // test GREATER false
     celix_filter_destroy(filter);
-    free(filter_str);
-    filter_str = celix_utils_strdup("(test_attr1>attr5)");
-    filter = celix_filter_create(filter_str);
+    free(str);
+    str = celix_utils_strdup("(test_attr1>attr5)");
+    filter = celix_filter_create(str);
     result = celix_filter_match(filter, props);
     EXPECT_FALSE(result);
 
-    //test SUBSTRING equals
+    // test SUBSTRING equals
     celix_filter_destroy(filter);
-    free(filter_str);
-    filter_str = celix_utils_strdup("(test_attr1=attr*)");
-    filter = celix_filter_create(filter_str);
+    free(str);
+    str = celix_utils_strdup("(test_attr1=attr*)");
+    filter = celix_filter_create(str);
     result = celix_filter_match(filter, props);
     EXPECT_TRUE(result);
 
     celix_filter_destroy(filter);
-    free(filter_str);
-    filter_str = celix_utils_strdup("(test_attr1=attr*charsNotPresent)");
-    filter = celix_filter_create(filter_str);
+    free(str);
+    str = celix_utils_strdup("(test_attr1=attr*charsNotPresent)");
+    filter = celix_filter_create(str);
     result = celix_filter_match(filter, props);
     EXPECT_FALSE(result);
 
-    //cleanup
+    // cleanup
     celix_properties_destroy(props);
     celix_filter_destroy(filter);
-    free(filter_str);
+    free(str);
     free(key);
     free(key2);
     free(val);
     free(val2);
 }
 
-TEST_F(FilterTestSuite, match_recursion) {
-    auto* filter_str = "(&(test_attr1=attr1)(|(&(test_attr2=attr2)(!(&(test_attr1=attr1)(test_attr3=attr3))))(test_attr3=attr3)))";
-    auto* filter = celix_filter_create(filter_str);
+TEST_F(FilterTestSuite, MatchRecursionTest) {
+    auto* str = "(&(test_attr1=attr1)(|(&(test_attr2=attr2)(!(&(test_attr1=attr1)(test_attr3=attr3))))(test_attr3=attr3)))";
+    auto* filter = celix_filter_create(str);
     auto* props = celix_properties_create();
     auto* key = "test_attr1";
     auto* val = "attr1";
@@ -372,9 +382,9 @@ TEST_F(FilterTestSuite, match_recursion) {
     celix_filter_destroy(filter);
 }
 
-TEST_F(FilterTestSuite, match_false) {
-    auto* filter_str = "(&(test_attr1=attr1)(&(test_attr2=attr2)(test_attr3=attr3)))";
-    celix_filter_t* filter = celix_filter_create(filter_str);
+TEST_F(FilterTestSuite, FalseMatchTest) {
+    auto* str = "(&(test_attr1=attr1)(&(test_attr2=attr2)(test_attr3=attr3)))";
+    celix_filter_t* filter = celix_filter_create(str);
     celix_properties_t* props = celix_properties_create();
     auto* key = "test_attr1";
     auto* val = "attr1";
@@ -386,29 +396,28 @@ TEST_F(FilterTestSuite, match_false) {
     bool result = celix_filter_match(filter, props);
     ASSERT_FALSE(result);
 
-    //cleanup
+    // cleanup
     celix_properties_destroy(props);
     celix_filter_destroy(filter);
 }
 
-TEST_F(FilterTestSuite, getString) {
-    auto* filter_str = "(&(test_attr1=attr1)(|(test_attr2=attr2)(test_attr3=attr3)))";
-    celix_filter_t * filter = celix_filter_create(filter_str);
+TEST_F(FilterTestSuite, GetStringTest) {
+    auto* str = "(&(test_attr1=attr1)(|(test_attr2=attr2)(test_attr3=attr3)))";
+    celix_filter_t* filter = celix_filter_create(str);
 
-    const char * get_str = celix_filter_getFilterString(filter);
-    ASSERT_STREQ(filter_str, get_str);
+    const char* get_str = celix_filter_getFilterString(filter);
+    ASSERT_STREQ(str, get_str);
 
-    //cleanup
+    // cleanup
     celix_filter_destroy(filter);
 }
 
-
-TEST_F(FilterTestSuite, filterMatch) {
+TEST_F(FilterTestSuite, FilterEqualsTest) {
     auto* f1 = celix_filter_create("(test_attr1=attr1)");
     auto* f2 = celix_filter_create("(test_attr1=attr1)");
     auto* f3 = celix_filter_create("(test_attr1=attr2)");
-    EXPECT_TRUE(celix_filter_matchFilter(f1, f2));
-    EXPECT_FALSE(celix_filter_matchFilter(f1, f3));
+    EXPECT_TRUE(celix_filter_equals(f1, f2));
+    EXPECT_FALSE(celix_filter_equals(f1, f3));
     celix_filter_destroy(f1);
     celix_filter_destroy(f2);
     celix_filter_destroy(f3);
@@ -418,16 +427,56 @@ TEST_F(FilterTestSuite, AutoCleanupTest) {
     celix_autoptr(celix_filter_t) filter = celix_filter_create("(test_attr1=attr1)");
 }
 
-TEST_F(FilterTestSuite, create_fail_missing_filter_operand) {
-    celix_filter_t * filter= celix_filter_create("(&(test))");
-    ASSERT_TRUE(filter == NULL);
+TEST_F(FilterTestSuite, MissingOperandCreateTest) {
+    celix_filter_t* filter = celix_filter_create("(&(test))");
+    ASSERT_TRUE(filter == nullptr);
 
-    filter= celix_filter_create("(!(test))");
-    ASSERT_TRUE(filter == NULL);
+    filter = celix_filter_create("(!(test))");
+    ASSERT_TRUE(filter == nullptr);
+}
+
+TEST_F(FilterTestSuite, SubStringTest) {
+    celix_autoptr(celix_properties_t) props = celix_properties_create();
+    celix_properties_set(props, "test", "John Bob Doe");
+
+    //test filter with matching subInitial
+    celix_autoptr(celix_filter_t) filter1 = celix_filter_create("(test=Jo*)");
+    EXPECT_TRUE(celix_filter_match(filter1, props));
+
+    //test filter with un-matching subInitial
+    celix_autoptr(celix_filter_t) filter2 = celix_filter_create("(test=Joo*)");
+    EXPECT_FALSE(celix_filter_match(filter2, props));
+
+    //test filter with matching subFinal
+    celix_autoptr(celix_filter_t) filter3 = celix_filter_create("(test=*Doe)");
+    EXPECT_TRUE(celix_filter_match(filter3, props));
+
+    //test filter with un-matching subFinal
+    celix_autoptr(celix_filter_t) filter4 = celix_filter_create("(test=*Doo)");
+    EXPECT_FALSE(celix_filter_match(filter4, props));
+
+    //test filter with matching subAny
+    celix_autoptr(celix_filter_t) filter5 = celix_filter_create("(test=*Bob*)");
+    EXPECT_TRUE(celix_filter_match(filter5, props));
+
+    //test filter with un-matching subAny
+    //TODO fixme
+//    celix_autoptr(celix_filter_t) filter6 = celix_filter_create("(test=*Boo*)");
+//    EXPECT_FALSE(celix_filter_match(filter6, props));
+
+    //test filter with matching subAny, subInitial and subFinal
+    celix_autoptr(celix_filter_t) filter7 = celix_filter_create("(test=Jo*Bob*Doe)");
+    EXPECT_TRUE(celix_filter_match(filter7, props));
+
+    //test filter with un-matching subAny, subInitial and subFinal
+    celix_autoptr(celix_filter_t) filter8 = celix_filter_create("(test=Jo*Boo*Doe)");
+
+    //test filter with un-matching overlapping subAny, subInitial and subFinal
+    celix_autoptr(celix_filter_t) filter9 = celix_filter_create("(test=John B*Bob*b Doe)");
 }
 
 #include "filter.h"
-TEST_F(FilterTestSuite, deprecatedApi) {
+TEST_F(FilterTestSuite, DeprecatedApiTest) {
     auto* f1 = filter_create("(test_attr1=attr1)");
     auto* f2 = filter_create("(test_attr1=attr1)");
     bool result;

--- a/libs/utils/gtest/src/FilterTestSuite.cc
+++ b/libs/utils/gtest/src/FilterTestSuite.cc
@@ -435,6 +435,33 @@ TEST_F(FilterTestSuite, MissingOperandCreateTest) {
     ASSERT_TRUE(filter == nullptr);
 }
 
+TEST_F(FilterTestSuite, TypedPropertiesAndFilterTest) {
+    celix_autoptr(celix_properties_t) props = celix_properties_create();
+    celix_autoptr(celix_version_t) version = celix_version_createVersionFromString("1.2.3");
+    celix_properties_set(props, "str", "test");
+    celix_properties_setLong(props, "long", 1L);
+    celix_properties_setDouble(props, "double", 0.0);
+    celix_properties_setBool(props, "bool", true);
+    celix_properties_setVersion(props, "version", version);
+
+    celix_autoptr(celix_filter_t) filter1 =
+        celix_filter_create("(&(str=test)(long=1)(double=0.0)(bool=true)(version=1.2.3))");
+    EXPECT_TRUE(celix_filter_match(filter1, props));
+
+    celix_autoptr(celix_filter_t) filter2 =
+        celix_filter_create("(&(str>tes)(long>0)(double>-1.0)(bool>false)(version>1.0.0))");
+    EXPECT_TRUE(celix_filter_match(filter2, props));
+
+    celix_autoptr(celix_filter_t) filter3 =
+                celix_filter_create("(&(str<tesu)(long<2)(double<1.0)(bool<=true)(version<2.0.0))");
+    EXPECT_TRUE(celix_filter_match(filter3, props));
+
+    celix_autoptr(celix_filter_t) filter4 =
+            celix_filter_create("(&(str!=test)(long!=1)(double!=0.0)(bool!=true)(version!=1.2.3))");
+    EXPECT_FALSE(celix_filter_match(filter4, props));
+}
+
+
 TEST_F(FilterTestSuite, SubStringTest) {
     celix_autoptr(celix_properties_t) props = celix_properties_create();
     celix_properties_set(props, "test", "John Bob Doe");

--- a/libs/utils/gtest/src/FilterTestSuite.cc
+++ b/libs/utils/gtest/src/FilterTestSuite.cc
@@ -457,54 +457,76 @@ TEST_F(FilterTestSuite, SubStringTest) {
     celix_autoptr(celix_properties_t) props = celix_properties_create();
     celix_properties_set(props, "test", "John Bob Doe");
     celix_properties_set(props, "test2", "*ValueWithStar");
+    celix_properties_set(props, "test3", " Value");
 
     //test filter with matching subInitial
     celix_autoptr(celix_filter_t) filter1 = celix_filter_create("(test=Jo*)");
+    EXPECT_NE(nullptr, filter1);
     EXPECT_TRUE(celix_filter_match(filter1, props));
 
     //test filter with un-matching subInitial
     celix_autoptr(celix_filter_t) filter2 = celix_filter_create("(test=Joo*)");
+    EXPECT_NE(nullptr, filter2);
     EXPECT_FALSE(celix_filter_match(filter2, props));
 
     //test filter with matching subFinal
     celix_autoptr(celix_filter_t) filter3 = celix_filter_create("(test=*Doe)");
+    EXPECT_NE(nullptr, filter3);
     EXPECT_TRUE(celix_filter_match(filter3, props));
 
     //test filter with un-matching subFinal
     celix_autoptr(celix_filter_t) filter4 = celix_filter_create("(test=*Doo)");
+    EXPECT_NE(nullptr, filter4);
     EXPECT_FALSE(celix_filter_match(filter4, props));
 
     //test filter with matching subAny
     celix_autoptr(celix_filter_t) filter5 = celix_filter_create("(test=*Bob*)");
+    EXPECT_NE(nullptr, filter5);
     EXPECT_TRUE(celix_filter_match(filter5, props));
 
     //test filter with un-matching subAny
     celix_autoptr(celix_filter_t) filter6 = celix_filter_create("(test=*Boo*)");
+    EXPECT_NE(nullptr, filter6);
     EXPECT_FALSE(celix_filter_match(filter6, props));
 
     //test filter with matching subAny, subInitial and subFinal
     celix_autoptr(celix_filter_t) filter7 = celix_filter_create("(test=Jo*Bob*Doe)");
+    EXPECT_NE(nullptr, filter7);
     EXPECT_TRUE(celix_filter_match(filter7, props));
 
     //test filter with un-matching subAny, subInitial and subFinal
     celix_autoptr(celix_filter_t) filter8 = celix_filter_create("(test=Jo*Boo*Doe)");
+    EXPECT_NE(nullptr, filter8);
     EXPECT_FALSE(celix_filter_match(filter8, props));
 
     //test filter with un-matching overlapping subAny and subInitial
     celix_autoptr(celix_filter_t) filter9 = celix_filter_create("(test=John B*Bob*b Doe)");
+    EXPECT_NE(nullptr, filter9);
     EXPECT_FALSE(celix_filter_match(filter9, props));
 
     //test filter with un-matching overlapping subAny and subFinal
     celix_autoptr(celix_filter_t) filter10 = celix_filter_create("(test=*Bob*b Doe)");
+    EXPECT_NE(nullptr, filter10);
     EXPECT_FALSE(celix_filter_match(filter10, props));
 
     //test filter with a starting escaped asterisk
     celix_autoptr(celix_filter_t) filter11 = celix_filter_create("(test2=\\*Value*)");
+    EXPECT_NE(nullptr, filter11);
     EXPECT_TRUE(celix_filter_match(filter11, props));
 
     //test filter with an invalid substring
     celix_autoptr(celix_filter_t) filter12 = celix_filter_create("(test=Bob*");
     EXPECT_EQ(nullptr, filter12);
+
+    //test filter with mathing subInitial beginning with whitespace
+    celix_autoptr(celix_filter_t) filter13 = celix_filter_create("(test3= Value*)");
+    EXPECT_NE(nullptr, filter13);
+    EXPECT_TRUE(celix_filter_match(filter13, props));
+
+    //test filter with matching subInitial consisting of spaces
+    celix_autoptr(celix_filter_t) filter14 = celix_filter_create("(test3= *)");
+    EXPECT_NE(nullptr, filter14);
+    EXPECT_TRUE(celix_filter_match(filter14, props));
 }
 
 TEST_F(FilterTestSuite, CreateEmptyFilter) {

--- a/libs/utils/gtest/src/FilterTestSuite.cc
+++ b/libs/utils/gtest/src/FilterTestSuite.cc
@@ -143,6 +143,16 @@ TEST_F(FilterTestSuite, MiscInvalidCreateTest) {
     ASSERT_TRUE(filter != nullptr);
     ASSERT_STREQ("strWith)inIt", (char*)filter->value);
     celix_filter_destroy(filter);
+
+    // test incomplete substring operator
+    const char* str8 = "(test_attr3=*attr3\\";
+    filter = celix_filter_create(str8);
+    ASSERT_TRUE(filter == nullptr);
+
+    // test incomplete substring operator
+    const char* str9 = "(test_attr3=*attr3";
+    filter = celix_filter_create(str9);
+    ASSERT_TRUE(filter == nullptr);
 }
 
 TEST_F(FilterTestSuite, MatchEqualTest) {

--- a/libs/utils/gtest/src/FilterTestSuite.cc
+++ b/libs/utils/gtest/src/FilterTestSuite.cc
@@ -130,6 +130,7 @@ TEST_F(FilterTestSuite, MiscInvalidCreateTest) {
     const char* str5 = "(test_attr3>=)";
     filter = celix_filter_create(str5);
     ASSERT_FALSE(filter == nullptr);
+    celix_filter_destroy(filter);
 
     // test parsing a value with an escaped closing parenthesis "\ ")"
     const char* str6 = "(test_attr3>=strWith\\)inIt)";
@@ -164,11 +165,13 @@ TEST_F(FilterTestSuite, MiscInvalidCreateTest) {
     const char* str11 = "(a~=)";
     filter = celix_filter_create(str11);
     ASSERT_FALSE(filter == nullptr);
+    celix_filter_destroy(filter);
 
     // test parsing LESS operator missing value
     const char* str12 = "(a<)";
     filter = celix_filter_create(str12);
     ASSERT_FALSE(filter == nullptr);
+    celix_filter_destroy(filter);
 }
 
 TEST_F(FilterTestSuite, MatchEqualTest) {

--- a/libs/utils/include/celix/Filter.h
+++ b/libs/utils/include/celix/Filter.h
@@ -125,7 +125,8 @@ namespace celix {
         }
 
         /**
-         * @brief Check whether the filter indicates the mandatory presence of an attribute with a specific value for the provided attribute key.
+         * @brief Check whether the filter indicates the mandatory presence of an attribute with a specific value for
+         * the provided attribute key.
          *
          * Example:
          *   using this method for attribute key "key1" on filter "(key1=value1)" yields true.
@@ -138,7 +139,8 @@ namespace celix {
         }
 
         /**
-         * @brief Check whether the filter indicates the mandatory absence of an attribute, regardless of its value, for the provided attribute key.
+         * @brief Check whether the filter indicates the mandatory absence of an attribute, regardless of its value, for
+         * the provided attribute key.
          *
          * example:
          *   using this function for attribute key "key1" on the filter "(!(key1=*))" yields true.

--- a/libs/utils/include/celix/Filter.h
+++ b/libs/utils/include/celix/Filter.h
@@ -23,6 +23,7 @@
 #include <memory>
 
 #include "celix_filter.h"
+#include "celix_err.h"
 
 #include "celix/Exception.h"
 #include "celix/Properties.h"
@@ -50,7 +51,18 @@ namespace celix {
      */
     class Filter {
     public:
-        Filter() : cFilter{createFilter("")} {}
+      /**
+       * @brief Create an empty ("()") filter based on the provided filter string.
+       * @param[in] filterStr The filter string.
+       * @throw celix::FilterException if the filter string is invalid also logs an error message is to celix_err.
+       */
+        Filter() : cFilter{createFilter(nullptr)} {}
+
+        /**
+         * @brief Create a filter based on the provided filter string.
+         * @param[in] filterStr The filter string.
+         * @throw celix::FilterException if the filter string is invalid also logs an error message is to celix_err.
+         */
         explicit Filter(const std::string& filterStr) : cFilter{createFilter(filterStr.c_str())} {}
 
 
@@ -157,12 +169,9 @@ namespace celix {
 
     private:
         static std::shared_ptr<celix_filter_t> createFilter(const char* filterStr) {
-            if (filterStr == nullptr || strnlen(filterStr, 1) == 0) {
-                return nullptr;
-            }
             auto* cf = celix_filter_create(filterStr);
             if (cf == nullptr) {
-                throw celix::FilterException{"Invalid LDAP filter '" + std::string{filterStr} + "'"};
+                throw celix::FilterException{"Cannot create filter: '" + std::string{filterStr} + "'"};
             }
             return std::shared_ptr<celix_filter_t>{cf, [](celix_filter_t *f) {
                 celix_filter_destroy(f);

--- a/libs/utils/include/celix_filter.h
+++ b/libs/utils/include/celix_filter.h
@@ -160,11 +160,16 @@ CELIX_UTILS_EXPORT bool celix_filter_equals(const celix_filter_t* filter1, const
 CELIX_UTILS_EXPORT const char* celix_filter_getFilterString(const celix_filter_t* filter);
 
 /**
- * @brief Find the filter attribute.
+ * @brief Find the first filter attribute value matching the provided attribute name.
+ *
+ * Examples:
+ *  - filter arg: "(key=value)", attribute arg: "key" -> "value"
+ *  - filter arg: "(key1=value1)(key2=value2)", attribute arg: "key2" -> "value2"
+ *  - filter arg: "(|(key1=value1)(key1=value2))", attribute arg: "key1" -> "value1"
  *
  * @param[in] filter The filter.
  * @param[in] attribute The attribute to find.
- * @return The found attribute value or NULL if the attribute is not found. The returned string is owned by the filter,
+ * @return The first found attribute or NULL if the attribute is not found. The returned string is owned by the filter,
  *         must not be freed and is only valid as long as the filter is valid.
  */
 CELIX_UTILS_EXPORT const char* celix_filter_findAttribute(const celix_filter_t* filter, const char* attribute);

--- a/libs/utils/include/celix_filter.h
+++ b/libs/utils/include/celix_filter.h
@@ -17,20 +17,65 @@
  * under the License.
  */
 
+/**
+ * @file celix_filter.h
+ * @brief Header file for the Celix Filter API.
+ *
+ * An Apache Celix filter is a based on LDAP filters, for more information about LDAP filters see:
+ *  - https://tools.ietf.org/html/rfc4515
+ *  - https://tools.ietf.org/html/rfc1960
+ *
+ * In short an Apache Celix filter is a tree of filter nodes, parsed from a filter string.
+ * Each node has an operand, an optional attribute string and an optional value string.
+ * The operand can be one of the following:
+ * - `=`: equal
+ * - `=*`: present
+ * - `~=`: approx
+ * - `>=`: greater
+ * - `<=`: less
+ * - `>=`: greater equal
+ * - `<=`: less equal
+ * - `=`: substring if string contains a `*`.
+ * - `!`: not
+ * - `&`: and
+ * - `|`: or
+ *
+ The filter string is a list of filter node strings wrapped in parenthesis to group filter nodes.
+ * The following are valid filter strings:
+ * - `(key=value)` # Matches if properties contains a entry with key "key" and value "value".
+ * - `(key>=2)`# Matches if properties contains a entry with key "key" and value greater or equal to 2.
+ * - `(key=*)` # Matches if properties contains a entry with key "key".
+ * - `(!(key=value))` # Matches if properties does not contain a entry with key "key" and value "value".
+ * - `(&(key1=value1)(key2=value2))` # Matches if properties contains a entry with key "key1" and value "value1" and
+ *                                   # a entry with key "key2" and value "value2".
+ * - `(|(key1=value1)(key2=value2))` # Matches if properties contains a entry with key "key1" and value "value1" or
+ *                                   # a entry with key "key2" and value "value2".
+ *
+ * Apache Celix filters can be used to match a set of Apache Celix properties and such Apache Celix filters should be
+ * used together with a set of properties.
+ *
+ * Internally attribute values will be parsed to a long, double, boolean and Apache Celix version if
+ * possible during creation. And these types attribute values will be used in the to-be-matched property value,
+ * if the property value is of the same type.
+ *
+ */
+
 #ifndef CELIX_FILTER_H_
 #define CELIX_FILTER_H_
 
-#include "celix_properties.h"
 #include "celix_array_list.h"
 #include "celix_cleanup.h"
+#include "celix_properties.h"
 #include "celix_utils_export.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-typedef enum celix_filter_operand_enum
-{
+/**
+ * @brief Enumeration of the filter operands.
+ */
+typedef enum celix_filter_operand_enum {
     CELIX_FILTER_OPERAND_EQUAL,
     CELIX_FILTER_OPERAND_APPROX,
     CELIX_FILTER_OPERAND_GREATER,
@@ -44,23 +89,25 @@ typedef enum celix_filter_operand_enum
     CELIX_FILTER_OPERAND_NOT,
 } celix_filter_operand_t;
 
+/**
+ * @brief Internal opaque struct for internal use only.
+ */
+typedef struct celix_filter_internal celix_filter_internal_t; // opaque struct for internal use only
 
-typedef struct celix_filter_internal celix_filter_internal_t; //opaque struct for internal use only
+/**
+ * @brief The Apache Celix filter struct.
+ */
+typedef struct celix_filter_struct {
+    celix_filter_operand_t operand; /**< The filter operand. */
+    const char* attribute;          /**< The filter attribute; NULL for operands `AND`, `OR` or `NOT`. */
+    const char* value;              /**< The filter value; NULL for operands `AND`, `OR` or `NOT`. */
+    const char* filterStr;          /**< The filter string representation. */
 
-typedef struct celix_filter_struct celix_filter_t;
+    celix_array_list_t* children; /**< The filter children; only valid if the operand is not `AND`, `OR` or `NOT` else
+                                     the value is NULL. */
 
-struct celix_filter_struct {
-    celix_filter_operand_t operand;
-    const char *attribute; //NULL for operands AND, OR ot NOT
-    const char *value; //NULL for operands AND, OR or NOT NOT
-    const char *filterStr;
-
-    //type is celix_filter_t* for AND, OR and NOT operator and char* for SUBSTRING
-    //for other operands children is NULL
-    celix_array_list_t *children;
-
-    celix_filter_internal_t* internal; //for internal use only
-};
+    celix_filter_internal_t* internal; /**< Internal use only. */
+} celix_filter_t;
 
 /**
  * @brief Create a filter based on the provided filter string.
@@ -70,45 +117,92 @@ struct celix_filter_struct {
  * @param filterStr The filter string.
  * @return The created filter or NULL if the filter string is invalid.
  */
-CELIX_UTILS_EXPORT celix_filter_t* celix_filter_create(const char *filterStr);
+CELIX_UTILS_EXPORT celix_filter_t* celix_filter_create(const char* filterStr);
 
-CELIX_UTILS_EXPORT void celix_filter_destroy(celix_filter_t *filter);
+/**
+ * @brief Destroy the provided filter. Ignores NULL values.
+ */
+CELIX_UTILS_EXPORT void celix_filter_destroy(celix_filter_t* filter);
 
+/**
+ * @brief Add support for `celix_autoptr`.
+ */
 CELIX_DEFINE_AUTOPTR_CLEANUP_FUNC(celix_filter_t, celix_filter_destroy)
 
-CELIX_UTILS_EXPORT bool celix_filter_match(const celix_filter_t *filter, const celix_properties_t* props);
-
-CELIX_UTILS_EXPORT bool celix_filter_equals(const celix_filter_t *filter1, const celix_filter_t *filter2);
-
-CELIX_UTILS_EXPORT const char* celix_filter_getFilterString(const celix_filter_t *filter);
-
 /**
- * Find the filter attribute.
- * @return The attribute value or NULL if the attribute is not found.
+ * @brief Check whether the provided filter matches the provided properties.
+ * @param[in] filter The filter.
+ * @param[in] props The properties.
+ * @return True if the filter matches the properties, false otherwise.
  */
-CELIX_UTILS_EXPORT const char* celix_filter_findAttribute(const celix_filter_t *filter, const char *attribute);
+CELIX_UTILS_EXPORT bool celix_filter_match(const celix_filter_t* filter, const celix_properties_t* props);
 
 /**
- * Check whether the filter indicates the mandatory presence of an attribute with a specific value for the provided attribute key.
+ * @brief Check whether the 2 filters are equal.
+ *
+ * Note that the equals is done based on the parsed filter string and not on the provided filter strings.
+ * So the filters parsed from the strings "(key=value)" and " (key=value)" are equal.
+ *
+ * @param[in] filter1 The first filter.
+ * @param[in] filter2 The second filter.
+ * @return True if the filters are equal, false otherwise.
+ */
+CELIX_UTILS_EXPORT bool celix_filter_equals(const celix_filter_t* filter1, const celix_filter_t* filter2);
+
+/**
+ * @brief Get the filter string representation.
+ *
+ * @param[in] filter The filter.
+ * @return The filter string representation. The returned string is owned by the filter, must not be freed and is only
+ *         valid as long as the filter is valid.
+ */
+CELIX_UTILS_EXPORT const char* celix_filter_getFilterString(const celix_filter_t* filter);
+
+/**
+ * @brief Find the filter attribute.
+ *
+ * @param[in] filter The filter.
+ * @param[in] attribute The attribute to find.
+ * @return The found attribute value or NULL if the attribute is not found. The returned string is owned by the filter,
+ *         must not be freed and is only valid as long as the filter is valid.
+ */
+CELIX_UTILS_EXPORT const char* celix_filter_findAttribute(const celix_filter_t* filter, const char* attribute);
+
+/**
+ * @brief Check whether the filter indicates the mandatory presence of an attribute with a specific value for the
+ * provided attribute key.
  *
  * Example:
  *   using this function for attribute key "key1" on filter "(key1=value1)" yields true.
  *   using this function for attribute key "key1" on filter "(!(key1=value1))" yields false.
  *   using this function for attribute key "key1" on filter "(key1>=value1)" yields false.
  *   using this function for attribute key "key1" on filter "(|(key1=value1)(key2=value2))" yields false.
-*/
-CELIX_UTILS_EXPORT bool celix_filter_hasMandatoryEqualsValueAttribute(const celix_filter_t *filter, const char *attribute);
+ *
+ * @param[in] filter The filter.
+ * @param[in] attribute The attribute to check.
+ * @return True if the filter indicates the mandatory presence of an attribute with a specific value for the provided
+ *         attribute key, false otherwise.
+ */
+CELIX_UTILS_EXPORT bool celix_filter_hasMandatoryEqualsValueAttribute(const celix_filter_t* filter,
+                                                                      const char* attribute);
 
 /**
- * Chek whether the filter indicates the mandatory absence of an attribute, regardless of its value, for the provided attribute key.
+ * @brief Check whether the filter indicates the mandatory absence of an attribute, regardless of its value, for the
+ * provided attribute key.
  *
  * example:
  *   using this function for attribute key "key1" on the filter "(!(key1=*))" yields true.
  *   using this function for attribute key "key1" on the filter "(key1=*) yields false.
  *   using this function for attribute key "key1" on the filter "(key1=value)" yields false.
  *   using this function for attribute key "key1" on the filter "(|(!(key1=*))(key2=value2))" yields false.
+ *
+ * @param[in] filter The filter.
+ * @param[in] attribute The attribute to check.
+ * @return True if the filter indicates the mandatory absence of an attribute, regardless of its value, for the provided
+ *         attribute key, false otherwise.
  */
-CELIX_UTILS_EXPORT bool celix_filter_hasMandatoryNegatedPresenceAttribute(const celix_filter_t *filter, const char *attribute);
+CELIX_UTILS_EXPORT bool celix_filter_hasMandatoryNegatedPresenceAttribute(const celix_filter_t* filter,
+                                                                          const char* attribute);
 
 #ifdef __cplusplus
 }

--- a/libs/utils/include/celix_filter.h
+++ b/libs/utils/include/celix_filter.h
@@ -62,6 +62,14 @@ struct celix_filter_struct {
     celix_filter_internal_t* internal; //for internal use only
 };
 
+/**
+ * @brief Create a filter based on the provided filter string.
+ *
+ * If the return status is NULL, an error message is logged to celix_err.
+ *
+ * @param filterStr The filter string.
+ * @return The created filter or NULL if the filter string is invalid.
+ */
 CELIX_UTILS_EXPORT celix_filter_t* celix_filter_create(const char *filterStr);
 
 CELIX_UTILS_EXPORT void celix_filter_destroy(celix_filter_t *filter);
@@ -70,7 +78,7 @@ CELIX_DEFINE_AUTOPTR_CLEANUP_FUNC(celix_filter_t, celix_filter_destroy)
 
 CELIX_UTILS_EXPORT bool celix_filter_match(const celix_filter_t *filter, const celix_properties_t* props);
 
-CELIX_UTILS_EXPORT bool celix_filter_matchFilter(const celix_filter_t *filter1, const celix_filter_t *filter2);
+CELIX_UTILS_EXPORT bool celix_filter_equals(const celix_filter_t *filter1, const celix_filter_t *filter2);
 
 CELIX_UTILS_EXPORT const char* celix_filter_getFilterString(const celix_filter_t *filter);
 

--- a/libs/utils/include/celix_filter.h
+++ b/libs/utils/include/celix_filter.h
@@ -55,7 +55,7 @@
  * used together with a set of properties.
  *
  * Internally attribute values will be parsed to a long, double, boolean and Apache Celix version if
- * possible during creation. And these types attribute values will be used in the to-be-matched property value,
+ * possible during creation. And these typed attribute values will be used in the to-be-matched property value,
  * if the property value is of the same type.
  *
  */
@@ -170,8 +170,11 @@ CELIX_UTILS_EXPORT const char* celix_filter_getFilterString(const celix_filter_t
 CELIX_UTILS_EXPORT const char* celix_filter_findAttribute(const celix_filter_t* filter, const char* attribute);
 
 /**
- * @brief Check whether the filter indicates the mandatory presence of an attribute with a specific value for the
- * provided attribute key.
+ * @brief Determines if a filter has a mandatory 'equals' attribute with the provided attribute name.
+ *
+ * This function recursively examines a filter object to determine if it contains  an 'equals' attribute that matches
+ * the specified attribute name. The function takes into account the logical operators AND, OR, and NOT in the
+ * filter structure, and appropriately handles them to assess the presence and name of the attribute.
  *
  * Example:
  *   using this function for attribute key "key1" on filter "(key1=value1)" yields true.
@@ -186,24 +189,26 @@ CELIX_UTILS_EXPORT const char* celix_filter_findAttribute(const celix_filter_t* 
  */
 CELIX_UTILS_EXPORT bool celix_filter_hasMandatoryEqualsValueAttribute(const celix_filter_t* filter,
                                                                       const char* attribute);
-
 /**
- * @brief Check whether the filter indicates the mandatory absence of an attribute, regardless of its value, for the
- * provided attribute key.
+ * @brief Determines if a filter mandates the absence of a specific attribute, irrespective of its value.
  *
- * example:
- *   using this function for attribute key "key1" on the filter "(!(key1=*))" yields true.
- *   using this function for attribute key "key1" on the filter "(key1=*) yields false.
- *   using this function for attribute key "key1" on the filter "(key1=value)" yields false.
- *   using this function for attribute key "key1" on the filter "(|(!(key1=*))(key2=value2))" yields false.
+ * This function recursively examines a filter object to determine if it contains a specification indicating the
+ * mandatory absence of the specified attribute. It takes into account logical operators AND, OR, and NOT in the filter
+ * structure, and appropriately handles them to assess the absence of the attribute.
  *
- * @param[in] filter The filter.
- * @param[in] attribute The attribute to check.
- * @return True if the filter indicates the mandatory absence of an attribute, regardless of its value, for the provided
- *         attribute key, false otherwise.
+ * Examples:
+ *   using this function for attribute key "key1" on filter "(!(key1=*))" yields true.
+ *   using this function for attribute key "key1" on filter "(key1=*)" yields false.
+ *   using this function for attribute key "key1" on filter "(key1=value)" yields false.
+ *   using this function for attribute key "key1" on filter "(|(!(key1=*))(key2=value2))" yields false.
+ *
+ * @param[in] filter The filter to examine.
+ * @param[in] attribute The attribute to check for mandatory absence.
+ * @return True if the filter indicates the mandatory absence of the specified attribute, false otherwise.
  */
 CELIX_UTILS_EXPORT bool celix_filter_hasMandatoryNegatedPresenceAttribute(const celix_filter_t* filter,
                                                                           const char* attribute);
+
 
 #ifdef __cplusplus
 }

--- a/libs/utils/include/celix_filter.h
+++ b/libs/utils/include/celix_filter.h
@@ -114,7 +114,7 @@ typedef struct celix_filter_struct {
  *
  * If the return status is NULL, an error message is logged to celix_err.
  *
- * @param filterStr The filter string.
+ * @param filterStr The filter string. If NULL or "" a match-all "(|)" filter is created.
  * @return The created filter or NULL if the filter string is invalid.
  */
 CELIX_UTILS_EXPORT celix_filter_t* celix_filter_create(const char* filterStr);
@@ -133,7 +133,7 @@ CELIX_DEFINE_AUTOPTR_CLEANUP_FUNC(celix_filter_t, celix_filter_destroy)
  * @brief Check whether the provided filter matches the provided properties.
  * @param[in] filter The filter.
  * @param[in] props The properties.
- * @return True if the filter matches the properties, false otherwise.
+ * @return True if the filter matches the properties, false otherwise. If filter or props is NULL false is returned.
  */
 CELIX_UTILS_EXPORT bool celix_filter_match(const celix_filter_t* filter, const celix_properties_t* props);
 

--- a/libs/utils/include/celix_filter.h
+++ b/libs/utils/include/celix_filter.h
@@ -133,7 +133,8 @@ CELIX_DEFINE_AUTOPTR_CLEANUP_FUNC(celix_filter_t, celix_filter_destroy)
  * @brief Check whether the provided filter matches the provided properties.
  * @param[in] filter The filter.
  * @param[in] props The properties.
- * @return True if the filter matches the properties, false otherwise. If filter or props is NULL false is returned.
+ * @return True if the filter matches the properties, false otherwise. If filter is NULL always returns true and
+ *         if props is NULL, the result is the same as if an empty properties set was provided.
  */
 CELIX_UTILS_EXPORT bool celix_filter_match(const celix_filter_t* filter, const celix_properties_t* props);
 

--- a/libs/utils/src/celix_convert_utils.c
+++ b/libs/utils/src/celix_convert_utils.c
@@ -42,29 +42,31 @@ static bool celix_utils_isEndptrEndOfStringOrOnlyContainsWhitespaces(const char*
 }
 
 bool celix_utils_convertStringToBool(const char* val, bool defaultValue, bool* converted) {
-    bool result = defaultValue;
+    bool result;
     if (converted != NULL) {
         *converted = false;
     }
-    if (val != NULL) {
-        char buf[32];
-        char* valCopy = celix_utils_writeOrCreateString(buf, sizeof(buf), "%s", val);
-        if (valCopy == NULL) {
-            return result;
-        }
-        char *trimmed = celix_utils_trimInPlace(valCopy);
-        if (strcasecmp("true", trimmed) == 0) {
-            result = true;
-            if (converted) {
-                *converted = true;
-            }
-        } else if (strcasecmp("false", trimmed) == 0) {
-            result = false;
-            if (converted) {
-                *converted = true;
-            }
-        }
-        celix_utils_freeStringIfNotEqual(buf, valCopy);
+    if (val == NULL) {
+        return defaultValue;
+    }
+    const char* p = val;
+    while (isspace(*p)) {
+        p++;
+    }
+    if (strncasecmp("true", p, 4) == 0) {
+        p += 4;
+        result = true;
+    } else if (strncasecmp("false", p, 5) == 0) {
+        p += 5;
+        result = false;
+    } else {
+        return defaultValue;
+    }
+    if (!celix_utils_isEndptrEndOfStringOrOnlyContainsWhitespaces(p)) {
+        return defaultValue;
+    }
+    if (converted != NULL) {
+        *converted = true;
     }
     return result;
 }

--- a/libs/utils/src/filter.c
+++ b/libs/utils/src/filter.c
@@ -789,8 +789,8 @@ void celix_filter_destroy(celix_filter_t* filter) {
 }
 
 bool celix_filter_match(const celix_filter_t* filter, const celix_properties_t* properties) {
-    if (!filter || !properties) {
-        return false; // matching on null filter or property is always false
+    if (!filter) {
+        return true; // if filter is NULL, it matches
     }
 
     if (filter->operand == CELIX_FILTER_OPERAND_PRESENT) {

--- a/libs/utils/src/filter.c
+++ b/libs/utils/src/filter.c
@@ -421,7 +421,7 @@ static celix_status_t celix_filter_parseSubstringAny(const char* filterString, i
         rc = fputc(filterString[*pos], stream);
         if (rc == EOF) {
             celix_err_push("Filter Error: Failed to write to stream.\n");
-            return CELIX_FILE_IO_EXCEPTION;
+            return CELIX_ENOMEM;
         }
         (*pos)++;
     }

--- a/libs/utils/src/filter.c
+++ b/libs/utils/src/filter.c
@@ -520,16 +520,23 @@ static celix_status_t celix_filter_compile(celix_filter_t* filter) {
         if (filter->internal == NULL) {
             celix_err_push("Filter Error: Failed to allocate memory.");
             return CELIX_ENOMEM;
-        } else {
-            filter->internal->longValue =
-                celix_utils_convertStringToLong(filter->value, 0, &filter->internal->convertedToLong);
-            filter->internal->doubleValue =
-                celix_utils_convertStringToDouble(filter->value, 0.0, &filter->internal->convertedToDouble);
-            filter->internal->versionValue =
-                celix_utils_convertStringToVersion(filter->value, NULL, &filter->internal->convertedToVersion);
-            filter->internal->boolValue =
-                celix_utils_convertStringToBool(filter->value, false, &filter->internal->convertedToBool);
         }
+        do {
+            filter->internal->longValue =
+                    celix_utils_convertStringToLong(filter->value, 0, &filter->internal->convertedToLong);
+            filter->internal->doubleValue =
+                    celix_utils_convertStringToDouble(filter->value, 0.0, &filter->internal->convertedToDouble);
+            if (filter->internal->convertedToLong || filter->internal->convertedToDouble) {
+                break;
+            }
+            filter->internal->boolValue =
+                    celix_utils_convertStringToBool(filter->value, false, &filter->internal->convertedToBool);
+            if (filter->internal->convertedToBool) {
+                break;
+            }
+            filter->internal->versionValue =
+                    celix_utils_convertStringToVersion(filter->value, NULL, &filter->internal->convertedToVersion);
+        } while(false);
     }
 
     if (celix_filter_hasFilterChildren(filter)) {

--- a/libs/utils/src/filter.c
+++ b/libs/utils/src/filter.c
@@ -458,7 +458,6 @@ static celix_array_list_t* celix_filter_parseSubstring(const char* filterString,
         return NULL;
     }
 
-    celix_filter_skipWhiteSpace(filterString, pos);
     if (filterString[*pos] == '*') {
         // initial substring is NULL
         // eat '*'

--- a/libs/utils/src/filter.c
+++ b/libs/utils/src/filter.c
@@ -158,7 +158,7 @@ static celix_filter_t* celix_filter_parseAndOrOr(const char* filterString, celix
             if (child == NULL) {
                 return NULL;
             }
-            if(celix_arrayList_add(children, child) != CELIX_SUCCESS) {
+            if (celix_arrayList_add(children, child) != CELIX_SUCCESS) {
                 celix_err_push("Filter Error: Failed to add filter node.");
                 celix_filter_destroy(child);
                 return NULL;
@@ -463,7 +463,7 @@ static celix_array_list_t* celix_filter_parseSubstring(const char* filterString,
         // initial substring is NULL
         // eat '*'
         (*pos)++;
-        if(celix_arrayList_add(subs, NULL) != CELIX_SUCCESS) {
+        if (celix_arrayList_add(subs, NULL) != CELIX_SUCCESS) {
             celix_err_push("Filter Error: Failed to add element to array list.");
             return NULL;
         }
@@ -477,7 +477,7 @@ static celix_array_list_t* celix_filter_parseSubstring(const char* filterString,
             return NULL;
         }
         if (element) {
-            if(celix_arrayList_add(subs, element) != CELIX_SUCCESS) {
+            if (celix_arrayList_add(subs, element) != CELIX_SUCCESS) {
                 free(element);
                 celix_err_push("Filter Error: Failed to add element to array list.");
                 return NULL;
@@ -487,7 +487,7 @@ static celix_array_list_t* celix_filter_parseSubstring(const char* filterString,
             // final substring is NULL
             (*pos)++; // eat '*'
             if (celix_filter_isNextNonWhiteSpaceChar(filterString, *pos, ')')) {
-                if(celix_arrayList_add(subs, NULL) != CELIX_SUCCESS) {
+                if (celix_arrayList_add(subs, NULL) != CELIX_SUCCESS) {
                     celix_err_push("Filter Error: Failed to add element to array list.");
                     return NULL;
                 }

--- a/libs/utils/src/filter.c
+++ b/libs/utils/src/filter.c
@@ -743,15 +743,6 @@ celix_filter_t* celix_filter_create(const char* filterString) {
         return NULL;
     }
 
-    if (filter->operand != CELIX_FILTER_OPERAND_OR && filter->operand != CELIX_FILTER_OPERAND_AND &&
-        filter->operand != CELIX_FILTER_OPERAND_NOT && filter->operand != CELIX_FILTER_OPERAND_SUBSTRING &&
-        filter->operand != CELIX_FILTER_OPERAND_PRESENT) {
-        if (filter->attribute == NULL || filter->value == NULL) {
-            celix_err_push("Filter Error: Missing attribute or value.");
-            return NULL;
-        }
-    }
-
     filter->filterStr = celix_steal_ptr(str);
     if (celix_filter_compile(filter) != CELIX_SUCCESS) {
         celix_err_push("Failed to compile filter");

--- a/libs/utils/src/filter.c
+++ b/libs/utils/src/filter.c
@@ -524,9 +524,12 @@ static celix_status_t celix_filter_compile(celix_filter_t* filter) {
         do {
             filter->internal->longValue =
                     celix_utils_convertStringToLong(filter->value, 0, &filter->internal->convertedToLong);
+            if (filter->internal->convertedToLong) {
+                break;
+            }
             filter->internal->doubleValue =
                     celix_utils_convertStringToDouble(filter->value, 0.0, &filter->internal->convertedToDouble);
-            if (filter->internal->convertedToLong || filter->internal->convertedToDouble) {
+            if (filter->internal->convertedToDouble) {
                 break;
             }
             filter->internal->boolValue =


### PR DESCRIPTION
# Intro
This PR updates the Apache Celix filter to utilize typed properties entries and also refactors the filter implementation.

My intention was to create a small PR allowing filters to work with typed properties before starting on array support. However, I observed several issues with the filter implementation that I also wanted to address.

# Benchmark
With this PR, a filter match will take into account the underlying properties entry type and use it for a more efficient comparison. A Filter match benchmark is introduced (and run before using the typed properties entries in filter match) to ensure the desired effect. 

Here are some before and after results (measured on my machine), where the range indicates the size of the properties set used within a filter match.

## Before Refactor

```
--------------------------------------------------------------------------------------------------------------------------------------
Benchmark                                                                            Time             CPU   Iterations UserCounters...
--------------------------------------------------------------------------------------------------------------------------------------
FilterBenchmark_testStringCFilter/10000/process_time/real_time                    14.5 ns         14.5 ns     48853882 fillEntriesOptimizationBufferPercentage=1 fillStringOptimizationBufferPercentage=0.992188 items_per_second=68.9608M/s
FilterBenchmark_testStringFilter/10000/process_time/real_time                     14.4 ns         14.4 ns     48922109 fillEntriesOptimizationBufferPercentage=1 fillStringOptimizationBufferPercentage=0.992188 items_per_second=69.5677M/s
FilterBenchmark_testLongFilter/10000/process_time/real_time                       22.3 ns         22.3 ns     31418137 fillEntriesOptimizationBufferPercentage=1 fillStringOptimizationBufferPercentage=0.992188 items_per_second=44.8544M/s
FilterBenchmark_testBoolFilter/10000/process_time/real_time                       16.3 ns         16.3 ns     42884878 fillEntriesOptimizationBufferPercentage=1 fillStringOptimizationBufferPercentage=0.992188 items_per_second=61.21M/s
FilterBenchmark_testVersionFilter/10000/process_time/real_time                     131 ns          131 ns      5332730 fillEntriesOptimizationBufferPercentage=1 fillStringOptimizationBufferPercentage=0.992188 items_per_second=7.6231M/s
FilterBenchmark_testVersionWithQualifierFilter/10000/process_time/real_time        163 ns          163 ns      4351054 fillEntriesOptimizationBufferPercentage=1 fillStringOptimizationBufferPercentage=0.992188 items_per_second=6.13215M/s
FilterBenchmark_testStringGreaterEqualFilter/10000/process_time/real_time         14.4 ns         14.4 ns     48966825 fillEntriesOptimizationBufferPercentage=1 fillStringOptimizationBufferPercentage=0.992188 items_per_second=69.4911M/s
FilterBenchmark_testLongGreaterEqualFilter/10000/process_time/real_time           22.1 ns         22.1 ns     29620437 fillEntriesOptimizationBufferPercentage=1 fillStringOptimizationBufferPercentage=0.992188 items_per_second=45.307M/s
FilterBenchmark_testDoubleGreaterEqualFilter/10000/process_time/real_time         43.5 ns         43.5 ns     16141792 fillEntriesOptimizationBufferPercentage=1 fillStringOptimizationBufferPercentage=0.992188 items_per_second=22.968M/s
FilterBenchmark_versionGreaterEqualFilter/10000/process_time/real_time             129 ns          129 ns      5429183 fillEntriesOptimizationBufferPercentage=1 fillStringOptimizationBufferPercentage=0.992188 items_per_second=7.74544M/s
FilterBenchmark_versionRangeFilter/10000/process_time/real_time                    276 ns          276 ns      2534677 fillEntriesOptimizationBufferPercentage=1 fillStringOptimizationBufferPercentage=0.992188 items_per_second=3.61734M/s
FilterBenchmark_substringFilter/10000/process_time/real_time                       276 ns          276 ns      2534366 fillEntriesOptimizationBufferPercentage=1 fillStringOptimizationBufferPercentage=0.992188 items_per_second=3.61947M/s
FilterBenchmark_complexFilter/10000/process_time/real_time                        28.1 ns         28.1 ns     25516281 fillEntriesOptimizationBufferPercentage=1 fillStringOptimizationBufferPercentage=0.992188 items_per_second=35.631M/s
```

## After refactor 
```
--------------------------------------------------------------------------------------------------------------------------------------
Benchmark                                                                            Time             CPU   Iterations UserCounters...
--------------------------------------------------------------------------------------------------------------------------------------
FilterBenchmark_testStringCFilter/10000/process_time/real_time                    15.4 ns         15.4 ns     45535697 fillEntriesOptimizationBufferPercentage=1 fillStringOptimizationBufferPercentage=0.992188 items_per_second=64.9322M/s
FilterBenchmark_testStringFilter/10000/process_time/real_time                     15.4 ns         15.4 ns     45357990 fillEntriesOptimizationBufferPercentage=1 fillStringOptimizationBufferPercentage=0.992188 items_per_second=64.7906M/s
FilterBenchmark_testLongFilter/10000/process_time/real_time                       14.9 ns         14.9 ns     46921381 fillEntriesOptimizationBufferPercentage=1 fillStringOptimizationBufferPercentage=0.992188 items_per_second=66.9823M/s
FilterBenchmark_testBoolFilter/10000/process_time/real_time                       15.4 ns         15.4 ns     45496705 fillEntriesOptimizationBufferPercentage=1 fillStringOptimizationBufferPercentage=0.992188 items_per_second=64.8934M/s
FilterBenchmark_testVersionFilter/10000/process_time/real_time                    19.1 ns         19.1 ns     36715526 fillEntriesOptimizationBufferPercentage=1 fillStringOptimizationBufferPercentage=0.992188 items_per_second=52.4212M/s
FilterBenchmark_testVersionWithQualifierFilter/10000/process_time/real_time       19.6 ns         19.6 ns     35566450 fillEntriesOptimizationBufferPercentage=1 fillStringOptimizationBufferPercentage=0.992188 items_per_second=50.8923M/s
FilterBenchmark_testStringGreaterEqualFilter/10000/process_time/real_time         14.8 ns         14.8 ns     47205823 fillEntriesOptimizationBufferPercentage=1 fillStringOptimizationBufferPercentage=0.992188 items_per_second=67.484M/s
FilterBenchmark_testLongGreaterEqualFilter/10000/process_time/real_time           15.7 ns         15.7 ns     44793529 fillEntriesOptimizationBufferPercentage=1 fillStringOptimizationBufferPercentage=0.992188 items_per_second=63.8461M/s
FilterBenchmark_testDoubleGreaterEqualFilter/10000/process_time/real_time         16.7 ns         16.7 ns     42395112 fillEntriesOptimizationBufferPercentage=1 fillStringOptimizationBufferPercentage=0.992188 items_per_second=60.0551M/s
FilterBenchmark_versionGreaterEqualFilter/10000/process_time/real_time            25.6 ns         25.6 ns     27321443 fillEntriesOptimizationBufferPercentage=1 fillStringOptimizationBufferPercentage=0.992188 items_per_second=39.0526M/s
FilterBenchmark_versionRangeFilter/10000/process_time/real_time                   40.9 ns         40.9 ns     17123791 fillEntriesOptimizationBufferPercentage=1 fillStringOptimizationBufferPercentage=0.992188 items_per_second=24.4385M/s
FilterBenchmark_substringFilter/10000/process_time/real_time                      40.8 ns         40.8 ns     17131224 fillEntriesOptimizationBufferPercentage=1 fillStringOptimizationBufferPercentage=0.992188 items_per_second=24.5143M/s
FilterBenchmark_complexFilter/10000/process_time/real_time                        29.3 ns         29.3 ns     23892366 fillEntriesOptimizationBufferPercentage=1 fillStringOptimizationBufferPercentage=0.992188 items_per_second=34.1668M/s
```


# Substring Refactor

The filter substring implementation was incorrect (not according to the [RFC](https://datatracker.ietf.org/doc/html/rfc4515)) and has been updated. Additionally, the previous implementation required a malloc during matching; this need has now been removed, ensuring that a filter match does not require additional memory and thus cannot fail due to an allocation error.

# Small Refactor of AND and OR

The matching for AND and OR operators has been updated so that `(|)` and `(&)` will return true.

# Service Registration

Service registration, including component service registration, has been updated. Now, `service.id` and `service.version` are stored as `long` and `celix_version_t` types, respectively. Also, some minor "last boy scout rule" changes have been implemented for error handling in the service registration flow.

# Error Handling

Most of the string parsing part has been refactored to use `open_memstream`. Error handling, including error injection testing, is now in place.


