### PR TITLE
Update gtest dependency version to v17

### DIFF
--- a/cmake/AddGTest.cmake
+++ b/cmake/AddGTest.cmake
@@ -21,6 +21,6 @@ FetchContent_Declare(
         googletest
         GIT_REPOSITORY https://github.com/google/googletest.git
 #        GIT_REPOSITORY https://gitee.com/mirrors/googletest.git
-        GIT_TAG        release-1.11.0
+        GIT_TAG        v1.17.0
 )
 FetchContent_MakeAvailable(googletest)

--- a/conanfile.py
+++ b/conanfile.py
@@ -157,7 +157,7 @@ class CelixConan(ConanFile):
 
     def build_requirements(self):
         if self.options.enable_testing:
-            self.test_requires("gtest/1.10.0")
+            self.test_requires("gtest/1.17.0")
         if self.options.enable_ccache:
             self.build_requires("ccache/4.7.4")
         if self.options.enable_benchmarking:


### PR DESCRIPTION
Updates the gtest dependency to version 17.

This PR only updates a dependency version and will follow the "commit first, review later" process. 