### PR TITLE
Update linux-build-apt to use ninja.

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -110,6 +110,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install -yq --no-install-recommends \
           build-essential \
+          ninja-build \
           curl \
           uuid-dev \
           libzip-dev \
@@ -145,11 +146,12 @@ jobs:
           -DENABLE_TESTING_ON_CI=ON
           -DCMAKE_BUILD_TYPE=${{ matrix.type }}
           -DENABLE_CCACHE=ON
+          -G Ninja
       run: |
         mkdir build install
         cd build
         cmake ${BUILD_OPTIONS} -DCMAKE_INSTALL_PREFIX=../install ..
-        make -j $(nproc) && make install
+        ninja && ninja install
     - name: Test
       run: |
         cd $GITHUB_WORKSPACE/build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,11 +31,6 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
 
-# see https://public.kitware.com/Bug/view.php?id=15696
-IF (${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION} EQUAL 3.3 AND ${CMAKE_GENERATOR} STREQUAL "Unix Makefiles")
-    message( FATAL_ERROR "Building Celix using CMake 3.3 and makefiles is not supported due to a bug in the Makefile Generator (see Bug 15696). Please change the used CMake version - both, CMake 3.2 and CMake 3.4 are working fine. Or use a different generator (e.g. Ninja)." )
-ENDIF()
-
 # Options
 option(ENABLE_TESTING "Enables unit/bundle testing" FALSE)
 if (ENABLE_TESTING)


### PR DESCRIPTION
This PR remove irrelevant check which causes temporary CI failure and update linux-build-apt to use Ninja.

https://github.com/apache/celix/actions/runs/9883280941/job/27299892915#step:6:47
```
Run mkdir build install
-- The C compiler identification is GNU 11.4.0
-- The CXX compiler identification is GNU 11.4.0
-- The ASM compiler identification is GNU
-- Found assembler: /usr/bin/cc
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
-- Found Threads: TRUE
CMake Error at CMakeLists.txt:36 (message):
  Building Celix using CMake 3.3 and makefiles is not supported due to a bug
  in the Makefile Generator (see Bug 15696).  Please change the used CMake
  version - both, CMake 3.2 and CMake 3.4 are working fine.  Or use a
  different generator (e.g.  Ninja).
-- Configuring incomplete, errors occurred!
``` 