### PR TITLE
Hotfix/dm-component memory leak

### DIFF
--- a/libs/framework/gtest/src/DependencyManagerTestSuite.cc
+++ b/libs/framework/gtest/src/DependencyManagerTestSuite.cc
@@ -211,6 +211,33 @@ TEST_F(DependencyManagerTestSuite, DmGetInfo) {
     celix_arrayList_destroy(infos);
 }
 
+TEST_F(DependencyManagerTestSuite, DmInterfaceAddRemove) {
+    auto *mng = celix_bundleContext_getDependencyManager(ctx);
+    auto *cmp = celix_dmComponent_create(ctx, "test1");
+
+    void *dummyInterfacePointer = (void *) 0x42;
+
+    auto *p = celix_properties_create();
+    celix_properties_set(p, "key", "value");
+    celix_dmComponent_addInterface(cmp, "test-interface", nullptr, dummyInterfacePointer, p);
+
+    auto *dep = celix_dmServiceDependency_create();
+    celix_dmServiceDependency_setService(dep, "test-interface", nullptr, nullptr);
+    celix_dmComponent_addServiceDependency(cmp, dep);
+
+    celix_dependencyManager_add(mng, cmp);
+
+    celix_dmComponent_removeInterface(cmp, dummyInterfacePointer);
+
+    auto *infos = celix_dependencyManager_createInfos(mng);
+    ASSERT_EQ(1, celix_arrayList_size(infos));
+    auto *dmInfo = (celix_dependency_manager_info_t *) celix_arrayList_get(infos, 0);
+    ASSERT_EQ(1, celix_arrayList_size(dmInfo->components));
+    auto *info = (celix_dm_component_info_t *) celix_arrayList_get(dmInfo->components, 0);
+    EXPECT_EQ(0, celix_arrayList_size(info->interfaces));
+    celix_arrayList_destroy(infos);
+}
+
 TEST_F(DependencyManagerTestSuite, TestCheckActive) {
     auto *mng = celix_bundleContext_getDependencyManager(ctx);
     auto *cmp = celix_dmComponent_create(ctx, "test1");

--- a/libs/framework/src/dm_component_impl.c
+++ b/libs/framework/src/dm_component_impl.c
@@ -521,9 +521,7 @@ celix_status_t celix_dmComponent_removeInterface(celix_dm_component_t *component
 
     if (removedInterface != NULL) {
         celix_bundleContext_unregisterService(component->context, removedInterface->svcId);
-        if (removedInterface->properties != NULL) {
-            celix_properties_destroy(removedInterface->properties);
-        }
+        celix_properties_destroy(removedInterface->properties);
         free(removedInterface->serviceName);
         free(removedInterface);
     }

--- a/libs/framework/src/dm_component_impl.c
+++ b/libs/framework/src/dm_component_impl.c
@@ -521,6 +521,9 @@ celix_status_t celix_dmComponent_removeInterface(celix_dm_component_t *component
 
     if (removedInterface != NULL) {
         celix_bundleContext_unregisterService(component->context, removedInterface->svcId);
+        if (removedInterface->properties != NULL) {
+            celix_properties_destroy(removedInterface->properties);
+        }
         free(removedInterface->serviceName);
         free(removedInterface);
     }


### PR DESCRIPTION
This PR fixes a memory leak of a rarely-used dm-component method.