### PR TITLE
Hotfix/shaky-framework-test-fix

### DIFF
--- a/libs/framework/gtest/src/CelixFrameworkTestSuite.cc
+++ b/libs/framework/gtest/src/CelixFrameworkTestSuite.cc
@@ -26,7 +26,7 @@
 #include "celix_launcher.h"
 #include "celix_framework_factory.h"
 #include "celix_framework.h"
-#include "framework.h"
+#include "framework_private.h"
 #include "celix_constants.h"
 #include "celix_utils.h"
 
@@ -105,27 +105,27 @@ TEST_F(CelixFrameworkTestSuite, AsyncInstallStartStopUpdateAndUninstallBundleTes
     EXPECT_FALSE(celix_framework_isBundleActive(framework.get(), bndId));
 
     celix_framework_updateBundleAsync(framework.get(), bndId, NULL);
-    std::this_thread::sleep_for(std::chrono::milliseconds{100});
+    celix_framework_waitForBundleLifecycleHandlers(framework.get());
     EXPECT_FALSE(celix_framework_isBundleActive(framework.get(), bndId));
 
     celix_framework_startBundleAsync(framework.get(), bndId);
-    std::this_thread::sleep_for(std::chrono::milliseconds{100});
+    celix_framework_waitForBundleLifecycleHandlers(framework.get());
     EXPECT_TRUE(celix_framework_isBundleActive(framework.get(), bndId));
 
     celix_framework_updateBundleAsync(framework.get(), bndId, NULL);
-    std::this_thread::sleep_for(std::chrono::milliseconds{100});
+    celix_framework_waitForBundleLifecycleHandlers(framework.get());
     EXPECT_TRUE(celix_framework_isBundleActive(framework.get(), bndId));
 
     celix_framework_stopBundleAsync(framework.get(), bndId);
-    std::this_thread::sleep_for(std::chrono::milliseconds{100});
+    celix_framework_waitForBundleLifecycleHandlers(framework.get());
     EXPECT_FALSE(celix_framework_isBundleActive(framework.get(), bndId));
 
     celix_framework_updateBundleAsync(framework.get(), bndId, NULL);
-    std::this_thread::sleep_for(std::chrono::milliseconds{100});
+    celix_framework_waitForBundleLifecycleHandlers(framework.get());
     EXPECT_FALSE(celix_framework_isBundleActive(framework.get(), bndId));
 
     celix_framework_unloadBundleAsync(framework.get(), bndId);
-    std::this_thread::sleep_for(std::chrono::milliseconds{100});
+    celix_framework_waitForBundleLifecycleHandlers(framework.get());
     EXPECT_FALSE(celix_framework_isBundleInstalled(framework.get(), bndId));
 
     // reloaded bundle should reuse the same bundle id
@@ -134,7 +134,7 @@ TEST_F(CelixFrameworkTestSuite, AsyncInstallStartStopUpdateAndUninstallBundleTes
     EXPECT_FALSE(celix_framework_isBundleActive(framework.get(), bndId));
 
     celix_framework_uninstallBundleAsync(framework.get(), bndId);
-    std::this_thread::sleep_for(std::chrono::milliseconds{100});
+    celix_framework_waitForBundleLifecycleHandlers(framework.get());
     EXPECT_FALSE(celix_framework_isBundleInstalled(framework.get(), bndId));
 }
 

--- a/libs/framework/src/framework_private.h
+++ b/libs/framework/src/framework_private.h
@@ -345,11 +345,6 @@ void celix_framework_waitForAsyncRegistration(celix_framework_t *fw, long svcId)
 void celix_framework_waitForAsyncUnregistration(celix_framework_t *fw, long svcId);
 
 /**
- * Returns whether the current thread is the Celix framework event loop thread.
- */
-bool celix_framework_isCurrentThreadTheEventLoop(celix_framework_t* fw);
-
-/**
  * Increase the use count of a bundle and ensure that a bundle cannot be uninstalled.
  */
 void celix_framework_bundleEntry_increaseUseCount(celix_framework_bundle_entry_t *entry);


### PR DESCRIPTION
It use more reliable synchronization method to fix random test failure like the following:

https://github.com/apache/celix/actions/runs/8714109775/job/23903761534
```
/Users/runner/work/celix/celix/libs/framework/gtest/src/CelixFrameworkTestSuite.cc:113: Failure
Value of: celix_framework_isBundleActive(framework.get(), bndId)
  Actual: false
Expected: true
/Users/runner/work/celix/celix/libs/framework/gtest/src/CelixFrameworkTestSuite.cc:117: Failure
Value of: celix_framework_isBundleActive(framework.get(), bndId)
  Actual: false
Expected: true
Warning: 17T00:06:21] [warning] [celix_framework] [celix_framework_stopBundleInternal:2030] Cannot stop bundle, bundle state is INSTALLED
[  FAILED  ] CelixFrameworkTestSuite.AsyncInstallStartStopUpdateAndUninstallBundleTest (970 ms)
```