### PR TITLE
Upgrade macos-build-conan and mac-build to use macOS-13.

### DIFF
--- a/.github/workflows/conan_create.yml
+++ b/.github/workflows/conan_create.yml
@@ -76,7 +76,7 @@ jobs:
           conan remove -c celix/* 
 
   mac-build:
-    runs-on: macOS-latest
+    runs-on: macOS-13
     timeout-minutes: 120
     steps:
       - name: Checkout source code

--- a/.github/workflows/conan_create.yml
+++ b/.github/workflows/conan_create.yml
@@ -76,7 +76,7 @@ jobs:
           conan remove -c celix/* 
 
   mac-build:
-    runs-on: macOS-12
+    runs-on: macOS-13
     timeout-minutes: 120
     steps:
       - name: Checkout source code

--- a/.github/workflows/conan_create.yml
+++ b/.github/workflows/conan_create.yml
@@ -76,7 +76,7 @@ jobs:
           conan remove -c celix/* 
 
   mac-build:
-    runs-on: macOS-13
+    runs-on: macOS-latest
     timeout-minutes: 120
     steps:
       - name: Checkout source code

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -16,7 +16,7 @@ env:
 jobs:
 
   macos-build-conan:
-    runs-on: macOS-12
+    runs-on: macOS-13
     timeout-minutes: 120
     steps:
       - name: Checkout source code

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -16,7 +16,7 @@ env:
 jobs:
 
   macos-build-conan:
-    runs-on: macos-latest
+    runs-on: macOS-13
     timeout-minutes: 120
     steps:
       - name: Checkout source code

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -16,7 +16,7 @@ env:
 jobs:
 
   macos-build-conan:
-    runs-on: macOS-13
+    runs-on: macos-latest
     timeout-minutes: 120
     steps:
       - name: Checkout source code

--- a/bundles/cxx_remote_services/admin/src/RemoteServiceAdmin.h
+++ b/bundles/cxx_remote_services/admin/src/RemoteServiceAdmin.h
@@ -28,6 +28,11 @@
 #include <version>
 #endif
 
+#  if defined(__cpp_lib_memory_resource) \
+    && ((defined(__MAC_OS_X_VERSION_MIN_REQUIRED)  && __MAC_OS_X_VERSION_MIN_REQUIRED  < 140000) \
+     || (defined(__IPHONE_OS_VERSION_MIN_REQUIRED) && __IPHONE_OS_VERSION_MIN_REQUIRED < 170000))
+#   undef __cpp_lib_memory_resource // Only supported on macOS 14 and iOS 17
+#  endif
 #if __cpp_lib_memory_resource
 #include <memory_resource>
 #endif


### PR DESCRIPTION
This PR replaces now deprecated macOS-12 by macOS-latest

Note also that we opt out of standard library memory_resource on macOS < 14 and iOS < 17 to fix runtime error for cxx_remote_services. See https://github.com/qt/qtbase/commit/c70145c6bf54cda9723cccdc7ca07f8d8fd321cd for details.
