### PR TITLE
#797 workaround: Update macOS build configuration to use macOS 14

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -70,7 +70,7 @@ jobs:
           source deactivate_conanrun.sh
 
   macos-build-brew:
-    runs-on: macOS-latest
+    runs-on: macOS-14
     timeout-minutes: 120
     steps:
       - name: Checkout source code


### PR DESCRIPTION
This PR is intended as a workaround for #797 