### PR TITLE
Remove unneeded SELinux relabel for Celix repo root volume mount

### DIFF
--- a/.devcontainer/run-devcontainer.sh
+++ b/.devcontainer/run-devcontainer.sh
@@ -118,7 +118,7 @@ ${CONTAINER_ENGINE} run -it --rm --privileged -d \
                         --userns=keep-id \
                         --net=host \
                         ${ADDITIONAL_ARGS} \
-                        --volume "${CELIX_REPO_ROOT}":${CELIX_CONTAINER_ROOT}:Z \
+                        --volume "${CELIX_REPO_ROOT}":${CELIX_CONTAINER_ROOT} \
                         --workdir "${CELIX_CONTAINER_ROOT}" \
                         --security-opt label=disable \
                         apache/celix-conan-dev:latest bash -c "${CONTAINER_COMMAND}"


### PR DESCRIPTION
The relabel is not needed since the `--security-opt label=disable` option is already passed when starting the container