### PR TITLE
apacheGH-491: Check return value of vasprintf and asprintf

### DIFF
--- a/bundles/event_admin/remote_provider/remote_provider_mqtt/src/celix_earpm_impl.c
+++ b/bundles/event_admin/remote_provider/remote_provider_mqtt/src/celix_earpm_impl.c
@@ -148,6 +148,7 @@ celix_event_admin_remote_provider_mqtt_t* celix_earpm_create(celix_bundle_contex
     }
 
     if (asprintf(&earpm->syncEventAckTopic, CELIX_EARPM_SYNC_EVENT_ACK_TOPIC_PREFIX"%s", earpm->fwUUID) < 0) {
+        earpm->syncEventAckTopic = NULL;
         celix_logHelper_error(logHelper, "Failed to create sync event response topic.");
         return NULL;
     }

--- a/bundles/event_admin/remote_provider/remote_provider_mqtt/src/celix_earpm_impl.c
+++ b/bundles/event_admin/remote_provider/remote_provider_mqtt/src/celix_earpm_impl.c
@@ -147,11 +147,12 @@ celix_event_admin_remote_provider_mqtt_t* celix_earpm_create(celix_bundle_contex
         return NULL;
     }
 
-    if (asprintf(&earpm->syncEventAckTopic, CELIX_EARPM_SYNC_EVENT_ACK_TOPIC_PREFIX"%s", earpm->fwUUID) < 0) {
-        earpm->syncEventAckTopic = NULL;
+    earpm->syncEventAckTopic = NULL;
+    if (asprintf(&earpm->syncEventAckTopic, CELIX_EARPM_SYNC_EVENT_ACK_TOPIC_PREFIX "%s", earpm->fwUUID) < 0) {
         celix_logHelper_error(logHelper, "Failed to create sync event response topic.");
         return NULL;
     }
+
     celix_autofree char* syncEventAckTopic = earpm->syncEventAckTopic;
     celix_status_t status = celixThreadMutex_create(&earpm->mutex, NULL);
     if (status != CELIX_SUCCESS) {

--- a/bundles/http_admin/http_admin/src/activator.c
+++ b/bundles/http_admin/http_admin/src/activator.c
@@ -97,7 +97,12 @@ static int http_admin_start(http_admin_activator_t *act, celix_bundle_context_t 
 
     for(long port = prop_port_min; act->httpManager == NULL && port <= prop_port_max; port++) {
         char *port_str;
-        asprintf(&port_str, "%li", port);
+        rc= asprintf(&port_str, "%li", port);
+        if(rc < 0 || port_str == NULL) {
+            celix_bundleContext_log(ctx, CELIX_LOG_LEVEL_ERROR, "Cannot allocate memory for port string.");
+            free(httpRoot);
+            return CELIX_ENOMEM;
+        }
         svr_opts[3] = port_str;
         act->httpManager = httpAdmin_create(ctx, httpRoot, svr_opts);
         free(port_str);
@@ -136,6 +141,7 @@ static int http_admin_start(http_admin_activator_t *act, celix_bundle_context_t 
         }
     }
 
+    free(httpRoot);
     return CELIX_SUCCESS;
 }
 

--- a/bundles/http_admin/http_admin/src/activator.c
+++ b/bundles/http_admin/http_admin/src/activator.c
@@ -49,7 +49,7 @@ static int http_admin_start(http_admin_activator_t *act, celix_bundle_context_t 
         return CELIX_BUNDLE_EXCEPTION;
     }
 
-    char* httpRoot = NULL;
+    celix_autofree char* httpRoot = NULL;
     int rc = asprintf(&httpRoot, "%s/root", storeRoot);
     if (rc < 0) {
         celix_bundleContext_log(ctx, CELIX_LOG_LEVEL_ERROR, "Cannot create http root directory for the http admin bundle.");
@@ -61,7 +61,6 @@ static int http_admin_start(http_admin_activator_t *act, celix_bundle_context_t 
     celix_status_t status = celix_utils_createDirectory(httpRoot, false, NULL);
     if (status != CELIX_SUCCESS) {
         celix_bundleContext_log(ctx, CELIX_LOG_LEVEL_ERROR, "Cannot create http root directory for the http admin bundle.");
-        free(httpRoot);
         return status;
     }
     celix_bundleContext_log(ctx, CELIX_LOG_LEVEL_DEBUG, "Using http root directory %s", httpRoot);
@@ -141,7 +140,6 @@ static int http_admin_start(http_admin_activator_t *act, celix_bundle_context_t 
         }
     }
 
-    free(httpRoot);
     return CELIX_SUCCESS;
 }
 

--- a/bundles/http_admin/http_admin/src/http_admin.c
+++ b/bundles/http_admin/http_admin/src/http_admin.c
@@ -418,6 +418,10 @@ static void createAliasesSymlink(const char *aliases, const char *admin_root, co
             }
 
             asprintf(&alias_path, "%s/%s%s", cwd, admin_root, sub_token);
+            if (alias_path == NULL) {  // Check if asprintf failed.
+                continue;
+            }
+
             if(aliasList_containsAlias(alias_list, alias_path)) {
                 free(alias_path);
                 continue; //Alias already existing, Continue to next entry
@@ -431,6 +435,10 @@ static void createAliasesSymlink(const char *aliases, const char *admin_root, co
             }
 
             asprintf(&bnd_resource_path, "%s/%s/%s", cwd, bundle_root, sub_token);
+            if (bnd_resource_path == NULL) {  // Check if asprintf failed.
+                free(alias_path);
+                continue;
+            }
 
             if(symlink(bnd_resource_path, alias_path) == 0) {
                 http_alias_t *alias = calloc(1, sizeof(*alias));

--- a/bundles/http_admin/http_admin/src/service_tree.c
+++ b/bundles/http_admin/http_admin/src/service_tree.c
@@ -91,15 +91,23 @@ bool addServiceNode(service_tree_t *svc_tree, const char *uri, void *svc) {
         //Else root already exists
     } else if(svc_tree->root_node == NULL) { //No service yet added
         uri_cpy = strdup(uri);
+        if (uri_cpy == NULL) { // Check for memory allocation failure
+            return false;
+        }
         req_uri = strtok_r(uri_cpy, "/", &save_ptr);
         svc_tree->root_node = createServiceNode(NULL, NULL, NULL, NULL, req_uri, (tokenCount == 1 ? svc : NULL));
         svc_tree->tree_node_count = 1;
         uri_exists = false;
     } else if(strcmp(svc_tree->root_node->svc_data->sub_uri, "root") == 0){
-        asprintf(&uri_cpy, "%s%s", "root", uri);
+        if (asprintf(&uri_cpy, "%s%s", "root", uri)<0) {
+            return false;
+        }
         req_uri = strtok_r(uri_cpy, "/", &save_ptr);
     } else {
         uri_cpy = strdup(uri);
+        if (uri_cpy == NULL) { // Check for memory allocation failure
+            return false;
+        }
         req_uri = strtok_r(uri_cpy, "/", &save_ptr);
     }
 
@@ -293,9 +301,15 @@ service_tree_node_t *findServiceNodeInTree(service_tree_t *svc_tree, const char 
     if (tree_not_empty) {
         if(strcmp(current->svc_data->sub_uri, "root") == 0)
         {
-            asprintf(&uri_cpy, "%s%s", "root", uri);
+            if (asprintf(&uri_cpy, "%s%s", "root", uri)<0)
+            {
+                return NULL;
+            }
         } else {
             uri_cpy = strdup(uri);
+            if (uri_cpy == NULL) {  // Check for strdup failure
+                return NULL;
+            }
         }
 
         char *uri_token = strtok_r(uri_cpy, "/", &save_ptr);

--- a/bundles/remote_services/discovery_zeroconf/src/discovery_zeroconf_watcher.c
+++ b/bundles/remote_services/discovery_zeroconf/src/discovery_zeroconf_watcher.c
@@ -920,17 +920,11 @@ static int discoveryZeroConfWatcher_getHostIpAddresses(discovery_zeroconf_watche
     if (hostEntry != NULL) {
         CELIX_STRING_HASH_MAP_ITERATE(hostEntry->ipAddresses, iter) {
             const char *ip = iter.key;
-            char *tmp= NULL;
-            if (ipAddressesStr == NULL) {
-                tmp = celix_utils_strdup(ip);
-            } else {
-                asprintf(&tmp, "%s,%s", ipAddressesStr, ip);
-            }
+            celix_autofree char *tmp = (ipAddressesStr == NULL) ? celix_utils_strdup(ip) : celix_utils_concat(ipAddressesStr, ",", ip);
             if (tmp == NULL) {
                 return CELIX_ENOMEM;
             }
-            free(ipAddressesStr);
-            ipAddressesStr = tmp;
+            ipAddressesStr = celix_steal_ptr(tmp);
         }
     }
     if (ipAddressesStr == NULL) {

--- a/bundles/remote_services/topology_manager/tms_tst/disc_mock/disc_mock_activator.c
+++ b/bundles/remote_services/topology_manager/tms_tst/disc_mock/disc_mock_activator.c
@@ -79,6 +79,10 @@ celix_status_t celix_bundleActivator_start(void * userData, celix_bundle_context
     celix_properties_t *props = NULL;
     if (status == CELIX_SUCCESS) {
         props = celix_properties_create();
+        if (!props) {
+            free(scope);
+            return CELIX_ENOMEM;
+        }
         celix_properties_set(props, "DISCOVERY", "true");
         celix_properties_set(props, (char *) CELIX_RSA_ENDPOINT_LISTENER_SCOPE, scope);
     }
@@ -86,7 +90,9 @@ celix_status_t celix_bundleActivator_start(void * userData, celix_bundle_context
     if (status == CELIX_SUCCESS) {
         endpoint_listener_t *endpointListener = calloc(1, sizeof(struct endpoint_listener));
 
-        if (endpointListener) {
+        if (!endpointListener) {
+            status = CELIX_ENOMEM;
+        } else {
             endpointListener->handle = act;
             endpointListener->endpointAdded = discovery_endpointAdded;
             endpointListener->endpointRemoved = discovery_endpointRemoved;
@@ -105,8 +111,9 @@ celix_status_t celix_bundleActivator_start(void * userData, celix_bundle_context
     // We can release the scope, as celix_properties_set makes a copy of the key & value...
     free(scope);
 
-    //if properties are not used in service registration, destroy it.
-    celix_properties_destroy(props);
+    if (props) {
+        celix_properties_destroy(props);
+    }
 
     return status;
 }

--- a/libs/framework/src/bundle.c
+++ b/libs/framework/src/bundle.c
@@ -304,22 +304,32 @@ static char* celix_bundle_getBundleOrPersistentStoreEntry(const celix_bundle_t* 
         root = celix_bundleArchive_getPersistentStoreRoot(archive);
     }
 
-    char *entry = NULL;
-    if (name == NULL || strnlen(name, 1) == 0) { //NULL or ""
-        entry = celix_utils_strdup(root);
-    } else if ((strnlen(name, 1) > 0) && (name[0] == '/')) {
-        asprintf(&entry, "%s%s", root, name);
-    } else {
-        asprintf(&entry, "%s/%s", root, name);
+    if (root == NULL) {
+        fw_logCode(bnd->framework->logger, CELIX_BUNDLE_EXCEPTION, CELIX_ILLEGAL_STATE, "Failed to get valid root directory");
+        return NULL;
     }
 
-    if (celix_utils_fileExists(entry)) {
+    char *entry = NULL;
+    if (name == NULL || strnlen(name, 1) == 0) { // NULL or ""
+        entry = celix_utils_strdup(root);
+    } else if ((strnlen(name, 1) > 0) && (name[0] == '/')) {
+        if (asprintf(&entry, "%s%s", root, name) < 0) {
+            return NULL; // Memory allocation failure
+        }
+    } else {
+        if (asprintf(&entry, "%s/%s", root, name) < 0) {
+            return NULL; // Memory allocation failure
+        }
+    }
+
+    if (entry && celix_utils_fileExists(entry)) {
         return entry;
     } else {
         free(entry);
         return NULL;
     }
 }
+
 
 char* celix_bundle_getEntry(const celix_bundle_t* bnd, const char *path) {
 	char *entry = NULL;

--- a/libs/framework/src/service_registry.c
+++ b/libs/framework/src/service_registry.c
@@ -816,32 +816,49 @@ char* celix_serviceRegistry_createFilterFor(celix_service_registry_t* registry, 
     celix_autofree char* versionRange = NULL;
     if (versionRangeStr != NULL) {
         celix_autoptr(celix_version_range_t) range = celix_versionRange_parse(versionRangeStr);
-        if(range == NULL) {
+        if (range == NULL) {
             celix_framework_log(registry->framework->logger, CELIX_LOG_LEVEL_ERROR, __FUNCTION__, __BASE_FILE__, __LINE__,
-                          "Error incorrect version range.");
+                          "Error: incorrect version range.");
             return NULL;
         }
         versionRange = celix_versionRange_createLDAPFilter(range, CELIX_FRAMEWORK_SERVICE_VERSION);
         if (versionRange == NULL) {
             celix_framework_log(registry->framework->logger, CELIX_LOG_LEVEL_ERROR, __FUNCTION__, __BASE_FILE__, __LINE__,
-                          "Error creating LDAP filter.");
+                          "Error: creating LDAP filter.");
             return NULL;
         }
     }
 
-    //setting filter
+    // Setting filter
     if (additionalFilterIn != NULL && versionRange != NULL) {
-        asprintf(&filter, "(&(%s=%s)%s%s)", CELIX_FRAMEWORK_SERVICE_NAME, serviceName, versionRange, additionalFilterIn);
+        if (asprintf(&filter, "(&(%s=%s)%s%s)", CELIX_FRAMEWORK_SERVICE_NAME, serviceName, versionRange, additionalFilterIn) < 0) {
+            celix_framework_log(registry->framework->logger, CELIX_LOG_LEVEL_ERROR, __FUNCTION__, __BASE_FILE__, __LINE__,
+                          "Error: asprintf failed while constructing filter with serviceName '%s'.", serviceName);
+            return NULL;
+        }
     } else if (versionRange != NULL) {
-        asprintf(&filter, "(&(%s=%s)%s)", CELIX_FRAMEWORK_SERVICE_NAME, serviceName, versionRange);
+        if (asprintf(&filter, "(&(%s=%s)%s)", CELIX_FRAMEWORK_SERVICE_NAME, serviceName, versionRange) < 0) {
+            celix_framework_log(registry->framework->logger, CELIX_LOG_LEVEL_ERROR, __FUNCTION__, __BASE_FILE__, __LINE__,
+                          "Error: asprintf failed while constructing filter with serviceName '%s'.", serviceName);
+            return NULL;
+        }
     } else if (additionalFilterIn != NULL) {
-        asprintf(&filter, "(&(%s=%s)%s)", CELIX_FRAMEWORK_SERVICE_NAME, serviceName, additionalFilterIn);
+        if (asprintf(&filter, "(&(%s=%s)%s)", CELIX_FRAMEWORK_SERVICE_NAME, serviceName, additionalFilterIn) < 0) {
+            celix_framework_log(registry->framework->logger, CELIX_LOG_LEVEL_ERROR, __FUNCTION__, __BASE_FILE__, __LINE__,
+                          "Error: asprintf failed while constructing filter with serviceName '%s'.", serviceName);
+            return NULL;
+        }
     } else {
-        asprintf(&filter, "(&(%s=%s))", CELIX_FRAMEWORK_SERVICE_NAME, serviceName);
+        if (asprintf(&filter, "(&(%s=%s))", CELIX_FRAMEWORK_SERVICE_NAME, serviceName) < 0) {
+            celix_framework_log(registry->framework->logger, CELIX_LOG_LEVEL_ERROR, __FUNCTION__, __BASE_FILE__, __LINE__,
+                          "Error: asprintf failed while constructing filter with serviceName '%s'.", serviceName);
+            return NULL;
+        }
     }
 
     return filter;
 }
+
 
 static int celix_serviceRegistry_compareRegistrations(celix_array_list_entry_t a, celix_array_list_entry_t b) {
     const service_registration_t* regA = a.voidPtrVal;

--- a/libs/utils/src/properties.c
+++ b/libs/utils/src/properties.c
@@ -119,6 +119,7 @@ static celix_status_t celix_properties_fillEntry(celix_properties_t* properties,
     char convertedValueBuffer[21] = {0};
     memcpy(entry, prototype, sizeof(*entry));
     entry->value = NULL;
+
     if (entry->valueType == CELIX_PROPERTIES_VALUE_TYPE_VERSION) {
         bool written =
             celix_version_fillString(entry->typed.versionValue, convertedValueBuffer, sizeof(convertedValueBuffer));
@@ -137,7 +138,9 @@ static celix_status_t celix_properties_fillEntry(celix_properties_t* properties,
             entry->value = celix_properties_createString(properties, convertedValueBuffer);
         } else {
             char* val = NULL;
-            asprintf(&val, "%f", entry->typed.doubleValue);
+            if (asprintf(&val, "%f", entry->typed.doubleValue) < 0) {
+                return CELIX_ENOMEM; // Handle asprintf failure
+            }
             entry->value = val;
         }
     } else if (entry->valueType == CELIX_PROPERTIES_VALUE_TYPE_BOOL) {
@@ -152,6 +155,7 @@ static celix_status_t celix_properties_fillEntry(celix_properties_t* properties,
     if (entry->value == NULL) {
         return CELIX_ENOMEM;
     }
+
     return CELIX_SUCCESS;
 }
 

--- a/libs/utils/src/version.c
+++ b/libs/utils/src/version.c
@@ -211,7 +211,7 @@ int celix_version_compareTo(const celix_version_t* version, const celix_version_
 char* celix_version_toString(const celix_version_t* version) {
     char* string = NULL;
     int rc;
-    if (strlen(version->qualifier) > 0) {
+    if (version->qualifier != NULL && strlen(version->qualifier) > 0) {
         rc = asprintf(&string,"%d.%d.%d.%s", version->major, version->minor, version->micro, version->qualifier);
     } else {
         rc = asprintf(&string, "%d.%d.%d", version->major, version->minor, version->micro);


### PR DESCRIPTION
### Rationale for this change

The change addresses potential memory management issues in the discovery server, ensuring proper resource allocation, error handling, and cleanup to enhance stability and prevent crashes or memory leaks.


### What changes are included in this PR?

- Added checks for memory allocation failures (`malloc`, `strdup`, `asprintf`) with appropriate error handling.
- Improved cleanup logic to prevent memory leaks during error scenarios.


### Are these changes tested?

These changes are tested with existing functionality.


### Are there any user-facing changes?

No user-facing changes. These improvements focus on internal stability and reliability.