### PR TITLE
Add dispatch option for coverity workflow

### DIFF
--- a/.github/workflows/coverity-scan.yml
+++ b/.github/workflows/coverity-scan.yml
@@ -1,10 +1,9 @@
 name: Celix Coverity Scan
 
 on:
-#  push:
-#  pull_request:
   schedule:
     - cron: '0 0 * * 0' # Weekly at 00:00 UTC
+  workflow_dispatch:
 
 jobs:
   latest:


### PR DESCRIPTION
This PR should enable the coverity workflow to be dispatch manually. 

Although coverity should not be runned daily (requires too much resources for the coverity services), Ideally we run it manually on a branch once before a pull request is created and ready for review. 