### PR TITLE
Resolve stack-use-after in unit test

### DIFF
--- a/bundles/event_admin/remote_provider/remote_provider_mqtt/gtest/src/CelixEarpmIntegrationTestSuite.cc
+++ b/bundles/event_admin/remote_provider/remote_provider_mqtt/gtest/src/CelixEarpmIntegrationTestSuite.cc
@@ -84,7 +84,7 @@ public:
         std::future<void> receivedEventFuture = receivedEventPromise.get_future();
         auto props = celix_properties_create();
         celix_properties_set(props, CELIX_EVENT_TOPIC, "testEvent");
-        static celix_event_handler_service_t handler = {
+        celix_event_handler_service_t handler = {
                 .handle = &receivedEventPromise,
                 .handleEvent = [](void* handle, const char* topic, const celix_properties_t* properties) {
                     EXPECT_STREQ("testEvent", topic);
@@ -115,6 +115,7 @@ public:
         useOpts.filter.serviceName = CELIX_EVENT_ADMIN_SERVICE_NAME;
         useOpts.filter.versionRange = CELIX_EVENT_ADMIN_SERVICE_USE_RANGE;
         useOpts.callbackHandle = &handle;
+        useOpts.waitTimeoutInSeconds = 30;
         useOpts.use = [](void* handle, void* svc) {
             celix_event_admin_service_t *eventAdmin = static_cast<celix_event_admin_service_t *>(svc);
             celix_autoptr(celix_properties_t) props = celix_properties_create();
@@ -136,7 +137,7 @@ public:
             EXPECT_TRUE(tryCount >= 0);
         };
         auto found= celix_bundleContext_useServiceWithOptions(publisherCtx.get(), &useOpts);
-        ASSERT_TRUE(found);
+        EXPECT_TRUE(found);
 
         celix_bundleContext_unregisterService(subscriberCtx.get(), handlerServiceId);
     }


### PR DESCRIPTION
fix #783 

The actual problem is as follows:

~~~
2025-01-14T07:11:45.5993816Z 44: ==21998==ERROR: AddressSanitizer: stack-use-after-return on address 0x7fd2a7209180 at pc 0x5593e32a7dc3 bp 0x7fd290d7d7f0 sp 0x7fd290d7d7e0
2025-01-14T07:11:45.5994715Z 44: READ of size 8 at 0x7fd2a7209180 thread T40
2025-01-14T07:11:45.6988674Z 44: [2025-01-14T07:11:45] [  trace] [CelixEventAdmin] No event handlers found for topic testEvent
2025-01-14T07:11:45.6989614Z 44: [2025-01-14T07:11:45] [  trace] [CelixEventAdmin] Post event testEvent to remote provider.
2025-01-14T07:11:45.6990382Z 44: [2025-01-14T07:11:45] [  trace] [celix_earpm] Post event testEvent
2025-01-14T07:11:45.6995627Z 44: [2025-01-14T07:11:45] [  trace] [celix_earpm] Published message(mid:8). reason code 0
2025-01-14T07:11:45.6999750Z 44: [2025-01-14T07:11:45] [  trace] [celix_earpm] Received message on topic testEvent.
2025-01-14T07:11:45.7024420Z 44:     #0 0x5593e32a7dc2 in std::__shared_ptr<std::__future_base::_State_baseV2, (__gnu_cxx::_Lock_policy)2>::operator bool() const /usr/include/c++/13/bits/shared_ptr_base.h:1670
2025-01-14T07:11:45.7026144Z 44:     #1 0x5593e32a817b in void std::__future_base::_State_baseV2::_S_check<std::__future_base::_State_baseV2>(std::shared_ptr<std::__future_base::_State_baseV2> const&) /usr/include/c++/13/future:580
2025-01-14T07:11:45.7027450Z 44:     #2 0x5593e32a381d in std::promise<void>::_M_state() /usr/include/c++/13/future:1395
2025-01-14T07:11:45.7028265Z 44:     #3 0x5593e32a36ee in std::promise<void>::set_value() /usr/include/c++/13/future:1374
2025-01-14T07:11:45.7031253Z 44:     #4 0x5593e32a4e2b in CelixEarpmIntegrationTestSuite::TestEventPublish(bool)::{lambda(void*, char const*, celix_properties const*)#1}::operator()(void*, char const*, celix_properties const*) const /workspace/bundles/event_admin/remote_provider/remote_provider_mqtt/gtest/src/CelixEarpmIntegrationTestSuite.cc:98
2025-01-14T07:11:45.7035059Z 44:     #5 0x5593e32a5019 in CelixEarpmIntegrationTestSuite::TestEventPublish(bool)::{lambda(void*, char const*, celix_properties const*)#1}::_FUN(void*, char const*, celix_properties const*) /workspace/bundles/event_admin/remote_provider/remote_provider_mqtt/gtest/src/CelixEarpmIntegrationTestSuite.cc:103
2025-01-14T07:11:45.7037563Z 44:     #6 0x7fd2a84bd918 in celix_eventAdmin_deliverEventToHandler /workspace/bundles/event_admin/event_admin/src/celix_event_admin.c:666
2025-01-14T07:11:45.7039644Z 44:     #7 0x7fd2a84bee82 in celix_eventAdmin_deliverPendingEvent /workspace/bundles/event_admin/event_admin/src/celix_event_admin.c:806
2025-01-14T07:11:45.7041580Z 44:     #8 0x7fd2a84bf299 in celix_eventAdmin_deliverEventThread /workspace/bundles/event_admin/event_admin/src/celix_event_admin.c:827
2025-01-14T07:11:45.7043117Z 44:     #9 0x7fd2aa281a41 in asan_thread_start ../../../../src/libsanitizer/asan/asan_interceptors.cpp:234
2025-01-14T07:11:45.7044180Z 44:     #10 0x7fd2a9b07a93  (/lib/x86_64-linux-gnu/libc.so.6+0x9ca93) (BuildId: 6d64b17fbac799e68da7ebd9985ddf9b5cb375e6)
2025-01-14T07:11:45.7045331Z 44:     #11 0x7fd2a9b94a33 in __clone (/lib/x86_64-linux-gnu/libc.so.6+0x129a33) (BuildId: 6d64b17fbac799e68da7ebd9985ddf9b5cb375e6)
~~~