### PR TITLE
Check for unresolved symbols at build-time rather than runtime.

### DIFF
--- a/bundles/remote_services/examples/calculator_service/CMakeLists.txt
+++ b/bundles/remote_services/examples/calculator_service/CMakeLists.txt
@@ -23,7 +23,7 @@ add_celix_bundle(calculator
     VERSION 0.0.1
 )
 target_include_directories(calculator PRIVATE src)
-target_link_libraries(calculator PRIVATE Celix::c_rsa_spi calculator_api)
+target_link_libraries(calculator PRIVATE Celix::c_rsa_spi calculator_api m)
 
 get_target_property(DESCR calculator_api INTERFACE_DESCRIPTOR)
 celix_bundle_files(calculator ${DESCR} DESTINATION .)

--- a/bundles/remote_services/examples/remote_example_service/CMakeLists.txt
+++ b/bundles/remote_services/examples/remote_example_service/CMakeLists.txt
@@ -23,7 +23,7 @@ add_celix_bundle(remote_example_service
     VERSION 0.0.1
 )
 target_include_directories(remote_example_service PRIVATE src)
-target_link_libraries(remote_example_service PRIVATE Celix::c_rsa_spi remote_example_api)
+target_link_libraries(remote_example_service PRIVATE Celix::c_rsa_spi remote_example_api m)
 
 get_target_property(DESCR remote_example_api INTERFACE_DESCRIPTOR)
 celix_bundle_files(remote_example_service ${DESCR} DESTINATION .)

--- a/cmake/celix_project/CelixProject.cmake
+++ b/cmake/celix_project/CelixProject.cmake
@@ -26,8 +26,30 @@ mark_as_advanced(CLEAR ENABLE_THREAD_SANITIZER)
 
 if (ENABLE_ADDRESS_SANITIZER)
     if("${CMAKE_C_COMPILER_ID}" MATCHES "Clang")
-        set(CMAKE_C_FLAGS "-fsanitize=address -fno-omit-frame-pointer ${CMAKE_C_FLAGS}")
-        set(CMAKE_CXX_FLAGS "-fsanitize=address -fno-omit-frame-pointer ${CMAKE_CXX_FLAGS}")
+        set(CMAKE_C_FLAGS "-shared-libasan -fsanitize=address -fno-omit-frame-pointer ${CMAKE_C_FLAGS}")
+        set(CMAKE_CXX_FLAGS "-shared-libasan -fsanitize=address -fno-omit-frame-pointer ${CMAKE_CXX_FLAGS}")
+        if (NOT APPLE)
+            # Fix a linux clang deficiency where the ASan runtime library is not found automatically
+            # Find the ASan runtime library path and set RPATH
+            execute_process(
+                    COMMAND ${CMAKE_CXX_COMPILER} --print-file-name libclang_rt.asan-x86_64.so
+                    OUTPUT_VARIABLE ASAN_LIB_PATH
+                    OUTPUT_STRIP_TRAILING_WHITESPACE
+                    RESULT_VARIABLE ASAN_FIND_RESULT
+                    ERROR_QUIET # Avoid printing errors if the command fails during configuration
+            )
+
+            if (ASAN_FIND_RESULT EQUAL 0 AND EXISTS "${ASAN_LIB_PATH}")
+                get_filename_component(ASAN_LIB_DIR ${ASAN_LIB_PATH} DIRECTORY)
+                message(STATUS "Setting ASan RPATH to: ${ASAN_LIB_DIR}")
+                set(ASAN_RPATH_FLAG "-Wl,-rpath,${ASAN_LIB_DIR}")
+                # Append to executable, shared library, and module linker flags
+                set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${ASAN_RPATH_FLAG}")
+                set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${ASAN_RPATH_FLAG}")
+            else()
+                message(WARNING "Could not determine path for libclang_rt.asan-x86_64.so using ${CMAKE_CXX_COMPILER}. ASan RPATH not set automatically.")
+            endif()
+        endif ()
     elseif ("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU")
         set(CMAKE_C_FLAGS "-lasan -fsanitize=address -fno-omit-frame-pointer ${CMAKE_C_FLAGS}")
         set(CMAKE_CXX_FLAGS "-lasan -fsanitize=address -fno-omit-frame-pointer ${CMAKE_CXX_FLAGS}")

--- a/cmake/cmake_celix/BundlePackaging.cmake
+++ b/cmake/cmake_celix/BundlePackaging.cmake
@@ -251,6 +251,11 @@ function(add_celix_bundle)
                 "BUNDLE_TARGET" "${BUNDLE_TARGET_NAME}_bundle"
         )
         target_link_libraries(${BUNDLE_TARGET_NAME} PRIVATE Celix::framework)
+        if(APPLE)
+            target_link_options(${BUNDLE_TARGET_NAME} PRIVATE "-Wl,-undefined,error")
+        else ()
+            target_link_options(${BUNDLE_TARGET_NAME} PRIVATE "-Wl,-z,defs")
+        endif()
     else ()
         add_custom_target(${BUNDLE_TARGET_NAME})
         set_target_properties(${BUNDLE_TARGET_NAME} PROPERTIES

--- a/libs/framework/src/celix_libloader.c
+++ b/libs/framework/src/celix_libloader.c
@@ -29,9 +29,9 @@ celix_library_handle_t* celix_libloader_open(celix_bundle_context_t *ctx, const 
 #endif
     celix_library_handle_t* handle = NULL;
     bool noDelete = celix_bundleContext_getPropertyAsBool(ctx, CELIX_LOAD_BUNDLES_WITH_NODELETE, defaultNoDelete);
-    int flags = RTLD_NOW|RTLD_LOCAL;
+    int flags = RTLD_LAZY|RTLD_LOCAL;
     if (noDelete) {
-        flags = RTLD_NOW|RTLD_LOCAL|RTLD_NODELETE;
+        flags = RTLD_LAZY|RTLD_LOCAL|RTLD_NODELETE;
     }
 
     handle = dlopen(libPath, flags);

--- a/libs/framework/src/celix_libloader.c
+++ b/libs/framework/src/celix_libloader.c
@@ -29,9 +29,9 @@ celix_library_handle_t* celix_libloader_open(celix_bundle_context_t *ctx, const 
 #endif
     celix_library_handle_t* handle = NULL;
     bool noDelete = celix_bundleContext_getPropertyAsBool(ctx, CELIX_LOAD_BUNDLES_WITH_NODELETE, defaultNoDelete);
-    int flags = RTLD_LAZY|RTLD_LOCAL;
+    int flags = RTLD_NOW|RTLD_LOCAL;
     if (noDelete) {
-        flags = RTLD_LAZY|RTLD_LOCAL|RTLD_NODELETE;
+        flags = RTLD_NOW|RTLD_LOCAL|RTLD_NODELETE;
     }
 
     handle = dlopen(libPath, flags);


### PR DESCRIPTION
Existing unresolved symbol errors are also fixed. The one for linux clang build is tricky to fix:

>  Q: When I link my shared library with -fsanitize=address, it fails due to some undefined ASan symbols (e.g. asan_init_v4)?
> A: Most probably you link with -Wl,-z,defs or -Wl,--no-undefined. These flags don't work with ASan unless you also use -shared-libasan (which is the default mode for GCC, but not for Clang).

1. According to [ASAN wiki](https://github.com/google/sanitizers/wiki/AddressSanitizer) `-shared-libasan` must be used.
2. The linux clang can not find `ibclang_rt.asan-x86_64.so` automatically. And thus we give it some extra help.