### PR TITLE
Fix the "query" command to properly validate bundle ID input.

### DIFF
--- a/bundles/shell/shell/gtest/src/ShellTestSuite.cc
+++ b/bundles/shell/shell/gtest/src/ShellTestSuite.cc
@@ -41,6 +41,7 @@ public:
         auto properties = celix_properties_create();
         celix_properties_set(properties, "LOGHELPER_ENABLE_STDOUT_FALLBACK", "true");
         celix_properties_set(properties, CELIX_FRAMEWORK_CACHE_DIR, ".cacheShellTestSuite");
+        celix_properties_setBool(properties, CELIX_FRAMEWORK_CLEAN_CACHE_DIR_ON_CREATE, true);
         celix_properties_set(properties, "CELIX_LOGGING_DEFAULT_ACTIVE_LOG_LEVEL", "trace");
 
         //to ensure "query 0" is still a test case for am empty result.
@@ -206,10 +207,30 @@ TEST_F(ShellTestSuite, queryTest) {
             char *buf = nullptr;
             size_t len;
             FILE *sout = open_memstream(&buf, &len);
+            command->executeCommand(command->handle, "query 1", sout, sout);
+            fclose(sout);
+            char* found = strstr(buf, "Provided services found 1"); //note could be 11, 12, etc
+            EXPECT_TRUE(found != nullptr);
+            free(buf);
+        }
+        {
+            char *buf = nullptr;
+            size_t len;
+            FILE *sout = open_memstream(&buf, &len);
             auto cmd = std::string{"query "} + std::to_string(d->resourceBundleId);
             command->executeCommand(command->handle, cmd.c_str(), sout, sout); //note query test resource bundle -> no results
             fclose(sout);
-            char* found = strstr(buf, "No results"); //note could be 11, 12, etc
+            char* found = strstr(buf, "No results");
+            EXPECT_TRUE(found != nullptr);
+            free(buf);
+        }
+        {
+            char *buf = nullptr;
+            size_t len;
+            FILE *sout = open_memstream(&buf, &len);
+            command->executeCommand(command->handle, "query celix_shell_command", sout, sout); //note query test resource bundle -> no results
+            fclose(sout);
+            char* found = strstr(buf, "Provided services found 1"); //note could be 11, 12, etc
             EXPECT_TRUE(found != nullptr);
             free(buf);
         }

--- a/bundles/shell/shell/src/query_command.c
+++ b/bundles/shell/shell/src/query_command.c
@@ -17,6 +17,7 @@
  *under the License.
  */
 
+#include <ctype.h>
 #include <string.h>
 #include <stdlib.h>
 
@@ -201,7 +202,7 @@ bool queryCommand_execute(void *_ptr, const char *command_line_str, FILE *sout, 
             //check if its a number (bundle id)
             errno = 0;
             long bndId = strtol(sub_str, NULL, 10);
-            if (bndId >= CELIX_FRAMEWORK_BUNDLE_ID && errno == 0 /*not EINVAL*/) {
+            if (bndId >= CELIX_FRAMEWORK_BUNDLE_ID && isdigit(sub_str[0]) && errno == 0 /*not EINVAL*/) {
                 opts.bndId = bndId;
             } else {
                 //not option and not a bundle id -> query


### PR DESCRIPTION
Previously, query filtering with a service name or LDAP filter is broken.

According to `man strtol`:

```
ERRORS
       This function does not modify errno on success.

       EINVAL (not in C99) The given base contains an unsupported value.

       ERANGE The resulting value was out of range.

       The implementation may also set errno to EINVAL in case no conversion was performed (no digits seen, and 0 returned).
```

Clearly, glibc does NOT set errno to EINVAL in case no conversion was performed, as illustrated by new test case.