### PR TITLE
#667 upgrade libcurl to 8.4.0 to fix security issues.

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -55,8 +55,7 @@ jobs:
             -o celix:enable_testing_on_ci=True
             -o celix:enable_ccache=True
         run: |
-          #force require libcurl 7.64.1, due to a sha256 verify issue in libcurl/7.87.0
-          conan install . celix/ci -pr:b default -pr:h default -if build ${CONAN_BUILD_OPTIONS} -b missing -b cpputest --require-override=libcurl/7.64.1 --require-override=openssl/1.1.1s
+          conan install . celix/ci -pr:b default -pr:h default -if build ${CONAN_BUILD_OPTIONS} -b missing -b cpputest --require-override=openssl/1.1.1s
       - name: Build
         run: |
           conan build . -bf build

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -59,7 +59,6 @@ jobs:
             -o celix/*:framework_curlinit=False
             -o celix/*:enable_ccache=True
         run: |
-          #force require libcurl 7.64.1, due to a sha256 verify issue in libcurl/7.87.0
           conan build .  -c tools.cmake.cmaketoolchain:generator=Ninja -pr:b default -pr:h default -s:b build_type=Release -s:h build_type=Release -of build ${CONAN_BUILD_OPTIONS} -b missing -b cpputest
       - name: Test
         run: |

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -80,8 +80,7 @@ jobs:
             -o celix:framework_curlinit=False
             -o celix:enable_ccache=True
         run: |
-          #force require libcurl 7.64.1, due to a sha256 verify issue in libcurl/7.87.0
-          conan install . celix/ci -c tools.cmake.cmaketoolchain:generator=Ninja -pr:b release -pr:h default -if build ${CONAN_BUILD_OPTIONS} -b missing  -b cpputest --require-override=libcurl/7.64.1 --require-override=openssl/1.1.1s
+          conan install . celix/ci -c tools.cmake.cmaketoolchain:generator=Ninja -pr:b release -pr:h default -if build ${CONAN_BUILD_OPTIONS} -b missing  -b cpputest --require-override=openssl/1.1.1s
       - name: Build
         env:
           CC: ${{ matrix.compiler[0] }}

--- a/conanfile.py
+++ b/conanfile.py
@@ -374,7 +374,7 @@ class CelixConan(ConanFile):
                 or self.options.build_celix_etcdlib
                 or self.options.build_rsa_discovery_common or self.options.build_rsa_remote_service_admin_dfi
                 or self.options.build_launcher):
-            self.requires("libcurl/[>=7.64.1 <8.0.0]")
+            self.requires("libcurl/[>=8.4.0 <9.0.0]")
         if (self.options.build_rsa_discovery_common
                 or (self.options.build_rsa_remote_service_admin_dfi and self.options.enable_testing)):
             self.requires("libxml2/[>=2.9.9 <3.0.0]")


### PR DESCRIPTION
This PR fixes #667 by upgrading libcurl to 8.4.0.
It will be backported to 2.4 once merged.