### PR TITLE
Hotfix/Update macOS version and Python setup in conan_create workflow

### DIFF
--- a/.github/workflows/conan_create.yml
+++ b/.github/workflows/conan_create.yml
@@ -78,15 +78,17 @@ jobs:
           conan remove -c celix/* 
 
   mac-build:
-    runs-on: macOS-13
+    runs-on: macOS-15
     timeout-minutes: 120
     steps:
       - name: Checkout source code
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c #v3.3.0
-      - name: Install build dependencies
-        run: |
-          brew install python ninja
-          pip3 install -U conan
+      - name: Set up Python
+        uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c #v4.9.1
+        with:
+          python-version: '3.x'
+      - name: Install Conan
+        run: pip install conan
       - name: Setup Conan Profile
         run: |
           conan profile detect -f


### PR DESCRIPTION
This PR updates mac-build in conan_create to use macOS-15.