### PR TITLE
Hotfix: Upgrade GitHub cache actions to v4.2.2.

### DIFF
--- a/.github/workflows/conan_create.yml
+++ b/.github/workflows/conan_create.yml
@@ -41,7 +41,7 @@ jobs:
           sed -i 's/compiler.cppstd=gnu14/compiler.cppstd=gnu17/g' `conan profile path default`
       - name: Conan Cache
         id: cache-conan
-        uses: actions/cache@e12d46a63a90f2fae62d114769bbf2a179198b5c #v3
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf #v4.2.2
         env:
           cache-name: cache-conan2-modules
         with:
@@ -53,7 +53,7 @@ jobs:
         run: |
           echo timestamp=`date +"%Y-%m-%d-%H;%M;%S"` >> $GITHUB_OUTPUT
       - name: ccache Cache
-        uses: actions/cache@e12d46a63a90f2fae62d114769bbf2a179198b5c #v3
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf #v4.2.2
         with:
           path: ${{ env.CCACHE_DIR }}
           key: ${{ runner.os }}-ccache-${{ matrix.compiler[0] }}-${{ matrix.type }}-${{ steps.ccache_cache_timestamp.outputs.timestamp }}
@@ -90,7 +90,7 @@ jobs:
           conan profile detect -f
       - name: Conan Cache
         id: cache-conan
-        uses: actions/cache@e12d46a63a90f2fae62d114769bbf2a179198b5c #v3
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf #v4.2.2
         env:
           cache-name: cache-conan2-modules
         with:
@@ -102,7 +102,7 @@ jobs:
         run: |
           echo timestamp=`date +"%Y-%m-%d-%H;%M;%S"` >> $GITHUB_OUTPUT
       - name: ccache Cache
-        uses: actions/cache@e12d46a63a90f2fae62d114769bbf2a179198b5c #v3
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf #v4.2.2
         with:
           path: ${{ env.CCACHE_DIR }}
           key: ${{ runner.os }}-ccache-Release-${{ steps.ccache_cache_timestamp.outputs.timestamp }}

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -12,13 +12,13 @@ jobs:
       - name: Checkout source code
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c #v3.3.0
       - name: Cache Conan
-        uses: actions/cache@e12d46a63a90f2fae62d114769bbf2a179198b5c #v3
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf #v4.2.2
         with:
           path: ~/.conan2-container
           key: cache-conan-container-${{ runner.os }}-${{ github.job }}-${{ hashFiles('conanfile.py', '.devcontainer/*') }}
           restore-keys: cache-conan-container-${{ runner.os }}-${{ github.job }}-
       - name: Cache ccache
-        uses: actions/cache@e12d46a63a90f2fae62d114769bbf2a179198b5c #v3
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf #v4.2.2
         with:
           path: ~/.ccache-container
           key: cache-ccache-container-${{ runner.os }}-${{ github.job }}-${{ github.sha }}
@@ -70,7 +70,7 @@ jobs:
           cd .devcontainer && \
           docker build --tag apache/celix-apt-build:latest --target apt-build --file Containerfile .
       - name: Cache ccache
-        uses: actions/cache@e12d46a63a90f2fae62d114769bbf2a179198b5c #v3
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf #v4.2.2
         with:
           path: ~/.ccache-container
           key: cache-ccache-container-${{ runner.os }}-${{ github.job }}-${{ github.sha }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -28,7 +28,7 @@ jobs:
           conan profile update settings.compiler.libcxx=libstdc++11 default
       - name: Conan Cache
         id: cache-conan
-        uses: actions/cache@e12d46a63a90f2fae62d114769bbf2a179198b5c #v3
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf #v4.2.2
         env:
           cache-name: cache-conan2-modules
         with:
@@ -40,7 +40,7 @@ jobs:
         run: |
           echo timestamp=`date +"%Y-%m-%d-%H;%M;%S"` >> $GITHUB_OUTPUT
       - name: ccache Cache
-        uses: actions/cache@e12d46a63a90f2fae62d114769bbf2a179198b5c #v3
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf #v4.2.2
         with:
           path: ${{ env.CCACHE_DIR }}
           key: ${{ runner.os }}-gcov-ccache-${{ steps.ccache_cache_timestamp.outputs.timestamp }}

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -30,7 +30,7 @@ jobs:
           conan profile detect -f
       - name: Conan Cache
         id: cache-conan
-        uses: actions/cache@e12d46a63a90f2fae62d114769bbf2a179198b5c #v3
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf #v4.2.2
         env:
           cache-name: cache-conan2-modules
         with:
@@ -42,7 +42,7 @@ jobs:
         run: |
           echo timestamp=`date +"%Y-%m-%d-%H;%M;%S"` >> $GITHUB_OUTPUT
       - name: ccache Cache
-        uses: actions/cache@e12d46a63a90f2fae62d114769bbf2a179198b5c #v3
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf #v4.2.2
         with:
           path: ${{ env.CCACHE_DIR }}
           key: ${{ runner.os }}-test-ccache-Release-${{ steps.ccache_cache_timestamp.outputs.timestamp }}
@@ -81,7 +81,7 @@ jobs:
         run: |
           echo timestamp=`date +"%Y-%m-%d-%H;%M;%S"` >> $GITHUB_OUTPUT
       - name: ccache Cache
-        uses: actions/cache@e12d46a63a90f2fae62d114769bbf2a179198b5c #v3
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf #v4.2.2
         with:
           path: ${{ env.CCACHE_DIR }}
           key: ${{ runner.os }}-brew-test-ccache-Release-${{ steps.ccache_cache_timestamp.outputs.timestamp }}

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -49,7 +49,7 @@ jobs:
           conan profile show default
       - name: Conan Cache
         id: cache-conan
-        uses: actions/cache@e12d46a63a90f2fae62d114769bbf2a179198b5c #v3
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf #v4.2.2
         env:
           cache-name: cache-conan2-modules
         with:
@@ -61,7 +61,7 @@ jobs:
         run: |
           echo timestamp=`date +"%Y-%m-%d-%H;%M;%S"` >> $GITHUB_OUTPUT
       - name: ccache Cache
-        uses: actions/cache@e12d46a63a90f2fae62d114769bbf2a179198b5c #v3
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf #v4.2.2
         with:
           path: ${{ env.CCACHE_DIR }}
           key: ${{ runner.os }}-test-ccache-${{ matrix.compiler[0] }}-${{ matrix.type }}-${{ steps.ccache_cache_timestamp.outputs.timestamp }}
@@ -130,7 +130,7 @@ jobs:
       run: |
         echo timestamp=`date +"%Y-%m-%d-%H;%M;%S"` >> $GITHUB_OUTPUT
     - name: ccache Cache
-      uses: actions/cache@e12d46a63a90f2fae62d114769bbf2a179198b5c #v3
+      uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf #v4.2.2
       with:
         path: ${{ env.CCACHE_DIR }}
         key: ${{ runner.os }}-apt-test-ccache-gcc-${{ matrix.type }}-${{ steps.ccache_cache_timestamp.outputs.timestamp }}


### PR DESCRIPTION
This PR fixes the following CI error:

```
Error: This request has been automatically failed because it uses a deprecated version of `actions/cache: e12d46a63a90f2fae62d114769bbf2a179198b5c`. Please update your workflow to use v3/v4 of actions/cache to avoid interruptions. Learn more: https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down

```