### PR TITLE
Feature/87 create service tracker inside use tracked service call

### DIFF
--- a/libs/framework/gtest/src/CelixBundleContextServicesTestSuite.cc
+++ b/libs/framework/gtest/src/CelixBundleContextServicesTestSuite.cc
@@ -2009,3 +2009,39 @@ TEST_F(CelixBundleContextServicesTestSuite, UseTrackedServiceDuringTrackerCreati
     serviceFound = celix_bundleContext_useTrackedService(ctx, trkId, nullptr, nullptr);
     EXPECT_TRUE(serviceFound);
 }
+
+TEST_F(CelixBundleContextServicesTestSuite, UseTrackedServiceOnTheCelixEventThread) {
+    //Given a registered service with a service registration guard
+    long svcId = celix_bundleContext_registerService(ctx, (void*)0x42, "test", nullptr);
+    celix_auto(celix_service_registration_guard_t) svcGuard = celix_serviceRegistrationGuard_init(ctx, svcId);
+
+    //And a  service tracker for the "test" service with a service tracker guard
+    long trkId = celix_bundleContext_trackServices(ctx, "test");
+    celix_auto(celix_tracker_guard_t) trkGuard = celix_trackerGuard_init(ctx, trkId);
+
+    //When all events are processed
+    celix_bundleContext_waitForEvents(ctx);
+
+    //Then I can use the tracked service on the Celix event thread
+    struct callback_data {
+        celix_bundle_context_t* ctx;
+        long trkId;
+    };
+    callback_data cbData{ctx, trkId};
+    auto eventCallback = [](void *data) {
+        auto d = static_cast<callback_data*>(data);
+        bool called = celix_bundleContext_useTrackedService(d->ctx, d->trkId, nullptr, nullptr);
+        EXPECT_TRUE(called);
+    };
+
+    long eventId = celix_framework_fireGenericEvent(
+            fw,
+            -1,
+            celix_bundle_getId(celix_framework_getFrameworkBundle(fw)),
+            "use tracked service",
+            (void*)&cbData,
+            eventCallback,
+            nullptr,
+            nullptr);
+    celix_framework_waitForGenericEvent(fw, eventId);
+}

--- a/libs/framework/src/bundle_context.c
+++ b/libs/framework/src/bundle_context.c
@@ -847,7 +847,7 @@ static void celix_bundleContext_waitForUnusedServiceTracker(celix_bundle_context
     // note that the use count cannot be increased anymore, because the tracker is removed from the map
     struct timespec start = celix_gettime(CLOCK_MONOTONIC);
     int logCount = 0;
-    while (__atomic_load_n(&trkEntry->useCount, __ATOMIC_RELAXED) > 0) {
+    while (__atomic_load_n(&trkEntry->useCount, __ATOMIC_ACQUIRE) > 0) {
         if (celix_elapsedtime(CLOCK_MONOTONIC, start) > TRACKER_WARN_THRESHOLD_SEC) {
             fw_log(ctx->framework->logger,
                    CELIX_LOG_LEVEL_WARNING,
@@ -858,7 +858,7 @@ static void celix_bundleContext_waitForUnusedServiceTracker(celix_bundle_context
             start = celix_gettime(CLOCK_MONOTONIC);
             logCount++;
         }
-        usleep(1);
+        usleep(1000);
     }
 }
 
@@ -1082,7 +1082,7 @@ bool celix_bundleContext_useServiceWithId(
         const char *serviceName,
         void *callbackHandle,
         void (*use)(void *handle, void *svc)) {
-    char filter[32]; //20 is max long length
+    char filter[1+/*(*/sizeof(CELIX_FRAMEWORK_SERVICE_ID)-1+1/*=*/+20/*INT64_MIN*/+1/*)*/+1/*'\0'*/];
     (void)snprintf(filter, sizeof(filter), "(%s=%li)", CELIX_FRAMEWORK_SERVICE_ID, serviceId);
 
     celix_service_use_options_t opts = CELIX_EMPTY_SERVICE_USE_OPTIONS;
@@ -1458,7 +1458,7 @@ static size_t celix_bundleContext_useTrackedServiceWithOptionsInternal(celix_bun
             trkEntry->tracker, NULL, opts->callbackHandle, opts->use, opts->useWithProperties, opts->useWithOwner);
     }
 
-    (void)__atomic_fetch_sub(&trkEntry->useCount, 1, __ATOMIC_RELAXED);
+    (void)__atomic_fetch_sub(&trkEntry->useCount, 1, __ATOMIC_RELEASE);
     return callCount;
 }
 

--- a/libs/framework/src/bundle_context_private.h
+++ b/libs/framework/src/bundle_context_private.h
@@ -59,6 +59,9 @@ typedef struct celix_bundle_context_service_tracker_entry {
     // used for sync
     long createEventId;
     bool cancelled; // if tracker is stopped before created async
+
+    unsigned int useCount; // atomic, used to keep track of the number of times the tracker is used for a
+                           // useTrackedService or useService call
 } celix_bundle_context_service_tracker_entry_t;
 
 typedef struct celix_bundle_context_service_tracker_tracker_entry {


### PR DESCRIPTION
This PR adds support for creating a service tracking in a `celix_bundleContext_useTrackedService(s)*` calls. 

This is done by calling the use callbacks outside of the (read) lock. The prevent that the service tracker can be removed during a use callback, an atomic use count is introduced. 
