### PR TITLE
Hotfix/Standardize `CURLOPT_*` options to use long integers

### DIFF
--- a/bundles/remote_services/discovery_common/src/endpoint_discovery_poller.c
+++ b/bundles/remote_services/discovery_common/src/endpoint_discovery_poller.c
@@ -373,11 +373,11 @@ static celix_status_t endpointDiscoveryPoller_getEndpoints(endpoint_discovery_po
 		status = CELIX_ILLEGAL_STATE;
 	} else {
 		curl_easy_setopt(curl, CURLOPT_URL, url);
-		curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1);
+		curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1L);
 		curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, endpointDiscoveryPoller_writeMemory);
 		curl_easy_setopt(curl, CURLOPT_WRITEDATA, (void *)&chunk);
 		curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, 5L);
-		curl_easy_setopt(curl, CURLOPT_TIMEOUT, poller->poll_timeout);
+		curl_easy_setopt(curl, CURLOPT_TIMEOUT, (long)poller->poll_timeout);
 		res = curl_easy_perform(curl);
 
 		curl_easy_cleanup(curl);

--- a/bundles/remote_services/remote_service_admin_dfi/src/remote_service_admin_dfi.c
+++ b/bundles/remote_services/remote_service_admin_dfi/src/remote_service_admin_dfi.c
@@ -1104,8 +1104,8 @@ static celix_status_t remoteServiceAdmin_send(void *handle, endpoint_description
             curl_easy_setopt(curl, CURLOPT_HTTPHEADER, metadataHeader);
         }
 
-        curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1);
-        curl_easy_setopt(curl, CURLOPT_TIMEOUT, timeout);
+        curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1L);
+        curl_easy_setopt(curl, CURLOPT_TIMEOUT, (long)timeout);
         curl_easy_setopt(curl, CURLOPT_POST, 1L);
         curl_easy_setopt(curl, CURLOPT_READFUNCTION, remoteServiceAdmin_readCallback);
         curl_easy_setopt(curl, CURLOPT_READDATA, &post);

--- a/conanfile.py
+++ b/conanfile.py
@@ -382,6 +382,7 @@ class CelixConan(ConanFile):
         tc.cache_variables["CELIX_MAJOR"] = str(v.major.value)
         tc.cache_variables["CELIX_MINOR"] = str(v.minor.value)
         tc.cache_variables["CELIX_MICRO"] = str(v.patch.value)
+        tc.cache_variables["CMAKE_EXPORT_COMPILE_COMMANDS"] = "ON"
         tc.generate()
 
     def _configure_cmake(self):

--- a/libs/etcdlib/src/etcd.c
+++ b/libs/etcdlib/src/etcd.c
@@ -40,8 +40,8 @@
 #define ETCD_HEADER_INDEX               "X-Etcd-Index: "
 
 #define MAX_OVERHEAD_LENGTH           64
-#define DEFAULT_CURL_TIMEOUT          10
-#define DEFAULT_CURL_CONNECT_TIMEOUT  10
+#define DEFAULT_CURL_TIMEOUT          10L
+#define DEFAULT_CURL_CONNECT_TIMEOUT  10L
 
 struct etcdlib_struct {
     char *host;
@@ -682,7 +682,7 @@ performRequest(CURL **curl, pthread_mutex_t *mutex, char *url, request_t request
         curl_easy_reset(*curl);
     }
 
-    curl_easy_setopt(*curl, CURLOPT_NOSIGNAL, 1);
+    curl_easy_setopt(*curl, CURLOPT_NOSIGNAL, 1L);
     curl_easy_setopt(*curl, CURLOPT_TIMEOUT, DEFAULT_CURL_TIMEOUT);
     curl_easy_setopt(*curl, CURLOPT_CONNECTTIMEOUT, DEFAULT_CURL_CONNECT_TIMEOUT);
     curl_easy_setopt(*curl, CURLOPT_FOLLOWLOCATION, 1L);


### PR DESCRIPTION
This PR fix libcurl option type mismatches, which cause CI build failures.