### PR TITLE
Feature/215 async-signal-safe launcher shutdown

### DIFF
--- a/libs/framework/gtest/src/ScheduledEventTestSuite.cc
+++ b/libs/framework/gtest/src/ScheduledEventTestSuite.cc
@@ -231,7 +231,21 @@ TEST_F(ScheduledEventTestSuite, InvalidOptionsAndArgumentsTest) {
     auto ctx = fw->getFrameworkBundleContext();
     celix_scheduled_event_options_t opts{}; // no callback
     long scheduledEventId = celix_bundleContext_scheduleEvent(ctx->getCBundleContext(), &opts);
+    // Then I expect an error
+    EXPECT_LT(scheduledEventId, 0);
 
+    // When I create a scheduled event with negative initial delay
+    opts.name = "Invalid scheduled event test";
+    opts.initialDelayInSeconds = -1;
+    opts.callback = [](void* /*data*/) { FAIL() << "Scheduled event called, but should not be called"; };
+    scheduledEventId = celix_bundleContext_scheduleEvent(ctx->getCBundleContext(), &opts);
+    // Then I expect an error
+    EXPECT_LT(scheduledEventId, 0);
+
+    // When I create a scheduled event with negative interval value
+    opts.initialDelayInSeconds = 0.1;
+    opts.intervalInSeconds = -1;
+    scheduledEventId = celix_bundleContext_scheduleEvent(ctx->getCBundleContext(), &opts);
     // Then I expect an error
     EXPECT_LT(scheduledEventId, 0);
 

--- a/libs/framework/include/celix_launcher.h
+++ b/libs/framework/include/celix_launcher.h
@@ -29,6 +29,15 @@ extern "C" {
 #endif
 
 /**
+ * @brief Celix launcher environment property to specify interval of the periodic shutdown check performed by launcher.
+ *
+ * The launcher will perform a periodic check to see whether to perform a shutdown, and if so, the launcher will
+ * stop and destroy the framework. The interval of this check can be specified in seconds using this property.
+ */
+#define CELIX_LAUNCHER_SHUTDOWN_PERIOD_IN_SECONDS           "CELIX_LAUNCHER_SHUTDOWN_PERIOD_IN_SECONDS"
+#define CELIX_LAUNCHER_SHUTDOWN_PERIOD_IN_SECONDS_DEFAULT   1.0
+
+/**
  * @brief Launch a celix framework, wait (block) until the framework is stopped and destroy the framework when stopped.
  *
  * The launcher will also setup signal handlers for SIGINT, SIGTERM, SIGUSR1 and SIGUSR2 and initialize libcurl.

--- a/libs/framework/src/bundle_context.c
+++ b/libs/framework/src/bundle_context.c
@@ -579,7 +579,7 @@ celix_dependency_manager_t* celix_bundleContext_getDependencyManager(bundle_cont
     if (ctx->mng) {
         return ctx->mng;
     }
-    celixThreadRwlock_unlock(celix_steal_ptr(rlockGuard.lock));
+    celixRwlockRlockGuard_deinit(&rlockGuard);
 
     celix_auto(celix_rwlock_wlock_guard_t) wlockGuard = celixRwlockWlockGuard_init(&ctx->lock);
     if (ctx->mng == NULL) {

--- a/libs/framework/src/celix_launcher.c
+++ b/libs/framework/src/celix_launcher.c
@@ -49,8 +49,8 @@ typedef struct {
     framework_t* framework;
     long shutdownEventId;
     bool launched;
-    bool shutdown;
-    int signal;
+    bool shutdown; // accessed through atomic operations
+    int signal; // accessed through atomic operations
 } celix_launcher_t;
 
 typedef struct {
@@ -393,7 +393,6 @@ void celix_launcher_triggerStop() {
 }
 
 static void celix_launcher_shutdownCheck(void* data CELIX_UNUSED) {
-    // assert(data == &g_launcher)
     celix_auto(celix_mutex_lock_guard_t) lck = celixMutexLockGuard_init(&g_launcher.lock);
     if (__atomic_load_n(&g_launcher.shutdown, __ATOMIC_ACQUIRE)) {
         int sig = __atomic_load_n(&g_launcher.signal, __ATOMIC_RELAXED);

--- a/libs/framework/src/celix_launcher.c
+++ b/libs/framework/src/celix_launcher.c
@@ -178,6 +178,7 @@ int celix_launcher_launchAndWait(int argc, char* argv[], const char* embeddedCon
     celix_framework_t* framework = NULL;
     status = celix_launcher_createFramework(celix_steal_ptr(embeddedProps), runtimeProps, &framework);
     if (status != CELIX_SUCCESS) {
+        celix_launcher_resetLauncher();
         return CELIX_LAUNCHER_ERROR_EXIT_CODE;
     }
     status = celix_launcher_setGlobalFramework(framework);
@@ -255,12 +256,14 @@ static celix_status_t celix_launcher_createFramework(celix_properties_t* embedde
     return *frameworkOut != NULL ? CELIX_SUCCESS : CELIX_FRAMEWORK_EXCEPTION;
 }
 
+// LCOV_EXCL_START
 /**
  * @brief SIGUSR1 SIGUSR2 no-op callback
  */
 static void celix_launcher_noopSignalHandler(int signal __attribute__((unused))) {
     // ignoring signal SIGUSR1, SIGUSR2. Can be used on threads
 }
+// LCOV_EXCL_STOP
 
 static void celix_launcher_printUsage(char* progName) {
     printf("Usage:\n  %s [-h|-p|-c] [path/to/runtime/config.properties]\n", basename(progName));

--- a/libs/framework/src/celix_launcher_private.h
+++ b/libs/framework/src/celix_launcher_private.h
@@ -25,15 +25,6 @@ extern "C" {
 #endif
 
 /**
- * @brief Stop the framework, by stopping the framework bundle.
- *
- * Also logs a message if the framework is stopped due to a signal.
- *
- * @param signal The optional signal that caused the framework to stop.
- */
-void celix_launcher_stopInternal(const int* signal);
-
-/**
  * @brief Create a combined configuration properties set by combining the embedded properties with the runtime
  * properties.
  * @param[in,out] embeddedProps The embedded properties to use and extend with the runtime properties.

--- a/libs/framework/src/framework.c
+++ b/libs/framework/src/framework.c
@@ -1383,7 +1383,7 @@ static void celix_framework_processScheduledEvents(celix_framework_t* fw) {
         celixThreadMutex_lock(&fw->dispatcher.mutex);
         CELIX_LONG_HASH_MAP_ITERATE(fw->dispatcher.scheduledEvents, entry) {
             celix_scheduled_event_t* visit = entry.value.ptrValue;
-            if (celix_scheduledEvent_isMarkedForRemoval(visit)) {
+            if (!fw->dispatcher.active || celix_scheduledEvent_isMarkedForRemoval(visit)) {
                 removeEvent = visit;
                 celix_longHashMap_remove(fw->dispatcher.scheduledEvents, celix_scheduledEvent_getId(visit));
                 break;
@@ -1536,6 +1536,7 @@ static void *fw_eventDispatcher(void *fw) {
     celixThreadMutex_unlock(&framework->dispatcher.mutex);
     while (needExtraRun) {
         fw_handleEvents(framework);
+        celix_framework_processScheduledEvents(framework);
         celixThreadMutex_lock(&framework->dispatcher.mutex);
         needExtraRun = celix_framework_eventQueueSize(fw) > 0;
         celixThreadMutex_unlock(&framework->dispatcher.mutex);

--- a/libs/framework/src/framework.c
+++ b/libs/framework/src/framework.c
@@ -2542,6 +2542,13 @@ long celix_framework_scheduleEvent(celix_framework_t* fw,
                bndId);
         return -1;
     }
+    if (initialDelayInSeconds < 0 || intervalInSeconds < 0) {
+        fw_log(fw->logger,
+               CELIX_LOG_LEVEL_ERROR,
+               "Cannot add scheduled event for bundle id %li. Invalid intervals: (%f,%f).",
+               bndId, initialDelayInSeconds, intervalInSeconds);
+        return -1;
+    }
 
     celix_bundle_entry_t* bndEntry = celix_framework_bundleEntry_getBundleEntryAndIncreaseUseCount(fw, bndId);
     if (bndEntry == NULL) {

--- a/libs/framework/src/framework.c
+++ b/libs/framework/src/framework.c
@@ -1531,12 +1531,12 @@ static void *fw_eventDispatcher(void *fw) {
     }
 
     //not active anymore, extra runs for possible request leftovers
+    celix_framework_processScheduledEvents(framework);
     celixThreadMutex_lock(&framework->dispatcher.mutex);
     bool needExtraRun = celix_framework_eventQueueSize(fw) > 0;
     celixThreadMutex_unlock(&framework->dispatcher.mutex);
     while (needExtraRun) {
         fw_handleEvents(framework);
-        celix_framework_processScheduledEvents(framework);
         celixThreadMutex_lock(&framework->dispatcher.mutex);
         needExtraRun = celix_framework_eventQueueSize(fw) > 0;
         celixThreadMutex_unlock(&framework->dispatcher.mutex);


### PR DESCRIPTION
This PR fixes a long-standing issue #215 by implementing async-signal-safe launcher shutdown.
Without making our event loop more powerful (like [libuv](https://docs.libuv.org/en/v1.x/design.html)), I think setting a flag to be checked by a periodic scheduled event callback is the best we can do. So here it is.

This PR also makes `celix_launcher_triggerStop` safer. Previously a bundle may initiate a framework shutdown, which will cause `celix_framework_waitForStop` to return without noticing the launcher. In that case, `celix_launcher_triggerStop` might reference a to-be-destroyed framework instance to wreck havoc. Now we prevent it from happening with `g_launcher.lock`.
