### PR TITLE
Hotfix/Fix test_package error.

### DIFF
--- a/.github/workflows/conan_create.yml
+++ b/.github/workflows/conan_create.yml
@@ -76,7 +76,7 @@ jobs:
           conan remove -c celix/* 
 
   mac-build:
-    runs-on: macOS-11
+    runs-on: macOS-12
     timeout-minutes: 120
     steps:
       - name: Checkout source code

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -16,7 +16,7 @@ env:
 jobs:
 
   macos-build-conan:
-    runs-on: macOS-11
+    runs-on: macOS-12
     timeout-minutes: 120
     steps:
       - name: Checkout source code

--- a/libs/framework/gtest/CMakeLists.txt
+++ b/libs/framework/gtest/CMakeLists.txt
@@ -34,6 +34,7 @@ add_celix_bundle(cmp_test_bundle SOURCES src/CmpTestBundleActivator.cc VERSION 1
 add_celix_bundle(cond_test_bundle SOURCES src/CondTestBundleActivator.cc VERSION 1.0.0)
 add_subdirectory(subdir) #simple_test_bundle4, simple_test_bundle5 and sublib
 add_celix_bundle(celix_err_test_bundle SOURCES src/activator_with_celix_err.c VERSION 1.0.0)
+add_celix_bundle(immediate_stop_bundle SOURCES src/activator_stop.c VERSION 1.0.0)
 
 add_celix_bundle(unresolvable_bundle SOURCES src/nop_activator.c VERSION 1.0.0)
 if (CMAKE_BUILD_TYPE STREQUAL "Debug")
@@ -82,7 +83,7 @@ add_celix_bundle_dependencies(test_framework
         simple_test_bundle2 simple_test_bundle3 simple_test_bundle4
         simple_test_bundle5 bundle_with_exception bundle_with_bad_export
         unresolvable_bundle simple_cxx_bundle simple_cxx_dep_man_bundle cmp_test_bundle
-        celix_err_test_bundle dup_symbolic_name_bundle)
+        celix_err_test_bundle dup_symbolic_name_bundle immediate_stop_bundle)
 target_include_directories(test_framework PRIVATE ../src)
 celix_deprecated_utils_headers(test_framework)
 
@@ -94,6 +95,7 @@ celix_get_bundle_file(simple_test_bundle4 SIMPLE_TEST_BUNDLE4)
 celix_get_bundle_file(simple_test_bundle5 SIMPLE_TEST_BUNDLE5)
 celix_get_bundle_filename(simple_test_bundle4 SIMPLE_TEST_BUNDLE4_FILENAME)
 celix_get_bundle_filename(simple_test_bundle5 SIMPLE_TEST_BUNDLE5_FILENAME)
+celix_get_bundle_file(immediate_stop_bundle IMMEDIATE_STOP_BUNDLE)
 
 celix_get_bundle_filename(bundle_with_exception BUNDLE_WITH_EXCEPTION)
 celix_get_bundle_file(bundle_with_bad_export BUNDLE_WITH_BAD_EXPORT)
@@ -128,7 +130,9 @@ target_compile_definitions(test_framework PRIVATE
         CMP_TEST_BUNDLE_LOC="${CMP_TEST_BUNDLE_LOC}"
         COND_TEST_BUNDLE_LOC="${COND_TEST_BUNDLE_LOC}"
         INSTALL_AND_START_BUNDLES_CONFIG_PROPERTIES_FILE="${CMAKE_CURRENT_BINARY_DIR}/install_and_start_bundles.properties"
+        IMMEDIATE_STOP_BUNDLE_LOCATION="${IMMEDIATE_STOP_BUNDLE}"
 )
+
 if (ENABLE_TESTING_ON_CI)
     target_compile_definitions(test_framework PRIVATE TESTING_ON_CI=1)
 endif ()

--- a/libs/framework/gtest/src/CelixLauncherTestSuite.cc
+++ b/libs/framework/gtest/src/CelixLauncherTestSuite.cc
@@ -194,6 +194,19 @@ TEST_F(CelixLauncherTestSuite, LaunchWithInvalidConfigPropertiesTest) {
     EXPECT_EQ(status, std::future_status::ready);
 }
 
+TEST_F(CelixLauncherTestSuite, LaunchWithInvalidConfigProperties2Test) {
+
+    //When launching the framework with a properties set with a negative shutdown period
+    auto* props = celix_properties_create();
+    ASSERT_TRUE(props != nullptr);
+    celix_properties_set(props, CELIX_AUTO_START_0, IMMEDIATE_STOP_BUNDLE_LOCATION);
+    celix_properties_setDouble(props, CELIX_LAUNCHER_SHUTDOWN_PERIOD_IN_SECONDS, -1.0);
+    auto future = launchInThread({"programName"}, props, 0);
+    //Then launch will exit
+    auto status = future.wait_for(std::chrono::milliseconds{LAUNCH_WAIT_TIMEOUT});
+    EXPECT_EQ(status, std::future_status::ready);
+}
+
 
 TEST_F(CelixLauncherTestSuite, StopLauncherWithSignalTest) {
     auto* props = celix_properties_create();

--- a/libs/framework/gtest/src/CelixLauncherTestSuite.cc
+++ b/libs/framework/gtest/src/CelixLauncherTestSuite.cc
@@ -192,15 +192,6 @@ TEST_F(CelixLauncherTestSuite, LaunchWithInvalidConfigPropertiesTest) {
     //Then the launch will exit
     auto status = future.wait_for(std::chrono::milliseconds{LAUNCH_WAIT_TIMEOUT});
     EXPECT_EQ(status, std::future_status::ready);
-
-    //When launching the framework with a properties set with a negative shutdown period
-    auto* props = celix_properties_create();
-    ASSERT_TRUE(props != nullptr);
-    celix_properties_setDouble(props, CELIX_LAUNCHER_SHUTDOWN_PERIOD_IN_SECONDS, -1.0);
-    future = launchInThread({"programName"}, props, 1);
-    //Then launch will exit
-    status = future.wait_for(std::chrono::milliseconds{LAUNCH_WAIT_TIMEOUT});
-    EXPECT_EQ(status, std::future_status::ready);
 }
 
 

--- a/libs/framework/gtest/src/activator_stop.c
+++ b/libs/framework/gtest/src/activator_stop.c
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include "celix_bundle_activator.h"
+#include "celix_framework.h"
+
+typedef struct bundle_activator {
+    //empty
+} bundle_activator_t;
+
+static celix_status_t act_start(bundle_activator_t *act CELIX_UNUSED, celix_bundle_context_t *ctx CELIX_UNUSED) {
+    celix_framework_stopBundleAsync(celix_bundleContext_getFramework(ctx), CELIX_FRAMEWORK_BUNDLE_ID); // to make container quit immediately
+    return CELIX_SUCCESS;
+}
+
+static celix_status_t act_stop(bundle_activator_t *act CELIX_UNUSED, celix_bundle_context_t *ctx CELIX_UNUSED) {
+    return CELIX_SUCCESS;
+}
+
+CELIX_GEN_BUNDLE_ACTIVATOR(bundle_activator_t, act_start, act_stop);

--- a/libs/framework/src/celix_launcher.c
+++ b/libs/framework/src/celix_launcher.c
@@ -185,7 +185,6 @@ int celix_launcher_launchAndWait(int argc, char* argv[], const char* embeddedCon
     if (status != CELIX_SUCCESS) {
         celix_bundleContext_log(celix_framework_getFrameworkContext(framework), CELIX_LOG_LEVEL_WARNING,
                                 "Failed to schedule celix_shutdown_check");
-        status = CELIX_SUCCESS;
     }
     celix_framework_waitForStop(framework);
     celix_launcher_resetLauncher();
@@ -193,7 +192,7 @@ int celix_launcher_launchAndWait(int argc, char* argv[], const char* embeddedCon
     // Cleanup Curl
     curl_global_cleanup();
 #endif
-    return status == CELIX_SUCCESS ? CELIX_LAUNCHER_OK_EXIT_CODE : CELIX_LAUNCHER_ERROR_EXIT_CODE;
+    return CELIX_LAUNCHER_OK_EXIT_CODE;
 }
 
 static celix_status_t celix_launcher_parseOptions(int argc, char* argv[], celix_launcher_options_t* opts) {

--- a/libs/framework/src/celix_launcher.c
+++ b/libs/framework/src/celix_launcher.c
@@ -182,9 +182,12 @@ int celix_launcher_launchAndWait(int argc, char* argv[], const char* embeddedCon
         return CELIX_LAUNCHER_ERROR_EXIT_CODE;
     }
     status = celix_launcher_setGlobalFramework(framework);
-    if (status == CELIX_SUCCESS) {
-        celix_framework_waitForStop(framework);
+    if (status != CELIX_SUCCESS) {
+        celix_bundleContext_log(celix_framework_getFrameworkContext(framework), CELIX_LOG_LEVEL_WARNING,
+                                "Failed to schedule celix_shutdown_check");
+        status = CELIX_SUCCESS;
     }
+    celix_framework_waitForStop(framework);
     celix_launcher_resetLauncher();
 #ifndef CELIX_NO_CURLINIT
     // Cleanup Curl


### PR DESCRIPTION
As observed, trying to scheduling event to an inactive framework will lead to test_package failure:

```
celix/3.0.0 (test package): RUN: ./use_components_ready_check

Hello world from C bundle with id 2
Bundle 1: apache_celix_components_ready_check
Bundle 2: hello
Goodbye world from C bundle with id 2
[2024-06-24T09:03:00] [   info] [celix_framework] [framework_start:483] Celix framework started

ERROR: celix/3.0.0 (test package): Error in test() method, line 149
	self.run("./use_components_ready_check",
	ConanException: Error 1 while executing
```

This PR fixes this by only issuing a warning instead of returning error.
