### PR TITLE
Add optional GCC static analyzer support to CMake and Conan builds

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -155,13 +155,14 @@ jobs:
           -DCMAKE_BUILD_TYPE=${{ matrix.type }}
           -DENABLE_CCACHE=ON
           -DCMAKE_POLICY_VERSION_MINIMUM=3.5
-          -DENABLE_GCC_ANALYZER=ON
+          -DENABLE_GCC_ANALYZER=${{matrix.type == 'RelWithDebInfo' && 'ON' || 'OFF'}}
           -G Ninja
       run: |
         mkdir build install
         cd build
         cmake ${BUILD_OPTIONS} -DCMAKE_INSTALL_PREFIX=../install ..
-        ninja && ninja install
+        ninja  -j8 
+        ninja install 
     - name: Test
       run: |
         cd $GITHUB_WORKSPACE/build

--- a/cmake/celix_project/CelixProject.cmake
+++ b/cmake/celix_project/CelixProject.cmake
@@ -96,6 +96,7 @@ if (ENABLE_GCC_ANALYZER)
             "-Wno-analyzer-use-of-pointer-in-stale-stack-frame"
             "-Wno-analyzer-use-of-uninitialized-value" 
             "-Wno-analyzer-fd-leak" 
+            "-Wno-analyzer-shift-count-negative"
         )  
        add_compile_options(${ANALYZER_FLAGS})
     else()  

--- a/conanfile.py
+++ b/conanfile.py
@@ -390,7 +390,6 @@ class CelixConan(ConanFile):
             if "libcurl" in lst:
                 tc.cache_variables["BUILD_ERROR_INJECTOR_CURL"] = "ON"
         tc.cache_variables["CELIX_ERR_BUFFER_SIZE"] = str(self.options.celix_err_buffer_size)
-        tc.cache_variables["ENABLE_GCC_ANALYZER"] = self.options.enable_gcc_analyzer
         #tc.cache_variables["CMAKE_PROJECT_Celix_INCLUDE"] = os.path.join(self.build_folder, "conan_paths.cmake")
         # the following is workaround for https://github.com/conan-io/conan/issues/7192
         if self.settings.os == "Linux":


### PR DESCRIPTION
## This PR adds optional support for GCC’s static analyzer (-fanalyzer) to the Celix build system.

What’s included

Introduces a new `CMake` option:
ENABLE_GCC_ANALYZER (OFF by default)

When enabled and using `GCC`, `-fanalyzer` is added to:

`CMAKE_C_FLAGS`

`CMAKE_CXX_FLAGS`

Extends conanfile.py with a corresponding option `(enable_gcc_analyzer)` so the analyzer can also be enabled in Conan-based builds.

### What’s not included

* No analyzer warnings are fixed in this PR.

* The analyzer is not enabled in CI.

* No behavior or runtime changes.

>Motivation

GCC’s static analyzer has been improving significantly in recent releases and can help detect issues such as possible null dereferences and resource leaks.
This PR lays the groundwork for experimenting with the analyzer locally and for potential future CI integration.

Analyzer warnings can be addressed incrementally in follow-up PRs once there is agreement on scope and expectations.