### PR TITLE
Add upload and download fuzz corpus to the fuzzing ci

### DIFF
--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -79,7 +79,8 @@ jobs:
           done
           tar -czf fuzzing-corpora-artifact.tar.gz -C fuzzing-artifact .
       - name: Upload fuzzing artifacts
-        if: always() #Always package & upload updated fuzzing corpora artifact
+        #Always package & upload updated fuzzing corpora artifact on the master branch
+        if: always() && github.ref == 'refs/heads/master'
         uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 #v4.3.1
         with:
           name: fuzzing-corpora-artifact

--- a/.github/workflows/fuzzing.yml
+++ b/.github/workflows/fuzzing.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   fuzz-utils:
     runs-on: ubuntu-22.04
+    permissions:
+      actions: read
     timeout-minutes: 30
     steps:
       - name: Checkout source code
@@ -37,6 +39,17 @@ jobs:
         run: conan install . --output-folder=build --build=missing -o "celix/*:build_utils=True" -o "celix/*:enable_fuzzing=True" -o "celix/*:enable_address_sanitizer=True" -o "celix/*:enable_undefined_sanitizer=True"
       - name: Conan build
         run: conan build . --output-folder=build -o "celix/*:build_utils=True" -o "celix/*:enable_fuzzing=True"  -o "celix/*:enable_address_sanitizer=True" -o "celix/*:enable_undefined_sanitizer=True" -o "celix/*:celix_err_buffer_size=5120"
+      - name: Restore previous fuzzing corpora artifact
+        continue-on-error: true #can fail if no previous fuzzing-corpora-artifact exists
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+        run: | 
+          #retrieve lastest master / Celix Fuzzing run id
+          RUN_ID=$(gh run list --branch "${BRANCH_NAME}" --workflow "${{ github.workflow }}" --json databaseId --jq '.[0].databaseId')
+          gh run download "$RUN_ID" --name fuzzing-corpora-artifact
+          mkdir -p build/libs/utils/fuzzing
+          tar -xzf fuzzing-corpora-artifact.tar.gz -C fuzzing-previous
       - name: Set fuzzer run time
         id: set-runtime
         run: |
@@ -57,3 +70,17 @@ jobs:
         run: |
           source build/conanrun.sh
           ./build/libs/utils/fuzzing/celix_filter_fuzzer -max_total_time=$FUZZ_TIME ./build/libs/utils/fuzzing/filter_corpus
+      - name: Package fuzzing corpora artifacts
+        if: always() #Always package & upload updated fuzzing corpora artifacts
+        run: |
+          mkdir -p fuzzing-artifact
+          for path in build/libs/utils/fuzzing/*_corpus; do
+            cp -a "$path" fuzzing-artifact/
+          done
+          tar -czf fuzzing-corpora-artifact.tar.gz -C fuzzing-artifact .
+      - name: Upload fuzzing artifacts
+        if: always() #Always package & upload updated fuzzing corpora artifact
+        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 #v4.3.1
+        with:
+          name: fuzzing-corpora-artifact
+          path: fuzzing-corpora-artifact.tar.gz

--- a/documents/building/fuzz_testing.md
+++ b/documents/building/fuzz_testing.md
@@ -22,8 +22,9 @@ limitations under the License.
 # Fuzz Testing with libFuzzer
 
 The utilities library contains fuzz targets that can be built with
-[LLVM libFuzzer](https://llvm.org/docs/LibFuzzer.html).  Fuzzing is
-enabled when using the Clang compiler and the `UTILS_LIBFUZZER` CMake
+[LLVM libFuzzer](https://llvm.org/docs/LibFuzzer.html).  
+
+Fuzzing is enabled when using the Clang compiler and the `UTILS_LIBFUZZER` CMake
 option.
 
 ## Building
@@ -70,5 +71,12 @@ This will display all available LibFuzzer options.
 
 ## Continuous Fuzzing
 
-A GitHub Actions workflow runs the fuzzer periodically. The workflow
-configuration can be found at `.github/workflows/fuzzing.yml`.
+Each Celix Fuzzing run attempts to download the latest fuzzing artifact from the same branch and unpack any 
+existing corpora before executing the fuzzers so new inputs build on the most recent discoveries.
+
+### Maintaining the seed corpus
+
+The Celix Fuzzing workflow uploads the generated corpora files as a build artifact 
+named `fuzzing-corpora-artifact`. 
+The master version of the `fuzzing-corpora-artifactz` artifact is used to keep 
+the seed corpus in `libs/utils/fuzzing/{filter,properties,version}_corpus` updated. 


### PR DESCRIPTION
This PR introduces storage for the **fuzz testing corpus** using GitHub build artifacts.

## Proposed Workflow
* **Upload:** The fuzz testing corpus artifact is uploaded only when building on the `master` branch.
* **Usage:** All other branches pull and use the latest corpus artifact from the `master` branch during their runs.

## Feedback Requested

I’m looking for input on whether this is the optimal approach, specifically regarding:

1. **GitHub Artifacts:** Is using build artifacts the right storage mechanism for this, or should we look into alternatives?
2. **Branch Strategy:** Is using the `master` branch corpus for all other branches the correct way to handle seed data?
    * **The Logic:** The idea behind using the `master` corpora as a seed is to ensure branches have a more **deterministic build**. By doing this, the corpora only changes when the `master` branch itself is updated, preventing noise from fluctuating seeds on feature branches.

Any thoughts or suggestions on this setup are welcome!