### PR TITLE
Hotfix/Avoid scheduling event to an inactive framework.

### DIFF
--- a/libs/framework/src/framework.c
+++ b/libs/framework/src/framework.c
@@ -2583,8 +2583,13 @@ long celix_framework_scheduleEvent(celix_framework_t* fw,
     celix_bundleEntry_decreaseUseCount(bndEntry);
 
     celixThreadMutex_lock(&fw->dispatcher.mutex);
-    celix_longHashMap_put(fw->dispatcher.scheduledEvents, id, event);
-    celixThreadCondition_broadcast(&fw->dispatcher.cond); //notify dispatcher thread for newly added scheduled event
+    if (fw->dispatcher.active) {
+        celix_longHashMap_put(fw->dispatcher.scheduledEvents, id, event);
+        celixThreadCondition_broadcast(&fw->dispatcher.cond); //notify dispatcher thread for newly added scheduled event
+    } else {
+        celix_scheduledEvent_release(event);
+        id = -1L;
+    }
     celixThreadMutex_unlock(&fw->dispatcher.mutex);
 
     return id;


### PR DESCRIPTION
This PR fixes a program hang during framework shutdown (https://github.com/apache/celix/actions/runs/9630851373/job/26561902128) by avoiding scheduling event to an inactive framework:

```
Hello world from C bundle with id 3
Bundle 1: apache_celix_c_shell
Bundle 2: apache_celix_shell_wui
Bundle 3: hello
Goodbye world from C bundle with id 3
[2024-06-23T04:49:06] [   info] [celix_framework] [framework_start:483] Celix framework started
Warning: 23T04:49:08] [warning] [celix_framework] [celix_scheduledEvent_waitForRemoved:237] Timeout while waiting for removal of scheduled event 'celix_shutdown_check' (id=0) for bundle id 0.
Warning: 23T04:49:11] [warning] [celix_framework] [celix_scheduledEvent_waitForRemoved:237] Timeout while waiting for removal of scheduled event 'celix_shutdown_check' (id=0) for bundle id 0.
Warning: 23T04:49:13] [warning] [celix_framework] [celix_scheduledEvent_waitForRemoved:237] Timeout while waiting for removal of scheduled event 'celix_shutdown_check' (id=0) for bundle id 0.
Warning: 23T04:49:15] [warning] [celix_framework] [celix_scheduledEvent_waitForRemoved:237] Timeout while waiting for removal of scheduled event 'celix_shutdown_check' (id=0) for bundle id 0.
Warning: 23T04:49:17] [warning] [celix_framework] [celix_scheduledEvent_waitForRemoved:237] Timeout while waiting for removal of scheduled event 'celix_shutdown_check' (id=0) for bundle id 0.
Warning: 23T04:49:19] [warning] [celix_framework] [celix_scheduledEvent_waitForRemoved:237] Timeout while waiting for removal of scheduled event 'celix_shutdown_check' (id=0) for bundle id 0.
```

The root cause is that `examples/conan_test_package/hello_bundle.c` calls `celix_framework_stopBundleAsync` during its bundle start, which may lead framework shutdown to happen between `celix_launcher_createFramework` and `celix_launcher_setGlobalFramework`. Note that `celix_shutdown_check` is scheduled in `celix_launcher_setGlobalFramework`.