### PR TITLE
Fix codecov-action to 3.1.6 using git-hash.

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -67,7 +67,7 @@ jobs:
           source deactivate_conanrun.sh
           lcx="lcov --output-file=coverage.info " && for i in `find . -name "*.info.cleaned"`; do lcx+=" --add-tracefile=$i"; done && $lcx
       - name: Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@ab904c41d6ece82784817410c45d8b8c02684457
         with:
           files: build/coverage.info
           name: codecov-celix


### PR DESCRIPTION
It is done to be compliant to Apache infra team's policy, as reminded by @rlenferink: https://github.com/apache/celix/pull/722#issuecomment-1923536557

It seems that v4 is out followed by an almost immediate v4.0.1: https://github.com/codecov/codecov-action/releases
I think we'd better use the latest v3.x stable release rather than v4.0.1.