### PR TITLE
Hotfix/conan private dep

### DIFF
--- a/.github/workflows/conan_create.yml
+++ b/.github/workflows/conan_create.yml
@@ -110,7 +110,7 @@ jobs:
             ${{ runner.os }}-ccache-Release-
       - name: Create Celix
         run: |
-          conan create . -c tools.cmake.cmaketoolchain:generator=Ninja -b missing -o celix/*:build_all=True  -o celix/*:enable_ccache=True -pr:b default -pr:h default -s:b build_type=Release -s:h build_type=Release -tf examples/conan_test_package_v2 -o celix/*:celix_cxx17=True -o celix/*:celix_install_deprecated_api=True -vvv
+          conan create . -c tools.cmake.cmaketoolchain:generator=Ninja -b missing -o celix/*:build_all=True  -o celix/*:enable_ccache=True -pr:b default -pr:h default -s:b build_type=Release -s:h build_type=Release -tf examples/conan_test_package_v2 -o celix/*:celix_cxx17=True -o celix/*:celix_install_deprecated_api=True
       - name: Dependency Deduction Test
         run: |
           conan inspect .  | awk 'BEGIN { FS="[\t:]+"; output=0 } /build/ && !/build_all/ && !/build_rsa_remote_service_admin_shm_v2/ && !/build_rsa_discovery_zeroconf/ { if(output) print $1} /^options/ {output=1} /^options_definitions/ {output=0}' | while read option; do conan build . -c tools.cmake.cmaketoolchain:generator=Ninja -b missing -o celix/*:${option}=True  -pr:b default -pr:h default -s:b build_type=Release -s:h build_type=Release -of  ${option}_dir -o celix/*:celix_cxx17=True -o celix/*:enable_ccache=True -o celix/*:celix_install_deprecated_api=True || exit 1; done

--- a/.github/workflows/conan_create.yml
+++ b/.github/workflows/conan_create.yml
@@ -110,7 +110,7 @@ jobs:
             ${{ runner.os }}-ccache-Release-
       - name: Create Celix
         run: |
-          conan create . -c tools.cmake.cmaketoolchain:generator=Ninja -b missing -o celix/*:build_all=True  -o celix/*:enable_ccache=True -pr:b default -pr:h default -s:b build_type=Release -s:h build_type=Release -tf examples/conan_test_package_v2 -o celix/*:celix_cxx17=True -o celix/*:celix_install_deprecated_api=True
+          conan create . -c tools.cmake.cmaketoolchain:generator=Ninja -b missing -o celix/*:build_all=True  -o celix/*:enable_ccache=True -pr:b default -pr:h default -s:b build_type=Release -s:h build_type=Release -tf examples/conan_test_package_v2 -o celix/*:celix_cxx17=True -o celix/*:celix_install_deprecated_api=True -vvv
       - name: Dependency Deduction Test
         run: |
           conan inspect .  | awk 'BEGIN { FS="[\t:]+"; output=0 } /build/ && !/build_all/ && !/build_rsa_remote_service_admin_shm_v2/ && !/build_rsa_discovery_zeroconf/ { if(output) print $1} /^options/ {output=1} /^options_definitions/ {output=0}' | while read option; do conan build . -c tools.cmake.cmaketoolchain:generator=Ninja -b missing -o celix/*:${option}=True  -pr:b default -pr:h default -s:b build_type=Release -s:h build_type=Release -of  ${option}_dir -o celix/*:celix_cxx17=True -o celix/*:enable_ccache=True -o celix/*:celix_install_deprecated_api=True || exit 1; done

--- a/conanfile.py
+++ b/conanfile.py
@@ -345,8 +345,7 @@ class CelixConan(ConanFile):
         # tc.cache_variables["CMAKE_PROJECT_Celix_INCLUDE"] = os.path.join(self.build_folder, "conan_paths.cmake")
         # the following is workaround for https://github.com/conan-io/conan/issues/7192
         for dep in self.dependencies.host.values():
-            copy(self, "*.dylib", dep.cpp_info.libdir, os.path.join(self.build_folder, "lib"))
-            copy(self, "*.so*", dep.cpp_info.libdir, os.path.join(self.build_folder, "lib"))
+            copy(self, "*", dep.cpp_info.libdir, os.path.join(self.build_folder, "lib"))
         tc.cache_variables["CMAKE_BUILD_RPATH"] = os.path.join(self.build_folder, "lib")
         v = Version(self.version)
         tc.cache_variables["CELIX_MAJOR"] = str(v.major.value)

--- a/conanfile.py
+++ b/conanfile.py
@@ -345,7 +345,8 @@ class CelixConan(ConanFile):
         # tc.cache_variables["CMAKE_PROJECT_Celix_INCLUDE"] = os.path.join(self.build_folder, "conan_paths.cmake")
         # the following is workaround for https://github.com/conan-io/conan/issues/7192
         for dep in self.dependencies.host.values():
-            copy(self, "*", dep.cpp_info.libdir, os.path.join(self.build_folder, "lib"))
+            copy(self, "*.dylib", dep.cpp_info.libdir, os.path.join(self.build_folder, "lib"))
+            copy(self, "*.so*", dep.cpp_info.libdir, os.path.join(self.build_folder, "lib"))
         tc.cache_variables["CMAKE_BUILD_RPATH"] = os.path.join(self.build_folder, "lib")
         v = Version(self.version)
         tc.cache_variables["CELIX_MAJOR"] = str(v.major.value)

--- a/conanfile.py
+++ b/conanfile.py
@@ -345,8 +345,10 @@ class CelixConan(ConanFile):
         # tc.cache_variables["CMAKE_PROJECT_Celix_INCLUDE"] = os.path.join(self.build_folder, "conan_paths.cmake")
         # the following is workaround for https://github.com/conan-io/conan/issues/7192
         for dep in self.dependencies.host.values():
-            copy(self, "*.dylib", dep.cpp_info.libdir, os.path.join(self.build_folder, "lib"))
-            copy(self, "*.so*", dep.cpp_info.libdir, os.path.join(self.build_folder, "lib"))
+            if self.settings.os == "Linux":
+                copy(self, "*.so*", dep.cpp_info.libdir, os.path.join(self.build_folder, "lib"))
+            elif self.settings.os == "Macos":
+                copy(self, "*.dylib", dep.cpp_info.libdir, os.path.join(self.build_folder, "lib"))
         tc.cache_variables["CMAKE_BUILD_RPATH"] = os.path.join(self.build_folder, "lib")
         v = Version(self.version)
         tc.cache_variables["CELIX_MAJOR"] = str(v.major.value)

--- a/conanfile.py
+++ b/conanfile.py
@@ -345,6 +345,8 @@ class CelixConan(ConanFile):
         # tc.cache_variables["CMAKE_PROJECT_Celix_INCLUDE"] = os.path.join(self.build_folder, "conan_paths.cmake")
         # the following is workaround for https://github.com/conan-io/conan/issues/7192
         for dep in self.dependencies.host.values():
+            self.output.info(dep.cpp_info.libdir)
+            self.output.info(os.path.join(self.build_folder, "lib"))
             if self.settings.os == "Linux":
                 copy(self, "*.so*", dep.cpp_info.libdir, os.path.join(self.build_folder, "lib"))
             elif self.settings.os == "Macos":

--- a/conanfile.py
+++ b/conanfile.py
@@ -345,12 +345,8 @@ class CelixConan(ConanFile):
         # tc.cache_variables["CMAKE_PROJECT_Celix_INCLUDE"] = os.path.join(self.build_folder, "conan_paths.cmake")
         # the following is workaround for https://github.com/conan-io/conan/issues/7192
         for dep in self.dependencies.host.values():
-            self.output.info(dep.cpp_info.libdir)
-            self.output.info(os.path.join(self.build_folder, "lib"))
-            if self.settings.os == "Linux":
-                copy(self, "*.so*", dep.cpp_info.libdir, os.path.join(self.build_folder, "lib"))
-            elif self.settings.os == "Macos":
-                copy(self, "*.dylib", dep.cpp_info.libdir, os.path.join(self.build_folder, "lib"))
+            copy(self, "*.dylib", dep.cpp_info.libdir, os.path.join(self.build_folder, "lib"))
+            copy(self, "*.so*", dep.cpp_info.libdir, os.path.join(self.build_folder, "lib"))
         tc.cache_variables["CMAKE_BUILD_RPATH"] = os.path.join(self.build_folder, "lib")
         v = Version(self.version)
         tc.cache_variables["CELIX_MAJOR"] = str(v.major.value)

--- a/conanfile.py
+++ b/conanfile.py
@@ -345,7 +345,7 @@ class CelixConan(ConanFile):
         # tc.cache_variables["CMAKE_PROJECT_Celix_INCLUDE"] = os.path.join(self.build_folder, "conan_paths.cmake")
         # the following is workaround for https://github.com/conan-io/conan/issues/7192
         for dep in self.dependencies.host.values():
-            if dep.cpp_info.libdir is not None:
+            if dep.cpp_info.libdirs:
                 copy(self, "*", dep.cpp_info.libdir, os.path.join(self.build_folder, "lib"))
         tc.cache_variables["CMAKE_BUILD_RPATH"] = os.path.join(self.build_folder, "lib")
         v = Version(self.version)

--- a/conanfile.py
+++ b/conanfile.py
@@ -345,7 +345,8 @@ class CelixConan(ConanFile):
         # tc.cache_variables["CMAKE_PROJECT_Celix_INCLUDE"] = os.path.join(self.build_folder, "conan_paths.cmake")
         # the following is workaround for https://github.com/conan-io/conan/issues/7192
         for dep in self.dependencies.host.values():
-            copy(self, "*", dep.cpp_info.libdir, os.path.join(self.build_folder, "lib"))
+            if dep.cpp_info.libdir is not None:
+                copy(self, "*", dep.cpp_info.libdir, os.path.join(self.build_folder, "lib"))
         tc.cache_variables["CMAKE_BUILD_RPATH"] = os.path.join(self.build_folder, "lib")
         v = Version(self.version)
         tc.cache_variables["CELIX_MAJOR"] = str(v.major.value)

--- a/conanfile.py
+++ b/conanfile.py
@@ -344,10 +344,9 @@ class CelixConan(ConanFile):
         tc.cache_variables["CELIX_ERR_BUFFER_SIZE"] = str(self.options.celix_err_buffer_size)
         # tc.cache_variables["CMAKE_PROJECT_Celix_INCLUDE"] = os.path.join(self.build_folder, "conan_paths.cmake")
         # the following is workaround for https://github.com/conan-io/conan/issues/7192
-        if self.settings.os == "Linux":
-            tc.cache_variables["CMAKE_EXE_LINKER_FLAGS"] = "-Wl,--unresolved-symbols=ignore-in-shared-libs"
-        elif self.settings.os == "Macos":
-            tc.cache_variables["CMAKE_EXE_LINKER_FLAGS"] = "-Wl,-undefined -Wl,dynamic_lookup"
+        for dep in self.dependencies.host.values():
+            copy(self, "*", dep.cpp_info.libdir, os.path.join(self.build_folder, "lib"))
+        tc.cache_variables["CMAKE_BUILD_RPATH"] = os.path.join(self.build_folder, "lib")
         v = Version(self.version)
         tc.cache_variables["CELIX_MAJOR"] = str(v.major.value)
         tc.cache_variables["CELIX_MINOR"] = str(v.minor.value)

--- a/examples/conan_test_package/conanfile.py
+++ b/examples/conan_test_package/conanfile.py
@@ -24,6 +24,9 @@ class TestPackageConan(ConanFile):
     generators = "cmake_paths", "cmake_find_package"
     # requires = "celix/2.3.0@docker/test"
 
+    def imports(self):
+        self.copy("*", src="@libdirs", dst="lib")
+
     def build(self):
         cmake = CMake(self)
         cmake.definitions["TEST_FRAMEWORK"] = self.options["celix"].build_framework
@@ -56,10 +59,7 @@ class TestPackageConan(ConanFile):
         cmake.definitions["TEST_COMPONENTS_READY_CHECK"] = self.options["celix"].build_components_ready_check
         cmake.definitions["CMAKE_PROJECT_test_package_INCLUDE"] = os.path.join(self.build_folder, "conan_paths.cmake")
         # the following is workaround https://github.com/conan-io/conan/issues/7192
-        if self.settings.os == "Linux":
-            cmake.definitions["CMAKE_EXE_LINKER_FLAGS"] = "-Wl,--unresolved-symbols=ignore-in-shared-libs"
-        elif self.settings.os == "Macos":
-            cmake.definitions["CMAKE_EXE_LINKER_FLAGS"] = "-Wl,-undefined -Wl,dynamic_lookup"
+        cmake.definitions["CMAKE_BUILD_RPATH"] = os.path.join(self.build_folder, "lib")
         cmake.configure()
         cmake.build()
 

--- a/examples/conan_test_package/conanfile.py
+++ b/examples/conan_test_package/conanfile.py
@@ -25,10 +25,7 @@ class TestPackageConan(ConanFile):
     # requires = "celix/2.3.0@docker/test"
 
     def imports(self):
-        if self.settings.os == "Linux":
-            self.copy("*.so*", src="@libdirs", dst="lib")
-        elif self.settings.os == "Macos":
-            self.copy("*.dylib", src="@libdirs", dst="lib")
+        self.copy("*", src="@libdirs", dst="lib")
 
     def build(self):
         cmake = CMake(self)

--- a/examples/conan_test_package/conanfile.py
+++ b/examples/conan_test_package/conanfile.py
@@ -25,7 +25,10 @@ class TestPackageConan(ConanFile):
     # requires = "celix/2.3.0@docker/test"
 
     def imports(self):
-        self.copy("*", src="@libdirs", dst="lib")
+        if self.settings.os == "Linux":
+            self.copy("*.so*", src="@libdirs", dst="lib")
+        elif self.settings.os == "Macos":
+            self.copy("*.dylib", src="@libdirs", dst="lib")
 
     def build(self):
         cmake = CMake(self)

--- a/examples/conan_test_package_v2/conanfile.py
+++ b/examples/conan_test_package_v2/conanfile.py
@@ -67,7 +67,7 @@ class TestPackageConan(ConanFile):
         tc.cache_variables["TEST_COMPONENTS_READY_CHECK"] = celix_options.build_components_ready_check
         # the following is workaround https://github.com/conan-io/conan/issues/7192
         for dep in self.dependencies.host.values():
-            if dep.cpp_info.libdir is not None:
+            if dep.cpp_info.libdirs:
                 copy(self, "*", dep.cpp_info.libdir, os.path.join(self.build_folder, "lib"))
         tc.cache_variables["CMAKE_BUILD_RPATH"] = os.path.join(self.build_folder, "lib")
         tc.user_presets_path = False

--- a/examples/conan_test_package_v2/conanfile.py
+++ b/examples/conan_test_package_v2/conanfile.py
@@ -67,8 +67,7 @@ class TestPackageConan(ConanFile):
         tc.cache_variables["TEST_COMPONENTS_READY_CHECK"] = celix_options.build_components_ready_check
         # the following is workaround https://github.com/conan-io/conan/issues/7192
         for dep in self.dependencies.host.values():
-            copy(self, "*.dylib", dep.cpp_info.libdir, os.path.join(self.build_folder, "lib"))
-            copy(self, "*.so*", dep.cpp_info.libdir, os.path.join(self.build_folder, "lib"))
+            copy(self, "*", dep.cpp_info.libdir, os.path.join(self.build_folder, "lib"))
         tc.cache_variables["CMAKE_BUILD_RPATH"] = os.path.join(self.build_folder, "lib")
         tc.user_presets_path = False
         tc.generate()

--- a/examples/conan_test_package_v2/conanfile.py
+++ b/examples/conan_test_package_v2/conanfile.py
@@ -67,7 +67,8 @@ class TestPackageConan(ConanFile):
         tc.cache_variables["TEST_COMPONENTS_READY_CHECK"] = celix_options.build_components_ready_check
         # the following is workaround https://github.com/conan-io/conan/issues/7192
         for dep in self.dependencies.host.values():
-            copy(self, "*", dep.cpp_info.libdir, os.path.join(self.build_folder, "lib"))
+            if dep.cpp_info.libdir is not None:
+                copy(self, "*", dep.cpp_info.libdir, os.path.join(self.build_folder, "lib"))
         tc.cache_variables["CMAKE_BUILD_RPATH"] = os.path.join(self.build_folder, "lib")
         tc.user_presets_path = False
         tc.generate()

--- a/examples/conan_test_package_v2/conanfile.py
+++ b/examples/conan_test_package_v2/conanfile.py
@@ -67,10 +67,8 @@ class TestPackageConan(ConanFile):
         tc.cache_variables["TEST_COMPONENTS_READY_CHECK"] = celix_options.build_components_ready_check
         # the following is workaround https://github.com/conan-io/conan/issues/7192
         for dep in self.dependencies.host.values():
-            if self.settings.os == "Linux":
-                copy(self, "*.so*", dep.cpp_info.libdir, os.path.join(self.build_folder, "lib"))
-            elif self.settings.os == "Macos":
-                copy(self, "*.dylib", dep.cpp_info.libdir, os.path.join(self.build_folder, "lib"))
+            copy(self, "*.dylib", dep.cpp_info.libdir, os.path.join(self.build_folder, "lib"))
+            copy(self, "*.so*", dep.cpp_info.libdir, os.path.join(self.build_folder, "lib"))
         tc.cache_variables["CMAKE_BUILD_RPATH"] = os.path.join(self.build_folder, "lib")
         tc.user_presets_path = False
         tc.generate()

--- a/examples/conan_test_package_v2/conanfile.py
+++ b/examples/conan_test_package_v2/conanfile.py
@@ -67,8 +67,10 @@ class TestPackageConan(ConanFile):
         tc.cache_variables["TEST_COMPONENTS_READY_CHECK"] = celix_options.build_components_ready_check
         # the following is workaround https://github.com/conan-io/conan/issues/7192
         for dep in self.dependencies.host.values():
-            copy(self, "*.dylib", dep.cpp_info.libdir, os.path.join(self.build_folder, "lib"))
-            copy(self, "*.so*", dep.cpp_info.libdir, os.path.join(self.build_folder, "lib"))
+            if self.settings.os == "Linux":
+                copy(self, "*.so*", dep.cpp_info.libdir, os.path.join(self.build_folder, "lib"))
+            elif self.settings.os == "Macos":
+                copy(self, "*.dylib", dep.cpp_info.libdir, os.path.join(self.build_folder, "lib"))
         tc.cache_variables["CMAKE_BUILD_RPATH"] = os.path.join(self.build_folder, "lib")
         tc.user_presets_path = False
         tc.generate()

--- a/examples/conan_test_package_v2/conanfile.py
+++ b/examples/conan_test_package_v2/conanfile.py
@@ -67,7 +67,8 @@ class TestPackageConan(ConanFile):
         tc.cache_variables["TEST_COMPONENTS_READY_CHECK"] = celix_options.build_components_ready_check
         # the following is workaround https://github.com/conan-io/conan/issues/7192
         for dep in self.dependencies.host.values():
-            copy(self, "*", dep.cpp_info.libdir, os.path.join(self.build_folder, "lib"))
+            copy(self, "*.dylib", dep.cpp_info.libdir, os.path.join(self.build_folder, "lib"))
+            copy(self, "*.so*", dep.cpp_info.libdir, os.path.join(self.build_folder, "lib"))
         tc.cache_variables["CMAKE_BUILD_RPATH"] = os.path.join(self.build_folder, "lib")
         tc.user_presets_path = False
         tc.generate()

--- a/examples/conan_test_package_v2/conanfile.py
+++ b/examples/conan_test_package_v2/conanfile.py
@@ -19,6 +19,7 @@ from conan import ConanFile
 from conan.tools.cmake import CMake, CMakeToolchain, cmake_layout
 from conan.tools.build import can_run
 from conan.tools.files import chdir
+from conan.tools.files import copy
 import os
 
 
@@ -65,10 +66,9 @@ class TestPackageConan(ConanFile):
         tc.cache_variables["TEST_UTILS"] = celix_options.build_utils
         tc.cache_variables["TEST_COMPONENTS_READY_CHECK"] = celix_options.build_components_ready_check
         # the following is workaround https://github.com/conan-io/conan/issues/7192
-        if self.settings.os == "Linux":
-            tc.cache_variables["CMAKE_EXE_LINKER_FLAGS"] = "-Wl,--unresolved-symbols=ignore-in-shared-libs"
-        elif self.settings.os == "Macos":
-            tc.cache_variables["CMAKE_EXE_LINKER_FLAGS"] = "-Wl,-undefined -Wl,dynamic_lookup"
+        for dep in self.dependencies.host.values():
+            copy(self, "*", dep.cpp_info.libdir, os.path.join(self.build_folder, "lib"))
+        tc.cache_variables["CMAKE_BUILD_RPATH"] = os.path.join(self.build_folder, "lib")
         tc.user_presets_path = False
         tc.generate()
 


### PR DESCRIPTION
Fix linker error caused by private linking of transitive dependencies.
Check https://github.com/conan-io/conan/issues/7192 for more information

Compared with previous workaround, this fix does not ignore unresolved symbols in shared libraries and thus is more robust.