### PR TITLE
Hotfix/macos-build-brew-fix

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -75,7 +75,7 @@ jobs:
         uses: actions/checkout@v3.3.0
       - name: Install dependencies
         run: |
-          brew install lcov jansson rapidjson libzip ccache ninja
+          brew install lcov jansson rapidjson libzip ccache ninja openssl@1.1
       - name: Prepare ccache timestamp
         id: ccache_cache_timestamp
         run: |
@@ -104,5 +104,5 @@ jobs:
       - name: Test
         run: |
           cd $GITHUB_WORKSPACE/build
-          export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH:$(pwd)/utils:$(pwd)/framework:$(pwd)/dfi
+          export DYLD_LIBRARY_PATH=$(brew --prefix openssl@1.1)/lib/:$DYLD_LIBRARY_PATH:$(pwd)/utils:$(pwd)/framework:$(pwd)/dfi
           ctest --output-on-failure

--- a/cmake/Findcivetweb.cmake
+++ b/cmake/Findcivetweb.cmake
@@ -21,11 +21,12 @@ if (NOT civetweb_FOUND)
     set(CIVETWEB_ENABLE_WEBSOCKETS TRUE CACHE BOOL "" FORCE)
     set(CIVETWEB_BUILD_TESTING FALSE CACHE BOOL "" FORCE)
     set(BUILD_SHARED_LIBS TRUE CACHE BOOL "" FORCE)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-error")
     FetchContent_Declare(
             civetweb
             GIT_REPOSITORY https://github.com/civetweb/civetweb.git
 #            GIT_REPOSITORY https://gitee.com/mirrors/civetweb.git
-            GIT_TAG        eefb26f82b233268fc98577d265352720d477ba4 # V1.15
+            GIT_TAG        d7ba35bbb649209c66e582d5a0244ba988a15159 # V1.16
     )
     FetchContent_MakeAvailable(civetweb)
     if (NOT TARGET civetweb::civetweb)

--- a/conanfile.py
+++ b/conanfile.py
@@ -340,8 +340,6 @@ class CelixConan(ConanFile):
             self.requires("mdnsresponder/1310.140.1")
         # 'libzip/1.10.1' requires 'zlib/1.2.13' while 'libcurl/7.64.1' requires 'zlib/1.2.12'
         self.requires("zlib/1.2.13", override=True)
-        # the latest civetweb (1.16) is not ready for openssl3
-        self.requires("openssl/1.1.1t", override=True)
         self.validate()
 
     def generate(self):


### PR DESCRIPTION
This PR fixes the currently broken macos-build-brew CI build: 

```
 17/24 Test #17: run_test_rsa_dfi .......................Subprocess aborted***Exception:   0.05 sec
WARNING: /Users/runner/work/celix/celix/build/bundles/remote_services/remote_service_admin_dfi/gtest/test_rsa_dfi is loading libcrypto in an unsafe way
```

It also updates civetweb to 1.16.