### PR TITLE
Add minimal cardinality for service dependencies

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -85,10 +85,12 @@ limitations under the License.
   The old manifest attribute names are also no longer defined in `celix_constants.h`.
 - Using jar to packaging bundles is no longer support. Jar was used to ensure the MANIFEST.MF was the first
   entry in a bundle zip file, but MANIFEST.MF is no longer used (replaced by MANIFEST.json).
+- It is no longer to set required or optional dependencies via `celix_dmServiceDependency_setRequired` or `setRequired`. This is now possible by using the new `celix_dmServiceDependency_setMinimalCardinality` or `setMinimalCardinality` function.
 
 ## New Features
 
 - Type support for value in celix Properties, including support for arrays.
+- Support for minimal cardinality of service dependencies. Setting a minimal cardinality will determine the amount of services that are required before a service dependency is available. 
 
 # Noteworthy Changes for 2.4.0 (2023-09-27)
 

--- a/bundles/components_ready_check/gtest/src/InactiveComponentBundle.cc
+++ b/bundles/components_ready_check/gtest/src/InactiveComponentBundle.cc
@@ -34,7 +34,7 @@ public:
         auto& cmp = ctx->getDependencyManager()->createComponent<CondComponent>();
         cmp.createServiceDependency<celix_condition>(CELIX_CONDITION_SERVICE_NAME)
                 .setFilter("(condition.id=does-not-exists)")
-                .setRequired(true);
+                .setMinimalCardinality(1);
         cmp.build();
     }
 

--- a/bundles/cxx_remote_services/admin/src/RemoteServiceAdminActivator.cc
+++ b/bundles/cxx_remote_services/admin/src/RemoteServiceAdminActivator.cc
@@ -32,15 +32,12 @@ public:
 
         auto& cmp = ctx->getDependencyManager()->createComponent(admin);
         cmp.createServiceDependency<celix::rsa::EndpointDescription>()
-                .setRequired(false)
                 .setStrategy(celix::dm::DependencyUpdateStrategy::locking)
                 .setCallbacks(&celix::rsa::RemoteServiceAdmin::addEndpoint, &celix::rsa::RemoteServiceAdmin::removeEndpoint);
         cmp.createServiceDependency<celix::rsa::IImportServiceFactory>()
-                .setRequired(false)
                 .setStrategy(celix::dm::DependencyUpdateStrategy::locking)
                 .setCallbacks(&celix::rsa::RemoteServiceAdmin::addImportedServiceFactory, &celix::rsa::RemoteServiceAdmin::removeImportedServiceFactory);
         cmp.createServiceDependency<celix::rsa::IExportServiceFactory>()
-                .setRequired(false)
                 .setStrategy(celix::dm::DependencyUpdateStrategy::locking)
                 .setCallbacks(&celix::rsa::RemoteServiceAdmin::addExportedServiceFactory, &celix::rsa::RemoteServiceAdmin::removeExportedServiceFactory);
         cmp.build();

--- a/bundles/cxx_remote_services/integration/src/CalculatorConsumer.cc
+++ b/bundles/cxx_remote_services/integration/src/CalculatorConsumer.cc
@@ -55,7 +55,7 @@ public:
     explicit CalculatorConsumerActivator(const std::shared_ptr<celix::BundleContext>& ctx) {
         auto& cmp = ctx->getDependencyManager()->createComponent(std::make_shared<CalculatorConsumer>());
         cmp.createServiceDependency<ICalculator>()
-                .setRequired(true)
+                .setMinimalCardinality(1)
                 .setCallbacks(&CalculatorConsumer::setCalculator);
         cmp.createProvidedService<celix::IShellCommand>()
                 .addProperty(celix::IShellCommand::COMMAND_NAME, "calc");

--- a/bundles/cxx_remote_services/integration/src/CalculatorProvider.cc
+++ b/bundles/cxx_remote_services/integration/src/CalculatorProvider.cc
@@ -91,10 +91,10 @@ public:
     explicit CalculatorProviderActivator(const std::shared_ptr<celix::BundleContext>& ctx) {
         auto& cmp = ctx->getDependencyManager()->createComponent(std::make_shared<CalculatorImpl>());
         cmp.createServiceDependency<celix::PromiseFactory>()
-                .setRequired(true)
+                .setMinimalCardinality(1)
                 .setCallbacks(&CalculatorImpl::setFactory);
         cmp.createServiceDependency<celix::PushStreamProvider>()
-            .setRequired(true)
+            .setMinimalCardinality(1)
             .setCallbacks(&CalculatorImpl::setPushStreamProvider);
         cmp.createProvidedService<ICalculator>()
                 .addProperty("service.exported.interfaces", celix::typeName<ICalculator>())

--- a/bundles/cxx_remote_services/integration/src/TestExportImportRemoteServiceFactory.cc
+++ b/bundles/cxx_remote_services/integration/src/TestExportImportRemoteServiceFactory.cc
@@ -340,11 +340,11 @@ private:
 
         auto& cmp = ctx->getDependencyManager()->createComponent(std::make_unique<ImportedCalculator>(logHelper, c2pChannelId, p2cChannelId));
         cmp.createServiceDependency<celix::PromiseFactory>()
-                .setRequired(true)
+                .setMinimalCardinality(1)
                 .setStrategy(DependencyUpdateStrategy::suspend)
                 .setCallbacks(&ImportedCalculator::setPromiseFactory);
         cmp.createServiceDependency<celix::PushStreamProvider>()
-                .setRequired(true)
+                .setMinimalCardinality(1)
                 .setStrategy(DependencyUpdateStrategy::suspend)
                 .setCallbacks(&ImportedCalculator::setPushStreamProvider);
 
@@ -560,12 +560,12 @@ private:
             std::make_unique<ExportedCalculator>(logHelper, c2pChannelId, p2cChannelId));
 
         cmp.createServiceDependency<celix::PromiseFactory>()
-                .setRequired(true)
+                .setMinimalCardinality(1)
                 .setStrategy(DependencyUpdateStrategy::suspend)
                 .setCallbacks(&ExportedCalculator::setPromiseFactory);
 
         cmp.createServiceDependency<ICalculator>()
-                .setRequired(true)
+                .setMinimalCardinality(1)
                 .setStrategy(DependencyUpdateStrategy::suspend)
                 .setFilter(std::string{"("}.append(celix::SERVICE_ID).append("=").append(svcId).append(")"))
                 .setCallbacks(&ExportedCalculator::setICalculator);

--- a/bundles/event_admin/event_admin/src/celix_event_admin_activator.c
+++ b/bundles/event_admin/event_admin/src/celix_event_admin_activator.c
@@ -122,7 +122,7 @@ celix_status_t celix_eventAdminActivator_start(celix_event_admin_activator_t *ac
         if (status != CELIX_SUCCESS) {
             return status;
         }
-        celix_dmServiceDependency_setRequired(eventAdminDep, true);
+        celix_dmServiceDependency_setMinimalCardinality(eventAdminDep, 1);
         celix_dmServiceDependency_setStrategy(eventAdminDep, DM_SERVICE_DEPENDENCY_STRATEGY_LOCKING);
         celix_dm_service_dependency_callback_options_t opts2 = CELIX_EMPTY_DM_SERVICE_DEPENDENCY_CALLBACK_OPTIONS;
         opts2.set = celix_eventAdapter_setEventAdminService;

--- a/bundles/remote_services/remote_service_admin_shm_v2/rsa_shm/src/rsa_shm_activator.c
+++ b/bundles/remote_services/remote_service_admin_shm_v2/rsa_shm/src/rsa_shm_activator.c
@@ -46,7 +46,7 @@ celix_status_t celix_rsaShmActivator_addRpcFactorySvcDependency(celix_dm_compone
     if (status != CELIX_SUCCESS) {
         return status;
     }
-    celix_dmServiceDependency_setRequired(rpcFactoryDep, true);
+    celix_dmServiceDependency_setMinimalCardinality(rpcFactoryDep, 1);
     celix_dmServiceDependency_setStrategy(rpcFactoryDep, DM_SERVICE_DEPENDENCY_STRATEGY_SUSPEND);
     celix_dm_service_dependency_callback_options_t opts = CELIX_EMPTY_DM_SERVICE_DEPENDENCY_CALLBACK_OPTIONS;
     opts.addWithProps = celix_rsaShm_addRpcFactorySvc;

--- a/documents/components.md
+++ b/documents/components.md
@@ -476,14 +476,16 @@ Remarks for the C example:
 5. Configures for which service name the service dependency will track services for. Optionally it is also possible
    to fine tune the tracked service by providing a service version range and/or service filter.
 6. Configures the update strategy for the service dependency to suspend-strategy.
-7. Configures the service dependency as a required service dependency.
+7. Configures the service dependency as a required service dependency by setting the minimalCardinality to at least `1`.
+   Setting the minimalCardinality determines howmany services are required for the service dependency to be available.
 8. Creates an empty service dependency callback options struct. This struct can be used to configure different
    service dependency callbacks.
 9. Configures the `set` service dependency callback to `componentWithServiceDependency_setHighestRankingShellCommand`
 10. Configures the dependency manager to use the callbacks configures in opts.
 11. Adds the DM service dependency object to the DM component object.
 12. Configures the update strategy for the service dependency to locking-strategy.
-13. Configures the service dependency as an optional service dependency.
+13. Configures the service dependency as an optional service dependency by setting the minimalCardinality to `0`. By
+    default, minimalCardinality is set to `0`.
 14. Configures the `addWithProps` service dependency callback to `componentWithServiceDependency_addShellCommand`.
 
 ```C
@@ -564,7 +566,7 @@ static celix_status_t componentWithServiceDependencyActivator_start(component_wi
     celix_dm_service_dependency_t* dep1 = celix_dmServiceDependency_create(); // <-----------------------------------<4>
     celix_dmServiceDependency_setService(dep1, CELIX_SHELL_COMMAND_SERVICE_NAME, NULL, NULL); // <-------------------<5>
     celix_dmServiceDependency_setStrategy(dep1, DM_SERVICE_DEPENDENCY_STRATEGY_SUSPEND); // <------------------------<6>
-    celix_dmServiceDependency_setRequired(dep1, true); // <----------------------------------------------------------<7>
+    celix_dmServiceDependency_setMinimalCardinality(dep1, 1); // <---------------------------------------------------<7>
     celix_dm_service_dependency_callback_options_t opts1 = CELIX_EMPTY_DM_SERVICE_DEPENDENCY_CALLBACK_OPTIONS; // <--<8>
     opts1.set = (void*)componentWithServiceDependency_setHighestRankingShellCommand; // <----------------------------<9>
     celix_dmServiceDependency_setCallbacksWithOptions(dep1, &opts1); // <-------------------------------------------<10>
@@ -574,7 +576,7 @@ static celix_status_t componentWithServiceDependencyActivator_start(component_wi
     celix_dm_service_dependency_t* dep2 = celix_dmServiceDependency_create();
     celix_dmServiceDependency_setService(dep2, CELIX_SHELL_COMMAND_SERVICE_NAME, NULL, NULL);
     celix_dmServiceDependency_setStrategy(dep2, DM_SERVICE_DEPENDENCY_STRATEGY_LOCKING);  // <----------------------<12>
-    celix_dmServiceDependency_setRequired(dep2, false); // <--------------------------------------------------------<13>
+    celix_dmServiceDependency_setMinimalCardinality(dep2, 0); // <--------------------------------------------------<13>
     celix_dm_service_dependency_callback_options_t opts2 = CELIX_EMPTY_DM_SERVICE_DEPENDENCY_CALLBACK_OPTIONS;
     opts2.addWithProps = (void*)componentWithServiceDependency_addShellCommand;  // <-------------------------------<14>
     opts2.removeWithProps = (void*)componentWithServiceDependency_removeShellCommand;
@@ -622,7 +624,8 @@ Remarks for the C++ example:
    service dependency, component or DM is build. Note that the `celix::dm::Component::createServiceDependency` method
    is called without provided a service name, the service name will be inferred using the `celix::typeName`.
 5. Configures the service dependency set callback.
-6. Configures the service dependency as a required service dependency.
+6. Configures the service dependency as a required service dependency by setting the minimalCardinality to at least `1`.
+   Setting the minimalCardinality determines howmany services are required for the service dependency to be available.
 7. Configures the update strategy for the service dependency to suspend-strategy.
 8. Creates another new DM service dependency object and in this case also explicitly provides the service name
    to use (`CELIX_SHELL_COMMAND_SERVICE_NAME`).
@@ -672,12 +675,12 @@ public:
 
         cmp.createServiceDependency<celix::IShellCommand>() // <-----------------------------------------------------<4>
                 .setCallbacks(&Cmp::setHighestRankingShellCommand) // <----------------------------------------------<5>
-                .setRequired(true) // <------------------------------------------------------------------------------<6>
+                .setMinimalCardinality(1) // <-----------------------------------------------------------------------<6>
                 .setStrategy(DependencyUpdateStrategy::suspend); // <------------------------------------------------<7>
 
         cmp.createServiceDependency<celix_shell_command_t>(CELIX_SHELL_COMMAND_SERVICE_NAME) // <--------------------<8>
                 .setCallbacks(&Cmp::addCShellCmd, &Cmp::removeCShellCmd) 
-                .setRequired(false)
+                .setMinimalCardinality(0)
                 .setStrategy(DependencyUpdateStrategy::locking);
 
         cmp.build(); // <--------------------------------------------------------------------------------------------<9>

--- a/documents/components.md
+++ b/documents/components.md
@@ -477,7 +477,7 @@ Remarks for the C example:
    to fine tune the tracked service by providing a service version range and/or service filter.
 6. Configures the update strategy for the service dependency to suspend-strategy.
 7. Configures the service dependency as a required service dependency by setting the minimalCardinality to at least `1`.
-   Setting the minimalCardinality determines howmany services are required for the service dependency to be available.
+   Setting the minimalCardinality determines how many services are required for the service dependency to be available.
 8. Creates an empty service dependency callback options struct. This struct can be used to configure different
    service dependency callbacks.
 9. Configures the `set` service dependency callback to `componentWithServiceDependency_setHighestRankingShellCommand`
@@ -625,7 +625,7 @@ Remarks for the C++ example:
    is called without provided a service name, the service name will be inferred using the `celix::typeName`.
 5. Configures the service dependency set callback.
 6. Configures the service dependency as a required service dependency by setting the minimalCardinality to at least `1`.
-   Setting the minimalCardinality determines howmany services are required for the service dependency to be available.
+   Setting the minimalCardinality determines how many services are required for the service dependency to be available.
 7. Configures the update strategy for the service dependency to suspend-strategy.
 8. Creates another new DM service dependency object and in this case also explicitly provides the service name
    to use (`CELIX_SHELL_COMMAND_SERVICE_NAME`).

--- a/examples/celix-examples/dependency_manager_example_cxx/baz/src/BazActivator.cc
+++ b/examples/celix-examples/dependency_manager_example_cxx/baz/src/BazActivator.cc
@@ -28,13 +28,12 @@ public:
                 .setCallbacks(nullptr, &Baz::start, &Baz::stop, nullptr);
 
         cmp.createServiceDependency<IAnotherExample>()
-                .setRequired(true)
+                .setMinimalCardinality(1)
                 .setStrategy(DependencyUpdateStrategy::locking)
                 .setVersionRange(IANOTHER_EXAMPLE_CONSUMER_RANGE)
                 .setCallbacks(&Baz::addAnotherExample, &Baz::removeAnotherExample);
 
         cmp.createCServiceDependency<example_t>(EXAMPLE_NAME)
-                .setRequired(false)
                 .setStrategy(DependencyUpdateStrategy::locking)
                 .setVersionRange(EXAMPLE_CONSUMER_RANGE)
                 .setCallbacks(&Baz::addExample, &Baz::removeExample);

--- a/examples/celix-examples/dependency_manager_example_cxx/foo/src/FooActivator.cc
+++ b/examples/celix-examples/dependency_manager_example_cxx/foo/src/FooActivator.cc
@@ -29,12 +29,11 @@ public:
                 .setCallbacks(nullptr, &Foo::start, &Foo::stop, nullptr);
 
         cmp.createServiceDependency<IAnotherExample>()
-                .setRequired(true)
+                .setMinimalCardinality(1)
                 .setVersionRange(IANOTHER_EXAMPLE_CONSUMER_RANGE)
                 .setCallbacks(&Foo::setAnotherExample);
 
         cmp.createCServiceDependency<example_t>(EXAMPLE_NAME)
-                .setRequired(false)
                 .setVersionRange(EXAMPLE_CONSUMER_RANGE)
                 .setCallbacks(&Foo::setExample);
     }

--- a/examples/celix-examples/dm_example/phase2a/src/phase2a_activator.c
+++ b/examples/celix-examples/dm_example/phase2a/src/phase2a_activator.c
@@ -56,7 +56,7 @@ static celix_status_t activator_start(struct phase2a_activator_struct *act, celi
         celix_dmServiceDependency_setService(dep, PHASE1_NAME, PHASE1_RANGE_ALL, NULL);
         celix_dmServiceDependency_setCallback(dep, (void*)phase2a_setPhase1);
         celix_dmServiceDependency_setStrategy(dep, DM_SERVICE_DEPENDENCY_STRATEGY_LOCKING);
-        celix_dmServiceDependency_setRequired(dep, true);
+        celix_dmServiceDependency_setMinimalCardinality(dep, 1);
         celix_dmComponent_addServiceDependency(cmp, dep);
 
         celix_dependency_manager_t *mng = celix_bundleContext_getDependencyManager(ctx);

--- a/examples/celix-examples/dm_example/phase2b/src/phase2b_activator.c
+++ b/examples/celix-examples/dm_example/phase2b/src/phase2b_activator.c
@@ -56,7 +56,7 @@ static celix_status_t activator_start(struct phase2b_activator_struct *act, celi
         celix_dm_service_dependency_t *dep = celix_dmServiceDependency_create();
         celix_dmServiceDependency_setService(dep, PHASE1_NAME, PHASE1_RANGE_EXACT, NULL);
         celix_dmServiceDependency_setCallback(dep, (void*)phase2b_setPhase1);
-        celix_dmServiceDependency_setRequired(dep, true);
+        celix_dmServiceDependency_setMinimalCardinality(dep, 1);
         celix_dmServiceDependency_setStrategy(dep, DM_SERVICE_DEPENDENCY_STRATEGY_LOCKING);
         celix_dmComponent_addServiceDependency(cmp, dep);
 

--- a/examples/celix-examples/dm_example/phase3/src/phase3_activator.c
+++ b/examples/celix-examples/dm_example/phase3/src/phase3_activator.c
@@ -47,7 +47,7 @@ static celix_status_t activator_start(struct phase3_activator_struct *act, celix
         opts.add = (void*)phase3_addPhase2;
         opts.remove = (void*)phase3_removePhase2;
         celix_dmServiceDependency_setCallbacksWithOptions(dep, &opts);
-        celix_dmServiceDependency_setRequired(dep, true);
+        celix_dmServiceDependency_setMinimalCardinality(dep, 1);
         celix_dmComponent_addServiceDependency(cmp, dep);
 
         celix_dependency_manager_t *mng = celix_bundleContext_getDependencyManager(ctx);

--- a/examples/celix-examples/dm_example_cxx/phase2/src/Phase2aActivator.cc
+++ b/examples/celix-examples/dm_example_cxx/phase2/src/Phase2aActivator.cc
@@ -36,7 +36,7 @@ public:
                 .addInterface<IPhase2>(IPHASE2_VERSION, props);
 
         cmp.createServiceDependency<IPhase1>()
-                .setRequired(true)
+                .setMinimalCardinality(1)
                 .setCallbacks(&Phase2Cmp::setPhase1);
 
         cmp.createServiceDependency<srv::info::IName>()
@@ -44,7 +44,6 @@ public:
                 .setCallbacks(&Phase2Cmp::setName);
 
         cmp.createCServiceDependency<celix_log_service_t>(CELIX_LOG_SERVICE_NAME)
-                .setRequired(false)
                 .setCallbacks(&Phase2Cmp::setLogService);
     }
 };

--- a/examples/celix-examples/dm_example_cxx/phase2/src/Phase2bActivator.cc
+++ b/examples/celix-examples/dm_example_cxx/phase2/src/Phase2bActivator.cc
@@ -32,11 +32,10 @@ public:
                 .addInterface<IPhase2>(IPHASE2_VERSION, props);
 
         cmp.createServiceDependency<IPhase1>()
-                .setRequired(true)
+                .setMinimalCardinality(1)
                 .setCallbacks(&Phase2Cmp::setPhase1);
 
         cmp.createCServiceDependency<celix_log_service_t>(CELIX_LOG_SERVICE_NAME)
-                .setRequired(false)
                 .setCallbacks(&Phase2Cmp::setLogService);
     }
 };

--- a/examples/celix-examples/dm_example_cxx/phase3/src/Phase3Activator.cc
+++ b/examples/celix-examples/dm_example_cxx/phase3/src/Phase3Activator.cc
@@ -26,7 +26,6 @@ using namespace celix::dm;
 
 Phase3Activator::Phase3Activator(std::shared_ptr<DependencyManager> mng) : Phase3BaseActivator{mng} {
     cmp.createServiceDependency<IPhase2>()
-             .setRequired(false)
              .setFilter("(&(name=phase2a)(non-existing=*))")
              .setCallbacks(&Phase3Cmp::setPhase2a);
 }

--- a/examples/celix-examples/dm_example_cxx/phase3/src/Phase3BaseActivator.cc
+++ b/examples/celix-examples/dm_example_cxx/phase3/src/Phase3BaseActivator.cc
@@ -26,6 +26,6 @@ Phase3BaseActivator::Phase3BaseActivator(std::shared_ptr<DependencyManager> mng)
     cmp.setCallbacks(nullptr, &Phase3Cmp::start, &Phase3Cmp::stop, nullptr);
 
     cmp.createServiceDependency<IPhase2>()
-            .setRequired(true)
+            .setMinimalCardinality(1)
             .setCallbacks(&Phase3Cmp::addPhase2, &Phase3Cmp::removePhase2);
 }

--- a/examples/celix-examples/readme_c_examples/src/component_with_service_dependency_activator.c
+++ b/examples/celix-examples/readme_c_examples/src/component_with_service_dependency_activator.c
@@ -94,7 +94,7 @@ static celix_status_t componentWithServiceDependencyActivator_start(component_wi
     celix_dm_service_dependency_t* dep1 = celix_dmServiceDependency_create(); // <-----------------------------------<4>
     celix_dmServiceDependency_setService(dep1, CELIX_SHELL_COMMAND_SERVICE_NAME, NULL, NULL); // <-------------------<5>
     celix_dmServiceDependency_setStrategy(dep1, DM_SERVICE_DEPENDENCY_STRATEGY_SUSPEND); // <------------------------<6>
-    celix_dmServiceDependency_setRequired(dep1, true); // <----------------------------------------------------------<7>
+    celix_dmServiceDependency_setMinimalCardinality(dep1, 1); // <----------------------------------------------------------<7>
     celix_dm_service_dependency_callback_options_t opts1 = CELIX_EMPTY_DM_SERVICE_DEPENDENCY_CALLBACK_OPTIONS; // <--<8>
     opts1.set = (void*)componentWithServiceDependency_setHighestRankingShellCommand; // <----------------------------<9>
     celix_dmServiceDependency_setCallbacksWithOptions(dep1, &opts1); // <-------------------------------------------<10>
@@ -104,7 +104,7 @@ static celix_status_t componentWithServiceDependencyActivator_start(component_wi
     celix_dm_service_dependency_t* dep2 = celix_dmServiceDependency_create();
     celix_dmServiceDependency_setService(dep2, CELIX_SHELL_COMMAND_SERVICE_NAME, NULL, NULL);
     celix_dmServiceDependency_setStrategy(dep2, DM_SERVICE_DEPENDENCY_STRATEGY_LOCKING);  // <----------------------<12>
-    celix_dmServiceDependency_setRequired(dep2, false); // <--------------------------------------------------------<13>
+    celix_dmServiceDependency_setMinimalCardinality(dep2, 0); // <--------------------------------------------------------<13>
     celix_dm_service_dependency_callback_options_t opts2 = CELIX_EMPTY_DM_SERVICE_DEPENDENCY_CALLBACK_OPTIONS;
     opts2.addWithProps = (void*)componentWithServiceDependency_addShellCommand;  // <-------------------------------<14>
     opts2.removeWithProps = (void*)componentWithServiceDependency_removeShellCommand;

--- a/examples/celix-examples/readme_cxx_examples/src/ComponentWithServiceDependencyActivator.cc
+++ b/examples/celix-examples/readme_cxx_examples/src/ComponentWithServiceDependencyActivator.cc
@@ -60,12 +60,11 @@ public:
 
         cmp.createServiceDependency<celix::IShellCommand>()
                 .setCallbacks(&Cmp::setHighestRankingShellCommand)
-                .setRequired(true)
+                .setMinimalCardinality(1)
                 .setStrategy(DependencyUpdateStrategy::suspend);
 
         cmp.createServiceDependency<celix_shell_command_t>(CELIX_SHELL_COMMAND_SERVICE_NAME)
                 .setCallbacks(&Cmp::addCShellCmd, &Cmp::removeCShellCmd)
-                .setRequired(false)
                 .setStrategy(DependencyUpdateStrategy::locking);
 
         cmp.build(); // <--------------------------------------------------------------------------------------------<8>

--- a/libs/framework/benchmark/src/DependencyManagerBenchmark.cc
+++ b/libs/framework/benchmark/src/DependencyManagerBenchmark.cc
@@ -94,7 +94,7 @@ static void createAndDestroyComponentTest(benchmark::State& state, bool cTest) {
             // This code gets timed
             auto& cmp = man->createComponent<TestComponent>();
             cmp.createProvidedService<IService>(IService::NAME);
-            cmp.createServiceDependency<IService>(IService::NAME).setRequired(true);
+            cmp.createServiceDependency<IService>(IService::NAME).setMinimalCardinality(1);
             man->buildAsync();
             man->wait();
             assert(cmp.getState() == ComponentState::TRACKING_OPTIONAL);

--- a/libs/framework/benchmark/src/DependencyManagerBenchmark.cc
+++ b/libs/framework/benchmark/src/DependencyManagerBenchmark.cc
@@ -17,8 +17,10 @@
  * under the License.
  */
 
-#include <benchmark/benchmark.h>
+#include "../../include/celix_dm_service_dependency.h"
+
 #include "celix/FrameworkFactory.h"
+#include <benchmark/benchmark.h>
 
 //note using c++ service for both the C and C++ benchmark, because this should not impact the performance.
 class IService {
@@ -81,7 +83,7 @@ static void createAndDestroyComponentTest(benchmark::State& state, bool cTest) {
 
             auto* dep = celix_dmServiceDependency_create();
             celix_dmServiceDependency_setService(dep, IService::NAME, nullptr, nullptr);
-            celix_dmServiceDependency_setRequired(dep, true);
+            celix_dmServiceDependency_setMinimalCardinality(dep, 1);
             celix_dmComponent_addServiceDependency(cmp, dep);
 
             celix_dependencyManager_addAsync(cMan, cmp);

--- a/libs/framework/benchmark/src/DependencyManagerBenchmark.cc
+++ b/libs/framework/benchmark/src/DependencyManagerBenchmark.cc
@@ -17,8 +17,6 @@
  * under the License.
  */
 
-#include "../../include/celix_dm_service_dependency.h"
-
 #include "celix/FrameworkFactory.h"
 #include <benchmark/benchmark.h>
 

--- a/libs/framework/gtest/src/DependencyManagerTestSuite.cc
+++ b/libs/framework/gtest/src/DependencyManagerTestSuite.cc
@@ -1277,3 +1277,62 @@ TEST_F(DependencyManagerTestSuite, TestPrintInfo) {
     ss << cmp;
     EXPECT_TRUE(strstr(ss.str().c_str(), "Cmp1"));
 }
+
+TEST_F(DependencyManagerTestSuite, TestCardinality) {
+    celix::dm::DependencyManager dm{ctx};
+    auto& cmp1 = dm.createComponent<Cmp1>().addInterface<TestService>();
+    cmp1.build();
+    auto& cmp3 = dm.createComponent<Cmp3>()
+                     .createServiceDependency<TestService>()
+                     .setRequired(true)
+                     .setMinimalCardinality(2);
+    cmp3.build();
+
+    dm.build();
+
+    {
+        auto info = dm.getInfo();
+        ASSERT_EQ(info.components.size(), 2);
+        auto& cmpInfo = info.components;
+        auto cmpIt =
+            std::find_if(cmpInfo.cbegin(), cmpInfo.cend(), [](const ComponentInfo& cmp) { return cmp.name == "Cmp3"; });
+        ASSERT_TRUE(cmpIt != cmpInfo.cend());
+
+        EXPECT_TRUE(!cmpIt->uuid.empty());
+        EXPECT_EQ(cmpIt->state, "WAITING_FOR_REQUIRED");
+        EXPECT_FALSE(cmpIt->isActive);
+        EXPECT_EQ(cmpIt->nrOfTimesStarted, 0);
+        EXPECT_EQ(cmpIt->nrOfTimesResumed, 0);
+
+        ASSERT_EQ(cmpIt->dependenciesInfo.size(), 1);
+        auto& dep = cmpIt->dependenciesInfo[0];
+        EXPECT_EQ(dep.serviceName, "TestService");
+        EXPECT_EQ(dep.isRequired, true);
+        EXPECT_EQ(dep.isAvailable, false);
+        EXPECT_EQ(dep.nrOfTrackedServices, 1);
+    }
+
+    auto& cmp2 = dm.createComponent(Cmp2{"c"}).addInterface<TestService>();
+    cmp2.build();
+
+    {
+        auto info = dm.getInfo();
+        ASSERT_EQ(info.components.size(), 3);
+        auto& cmpInfo = info.components;
+        auto cmpIt =
+            std::find_if(cmpInfo.cbegin(), cmpInfo.cend(), [](const ComponentInfo& cmp) { return cmp.name == "Cmp3"; });
+        ASSERT_TRUE(cmpIt != cmpInfo.cend());
+
+        EXPECT_TRUE(!cmpIt->uuid.empty());
+        EXPECT_TRUE(cmpIt->isActive);
+        EXPECT_EQ(cmpIt->nrOfTimesStarted, 1);
+        EXPECT_EQ(cmpIt->nrOfTimesResumed, 0);
+
+        ASSERT_EQ(cmpIt->dependenciesInfo.size(), 1);
+        auto& dep = cmpIt->dependenciesInfo[0];
+        EXPECT_EQ(dep.serviceName, "TestService");
+        EXPECT_EQ(dep.isRequired, true);
+        EXPECT_EQ(dep.isAvailable, true);
+        EXPECT_EQ(dep.nrOfTrackedServices, 2);
+    }
+}

--- a/libs/framework/gtest/src/DependencyManagerTestSuite.cc
+++ b/libs/framework/gtest/src/DependencyManagerTestSuite.cc
@@ -244,7 +244,7 @@ TEST_F(DependencyManagerTestSuite, TestCheckActive) {
 
     auto *dep = celix_dmServiceDependency_create();
     celix_dmServiceDependency_setService(dep, "svcname", nullptr, nullptr);
-    celix_dmServiceDependency_setRequired(dep, true);
+    celix_dmServiceDependency_setMinimalCardinality(dep, 1);
     celix_dmComponent_addServiceDependency(cmp, dep); //required dep -> cmp not active
 
 
@@ -281,7 +281,7 @@ TEST_F(DependencyManagerTestSuite, CxxDmGetInfo) {
 
     auto& cmp = mng.createComponent<Cmp1>();
     cmp.createProvidedService<TestService>().addProperty("key", "value");
-    cmp.createServiceDependency<TestService>().setVersionRange("[1,2)").setRequired(true);
+    cmp.createServiceDependency<TestService>().setVersionRange("[1,2)").setMinimalCardinality(1);
 
     auto infos = mng.getInfos();
     EXPECT_EQ(infos.size(), 1);
@@ -591,7 +591,7 @@ TEST_F(DependencyManagerTestSuite, RequiredDepsAreInjectedDuringStartStop) {
     auto& cmp = dm.createComponent<LifecycleComponent>()
             .setCallbacks(nullptr, &LifecycleComponent::start, &LifecycleComponent::stop, nullptr);
     cmp.createServiceDependency<TestService>()
-            .setRequired(true)
+            .setMinimalCardinality(1)
             .setCallbacks(&LifecycleComponent::setService)
             .setCallbacks(&LifecycleComponent::addService, &LifecycleComponent::remService);
     cmp.build();
@@ -634,7 +634,7 @@ TEST_F(DependencyManagerTestSuite, RemoveOwnDependencyShouldNotLeadToDoubleStop)
             .setCallbacks(nullptr, &LifecycleComponent::start, &LifecycleComponent::stop, nullptr);
     cmp.createProvidedService<TestService>();
     cmp.createServiceDependency<TestService>()
-            .setRequired(true);
+            .setMinimalCardinality(1);
     cmp.build();
     using celix::dm::ComponentState;
 
@@ -660,7 +660,7 @@ TEST_F(DependencyManagerTestSuite, RemoveOwnDependencyShouldNotLeadToDoubleStop)
 
     //When an additional required service dependency is added
     cmp.createServiceDependency<TestService>("DummyName")
-            .setRequired(true)
+            .setMinimalCardinality(1)
             .buildAsync();
 
     celix_bundleContext_waitForEvents(ctx);
@@ -738,11 +738,10 @@ TEST_F(DependencyManagerTestSuite, IntermediateStatesDuringInitDeinitStartingAnd
             .setCallbacks(&LifecycleComponent::init, &LifecycleComponent::start, &LifecycleComponent::stop, &LifecycleComponent::deinit);
     cmp.createServiceDependency<TestService>()
             .setStrategy(celix::dm::DependencyUpdateStrategy::suspend)
-            .setCallbacks([](std::shared_ptr<TestService> /*service*/, const std::shared_ptr<const celix::Properties>& /*properties*/){ std::cout << "Dummy set for svc callback\n"; })
-            .setRequired(false);
+            .setCallbacks([](std::shared_ptr<TestService> /*service*/, const std::shared_ptr<const celix::Properties>& /*properties*/){ std::cout << "Dummy set for svc callback\n"; });
     cmp.createServiceDependency<TestService>("RequiredTestService")
             .setStrategy(celix::dm::DependencyUpdateStrategy::locking)
-            .setRequired(true);
+            .setMinimalCardinality(1);
     cmp.buildAsync();
 
     //Then the component state should become waiting for required
@@ -882,7 +881,7 @@ TEST_F(DependencyManagerTestSuite, DepsAreInjectedAsSharedPointers) {
     auto& cmp = dm.createComponent<LifecycleComponent>()
             .setCallbacks(nullptr, &LifecycleComponent::start, &LifecycleComponent::stop, nullptr);
     cmp.createServiceDependency<TestService>()
-            .setRequired(true)
+            .setMinimalCardinality(1)
             .setCallbacks(&LifecycleComponent::setService)
             .setCallbacks(&LifecycleComponent::addService, &LifecycleComponent::remService);
     cmp.build();
@@ -943,7 +942,7 @@ TEST_F(DependencyManagerTestSuite, DepsNoPropsAreInjectedAsSharedPointers) {
     auto& cmp = dm.createComponent<LifecycleComponent>()
             .setCallbacks(nullptr, &LifecycleComponent::start, &LifecycleComponent::stop, nullptr);
     cmp.createServiceDependency<TestService>()
-            .setRequired(true)
+            .setMinimalCardinality(1)
             .setCallbacks(&LifecycleComponent::setService)
             .setCallbacks(&LifecycleComponent::addService, &LifecycleComponent::remService);
     cmp.build();
@@ -1096,7 +1095,7 @@ TEST_F(DependencyManagerTestSuite, ExceptionsInLifecycle) {
         EXPECT_EQ(cmp.getState(), ComponentState::TRACKING_OPTIONAL);
 
         //required service -> should stop, but fails at stop and should become inactive (component will disable itself)
-        cmp.createServiceDependency<TestService>().setRequired(true).build();
+        cmp.createServiceDependency<TestService>().setMinimalCardinality(1).build();
         cmp.wait();
         EXPECT_EQ(cmp.getState(), ComponentState::INACTIVE);
         dm.clear();
@@ -1284,7 +1283,7 @@ TEST_F(DependencyManagerTestSuite, TestCardinality) {
     cmp1.build();
     auto& cmp3 = dm.createComponent<Cmp3>()
                      .createServiceDependency<TestService>()
-                     .setRequired(true)
+                     .setMinimalCardinality(1)
                      .setMinimalCardinality(2);
     cmp3.build();
 

--- a/libs/framework/gtest/src/DependencyManagerTestSuite.cc
+++ b/libs/framework/gtest/src/DependencyManagerTestSuite.cc
@@ -1299,7 +1299,7 @@ TEST_F(DependencyManagerTestSuite, TestCardinality) {
         ASSERT_TRUE(cmpIt != cmpInfo.cend());
 
         EXPECT_TRUE(!cmpIt->uuid.empty());
-        EXPECT_EQ(cmpIt->state, "WAITING_FOR_REQUIRED");
+        EXPECT_EQ(cmpIt->state, celix_dmComponent_stateToString(CELIX_DM_CMP_STATE_WAITING_FOR_REQUIRED));
         EXPECT_FALSE(cmpIt->isActive);
         EXPECT_EQ(cmpIt->nrOfTimesStarted, 0);
         EXPECT_EQ(cmpIt->nrOfTimesResumed, 0);
@@ -1334,5 +1334,29 @@ TEST_F(DependencyManagerTestSuite, TestCardinality) {
         EXPECT_EQ(dep.isRequired, true);
         EXPECT_EQ(dep.isAvailable, true);
         EXPECT_EQ(dep.nrOfTrackedServices, 2);
+    }
+
+    dm.removeComponent(cmp2.getUUID());
+
+    {
+        auto info = dm.getInfo();
+        ASSERT_EQ(info.components.size(), 2);
+        auto& cmpInfo = info.components;
+        auto cmpIt =
+            std::find_if(cmpInfo.cbegin(), cmpInfo.cend(), [](const ComponentInfo& cmp) { return cmp.name == "Cmp3"; });
+        ASSERT_TRUE(cmpIt != cmpInfo.cend());
+
+        EXPECT_TRUE(!cmpIt->uuid.empty());
+        EXPECT_EQ(cmpIt->state, celix_dmComponent_stateToString(CELIX_DM_CMP_STATE_INITIALIZED_AND_WAITING_FOR_REQUIRED));
+        EXPECT_FALSE(cmpIt->isActive);
+        EXPECT_EQ(cmpIt->nrOfTimesStarted, 1);
+        EXPECT_EQ(cmpIt->nrOfTimesResumed, 0);
+
+        ASSERT_EQ(cmpIt->dependenciesInfo.size(), 1);
+        auto& dep = cmpIt->dependenciesInfo[0];
+        EXPECT_EQ(dep.serviceName, "TestService");
+        EXPECT_EQ(dep.isRequired, true);
+        EXPECT_EQ(dep.isAvailable, false);
+        EXPECT_EQ(dep.nrOfTrackedServices, 1);
     }
 }

--- a/libs/framework/include/celix/dm/DependencyManagerInfo.h
+++ b/libs/framework/include/celix/dm/DependencyManagerInfo.h
@@ -70,6 +70,11 @@ namespace celix { namespace dm {
         bool isRequired{};
 
         /**
+         * Minimal amount of dependencies needed for the service to be available
+         */
+        std::size_t minimalCardinality{0};
+
+        /**
          * Nummer tracker services.
          */
         std::size_t nrOfTrackedServices{0};

--- a/libs/framework/include/celix/dm/DependencyManager_Impl.h
+++ b/libs/framework/include/celix/dm/DependencyManager_Impl.h
@@ -188,6 +188,7 @@ static celix::dm::DependencyManagerInfo createDepManInfoFromC(celix_dependency_m
             depInfo.versionRange = std::string{cDepInfo->versionRange == nullptr ? "" : cDepInfo->versionRange};
             depInfo.isAvailable = cDepInfo->available;
             depInfo.isRequired = cDepInfo->required;
+            depInfo.minimalCardinality = cDepInfo->minimalCardinality;
             depInfo.nrOfTrackedServices = cDepInfo->count;
             cmpInfo.dependenciesInfo.emplace_back(std::move(depInfo));
         }

--- a/libs/framework/include/celix/dm/ServiceDependency.h
+++ b/libs/framework/include/celix/dm/ServiceDependency.h
@@ -166,7 +166,7 @@ namespace celix { namespace dm {
         CServiceDependency<T,I>& setRequired(bool req);
 
         /**
-         * Specify if the minimum amount of services required for the service dependency to be available
+         * Specify the minimum amount of service dependencies required to be available
          *
          * @return the C service dependency reference for chaining (fluent API)
          */
@@ -417,7 +417,7 @@ namespace celix { namespace dm {
         ServiceDependency<T,I>& setRequired(bool req);
 
         /**
-         * Specify if the minimum amount of services required for the service dependency to be available
+         * Specify the minimum amount of service dependencies required to be available
          *
          * @return the service dependency reference for chaining (fluent API)
          */

--- a/libs/framework/include/celix/dm/ServiceDependency.h
+++ b/libs/framework/include/celix/dm/ServiceDependency.h
@@ -166,6 +166,13 @@ namespace celix { namespace dm {
         CServiceDependency<T,I>& setRequired(bool req);
 
         /**
+         * Specify if the minimum amount of services required for the service dependency to be available
+         *
+         * @return the C service dependency reference for chaining (fluent API)
+         */
+        CServiceDependency<T,I>& setMinimalCardinality(size_t minimalCardinality);
+
+        /**
          * Specify if the update strategy to use
          *
          * @return the C service dependency reference for chaining (fluent API)
@@ -408,6 +415,13 @@ namespace celix { namespace dm {
          * @return the service dependency reference for chaining (fluent API)
          */
         ServiceDependency<T,I>& setRequired(bool req);
+
+        /**
+         * Specify if the minimum amount of services required for the service dependency to be available
+         *
+         * @return the service dependency reference for chaining (fluent API)
+         */
+        ServiceDependency<T,I>& setMinimalCardinality(size_t minimalCardinality);
 
         /**
          * Specify if the update strategy to use

--- a/libs/framework/include/celix/dm/ServiceDependency.h
+++ b/libs/framework/include/celix/dm/ServiceDependency.h
@@ -159,14 +159,10 @@ namespace celix { namespace dm {
         CServiceDependency<T,I>& setFilter(const std::string &filter);
 
         /**
-         * Specify if the service dependency is required. Default is false
+         * Specify the minimum number of services the service dependency requires before being counted as available.
          *
-         * @return the C service dependency reference for chaining (fluent API)
-         */
-        CServiceDependency<T,I>& setRequired(bool req);
-
-        /**
-         * Specify the minimum amount of service dependencies required to be available
+         * The minimal cardinality also affects whether a service is required. By default, the minimal cardinality is 0,
+         * implying that a service is not required.
          *
          * @return the C service dependency reference for chaining (fluent API)
          */
@@ -410,14 +406,10 @@ namespace celix { namespace dm {
                 std::function<void(const std::shared_ptr<I>& service)> remove);
 
         /**
-         * Specify if the service dependency is required. Default is false
+         * Specify the minimum number of services the service dependency requires before being counted as available.
          *
-         * @return the service dependency reference for chaining (fluent API)
-         */
-        ServiceDependency<T,I>& setRequired(bool req);
-
-        /**
-         * Specify the minimum amount of service dependencies required to be available
+         * The minimal cardinality also affects whether a service is required. By default, the minimal cardinality is 0,
+         * implying that a service is not required.
          *
          * @return the service dependency reference for chaining (fluent API)
          */

--- a/libs/framework/include/celix/dm/ServiceDependency_Impl.h
+++ b/libs/framework/include/celix/dm/ServiceDependency_Impl.h
@@ -119,6 +119,12 @@ CServiceDependency<T,I>& CServiceDependency<T,I>::setRequired(bool req) {
 }
 
 template<class T, typename I>
+CServiceDependency<T,I>& CServiceDependency<T,I>::setMinimalCardinality(size_t minimalCardinality) {
+    celix_dmServiceDependency_setMinimalCardinality(this->cServiceDependency(), minimalCardinality);
+    return *this;
+}
+
+template<class T, typename I>
 CServiceDependency<T,I>& CServiceDependency<T,I>::setStrategy(DependencyUpdateStrategy strategy) {
     this->setDepStrategy(strategy);
     return *this;
@@ -467,8 +473,13 @@ ServiceDependency<T,I>& ServiceDependency<T,I>::setRequired(bool req) {
     celix_dmServiceDependency_setRequired(this->cServiceDependency(), req);
     return *this;
 }
+template <class T, class I>
+ServiceDependency<T, I>& ServiceDependency<T, I>::setMinimalCardinality(size_t minimalCardinality) {
+    celix_dmServiceDependency_setMinimalCardinality(this->cServiceDependency(), minimalCardinality);
+    return *this;
+}
 
-template<class T, class I>
+template <class T, class I>
 ServiceDependency<T,I>& ServiceDependency<T,I>::setStrategy(DependencyUpdateStrategy strategy) {
     this->setDepStrategy(strategy);
     return *this;

--- a/libs/framework/include/celix/dm/ServiceDependency_Impl.h
+++ b/libs/framework/include/celix/dm/ServiceDependency_Impl.h
@@ -113,12 +113,6 @@ void CServiceDependency<T,I>::setupService() {
 }
 
 template<class T, typename I>
-CServiceDependency<T,I>& CServiceDependency<T,I>::setRequired(bool req) {
-    celix_dmServiceDependency_setRequired(this->cServiceDependency(), req);
-    return *this;
-}
-
-template<class T, typename I>
 CServiceDependency<T,I>& CServiceDependency<T,I>::setMinimalCardinality(size_t minimalCardinality) {
     celix_dmServiceDependency_setMinimalCardinality(this->cServiceDependency(), minimalCardinality);
     return *this;
@@ -464,13 +458,6 @@ ServiceDependency<T,I>& ServiceDependency<T,I>::setCallbacks(
                 remove(service);
             }
     );
-    return *this;
-}
-
-
-template<class T, class I>
-ServiceDependency<T,I>& ServiceDependency<T,I>::setRequired(bool req) {
-    celix_dmServiceDependency_setRequired(this->cServiceDependency(), req);
     return *this;
 }
 

--- a/libs/framework/include/celix/dm/ServiceDependency_Impl.h
+++ b/libs/framework/include/celix/dm/ServiceDependency_Impl.h
@@ -473,6 +473,7 @@ ServiceDependency<T,I>& ServiceDependency<T,I>::setRequired(bool req) {
     celix_dmServiceDependency_setRequired(this->cServiceDependency(), req);
     return *this;
 }
+
 template <class T, class I>
 ServiceDependency<T, I>& ServiceDependency<T, I>::setMinimalCardinality(size_t minimalCardinality) {
     celix_dmServiceDependency_setMinimalCardinality(this->cServiceDependency(), minimalCardinality);

--- a/libs/framework/include/celix_dm_info.h
+++ b/libs/framework/include/celix_dm_info.h
@@ -43,6 +43,7 @@ struct celix_dm_service_dependency_info_struct {
     char *filter;
     char *versionRange;
     bool available;
+    size_t minimalCardinality;
     bool required;
     size_t count;
 };

--- a/libs/framework/include/celix_dm_info.h
+++ b/libs/framework/include/celix_dm_info.h
@@ -42,10 +42,10 @@ struct celix_dm_service_dependency_info_struct {
     char *serviceName;
     char *filter;
     char *versionRange;
-    bool available;
-    size_t minimalCardinality;
-    bool required;
     size_t count;
+    size_t minimalCardinality;
+    bool available;
+    bool required;
 };
 typedef struct celix_dm_service_dependency_info_struct *dm_service_dependency_info_pt;  //deprecated
 typedef struct celix_dm_service_dependency_info_struct dm_service_dependency_info_t;  //deprecated
@@ -56,8 +56,8 @@ struct celix_dm_component_info_struct {
     char* bundleSymbolicName;
     char* id;
     char* name;
-    bool active;
     char* state;
+    bool active;
     size_t nrOfTimesStarted;
     size_t nrOfTimesResumed;
     celix_array_list_t *interfaces;   // type dm_interface_info_t*

--- a/libs/framework/include/celix_dm_service_dependency.h
+++ b/libs/framework/include/celix_dm_service_dependency.h
@@ -90,6 +90,11 @@ CELIX_DEFINE_AUTOPTR_CLEANUP_FUNC(celix_dm_service_dependency_t, celix_dmService
 CELIX_FRAMEWORK_EXPORT celix_status_t celix_dmServiceDependency_setRequired(celix_dm_service_dependency_t *dependency, bool required);
 
 /**
+ * Specify the minimum number of services the service dependency requires before being available.
+ */
+CELIX_FRAMEWORK_EXPORT celix_status_t celix_dmServiceDependency_setMinimalCardinality(celix_dm_service_dependency_t *dependency, size_t minimalCardinality);
+
+/**
  * Specify if the service dependency update strategy.
  *
  * The DM_SERVICE_DEPENDENCY_STRATEGY_LOCKING strategy notifies the component in case the dependencies set

--- a/libs/framework/include/celix_dm_service_dependency.h
+++ b/libs/framework/include/celix_dm_service_dependency.h
@@ -85,12 +85,10 @@ CELIX_FRAMEWORK_EXPORT void celix_dmServiceDependency_destroy(celix_dm_service_d
 CELIX_DEFINE_AUTOPTR_CLEANUP_FUNC(celix_dm_service_dependency_t, celix_dmServiceDependency_destroy);
 
 /**
- * Specify if the service dependency is required. default is false
- */
-CELIX_FRAMEWORK_EXPORT celix_status_t celix_dmServiceDependency_setRequired(celix_dm_service_dependency_t *dependency, bool required);
-
-/**
- * Specify the minimum number of services the service dependency requires before being available.
+ * Specify the minimum number of services the service dependency requires before being counted as available.
+ *
+ * The minimal cardinality also affects whether a service is required. By default, the minimal cardinality is 0,
+ * implying that a service is not required.
  */
 CELIX_FRAMEWORK_EXPORT celix_status_t celix_dmServiceDependency_setMinimalCardinality(celix_dm_service_dependency_t *dependency, size_t minimalCardinality);
 

--- a/libs/framework/include_deprecated/dm_service_dependency.h
+++ b/libs/framework/include_deprecated/dm_service_dependency.h
@@ -71,11 +71,6 @@ CELIX_FRAMEWORK_DEPRECATED_EXPORT celix_status_t serviceDependency_create(celix_
 CELIX_FRAMEWORK_DEPRECATED_EXPORT celix_status_t serviceDependency_destroy(celix_dm_service_dependency_t **dep);
 
 /**
- * Specify if the service dependency is required. default is false
- */
-CELIX_FRAMEWORK_DEPRECATED_EXPORT celix_status_t serviceDependency_setRequired(celix_dm_service_dependency_t *dependency, bool required);
-
-/**
  * Specify if the service dependency update strategy.
  *
  * The DM_SERVICE_DEPENDENCY_STRATEGY_LOCKING strategy notifies the component in case the dependencies set

--- a/libs/framework/src/dm_component_impl.c
+++ b/libs/framework/src/dm_component_impl.c
@@ -1108,6 +1108,7 @@ static void celix_dmComponent_printFullInfo(FILE *out, bool colors, celix_dm_com
         fprintf(out, "   |- %sDependency %i: %s%s\n", depStartColors, (depCnt+1), dependency->serviceName == NULL ? "(any)" : dependency->serviceName, endColors);
         fprintf(out, "      | %20s = %s\n", "Available", dependency->available ? "true " : "false");
         fprintf(out, "      | %20s = %lu\n", "Minimal Cardinality", dependency->minimalCardinality);
+        fprintf(out, "      | %20s = %lu\n", "Service Count", dependency->count);
         fprintf(out, "      | %20s = %s\n", "Required", dependency->required ? "true " : "false");
         fprintf(out, "      | %20s = %s\n", "Version Range", dependency->versionRange == NULL ? "N/A" : dependency->versionRange);
         fprintf(out, "      | %20s = %s\n", "Filter", dependency->filter == NULL ? "N/A" : dependency->filter);

--- a/libs/framework/src/dm_component_impl.c
+++ b/libs/framework/src/dm_component_impl.c
@@ -1106,10 +1106,11 @@ static void celix_dmComponent_printFullInfo(FILE *out, bool colors, celix_dm_com
             }
         }
         fprintf(out, "   |- %sDependency %i: %s%s\n", depStartColors, (depCnt+1), dependency->serviceName == NULL ? "(any)" : dependency->serviceName, endColors);
-        fprintf(out, "      | %15s = %s\n", "Available", dependency->available ? "true " : "false");
-        fprintf(out, "      | %15s = %s\n", "Required", dependency->required ? "true " : "false");
-        fprintf(out, "      | %15s = %s\n", "Version Range", dependency->versionRange == NULL ? "N/A" : dependency->versionRange);
-        fprintf(out, "      | %15s = %s\n", "Filter", dependency->filter == NULL ? "N/A" : dependency->filter);
+        fprintf(out, "      | %20s = %s\n", "Available", dependency->available ? "true " : "false");
+        fprintf(out, "      | %20s = %lu\n", "Minimal Cardinality", dependency->minimalCardinality);
+        fprintf(out, "      | %20s = %s\n", "Required", dependency->required ? "true " : "false");
+        fprintf(out, "      | %20s = %s\n", "Version Range", dependency->versionRange == NULL ? "N/A" : dependency->versionRange);
+        fprintf(out, "      | %20s = %s\n", "Filter", dependency->filter == NULL ? "N/A" : dependency->filter);
     }
     fprintf(out, "\n");
 }

--- a/libs/framework/src/dm_service_dependency.c
+++ b/libs/framework/src/dm_service_dependency.c
@@ -97,7 +97,9 @@ celix_status_t celix_dmServiceDependency_setRequired(celix_dm_service_dependency
 }
 
 celix_status_t celix_dmServiceDependency_setMinimalCardinality(celix_dm_service_dependency_t *dependency, size_t minimalCardinality) {
-    dependency->minimalCardinality = minimalCardinality;
+    if (minimalCardinality > 0) {
+        dependency->minimalCardinality = minimalCardinality;
+    }
     return CELIX_SUCCESS;
 }
 

--- a/libs/framework/src/dm_service_dependency.c
+++ b/libs/framework/src/dm_service_dependency.c
@@ -45,19 +45,18 @@ celix_status_t serviceDependency_create(celix_dm_service_dependency_t **dependen
 }
 
 celix_dm_service_dependency_t* celix_dmServiceDependency_create() {
-	celix_dm_service_dependency_t *dep = calloc(1, sizeof(*dep));
-	dep->strategy = DM_SERVICE_DEPENDENCY_DEFAULT_STRATEGY;
-	dep->svcTrackerId = -1;
-    dep->minimalCardinality = 1;
-	celixThreadMutex_create(&dep->mutex, NULL);
+    celix_dm_service_dependency_t* dep = calloc(1, sizeof(*dep));
+    dep->strategy = DM_SERVICE_DEPENDENCY_DEFAULT_STRATEGY;
+    dep->svcTrackerId = -1;
+    celixThreadMutex_create(&dep->mutex, NULL);
     return dep;
 }
 
 celix_status_t serviceDependency_destroy(celix_dm_service_dependency_t **dependency_ptr) {
-	if (dependency_ptr != NULL) {
-		celix_dmServiceDependency_destroy(*dependency_ptr);
-	}
-	return CELIX_SUCCESS;
+    if (dependency_ptr != NULL) {
+        celix_dmServiceDependency_destroy(*dependency_ptr);
+    }
+    return CELIX_SUCCESS;
 }
 
 void celix_dmServiceDependency_destroy(celix_dm_service_dependency_t *dep) {
@@ -78,54 +77,39 @@ void celix_dmServiceDependency_destroy(celix_dm_service_dependency_t *dep) {
     }
 }
 
-celix_status_t serviceDependency_setRequired(celix_dm_service_dependency_t *dependency, bool required) {
-	return celix_dmServiceDependency_setRequired(dependency, required);
-}
-
-celix_status_t celix_dmServiceDependency_setRequired(celix_dm_service_dependency_t *dependency, bool required) {
-	celix_status_t status = CELIX_SUCCESS;
-
-	if (!dependency) {
-		status = CELIX_ILLEGAL_ARGUMENT;
-	}
-
-	if (status == CELIX_SUCCESS) {
-		dependency->required = required;
-	}
-
-	return status;
-}
-
 celix_status_t celix_dmServiceDependency_setMinimalCardinality(celix_dm_service_dependency_t *dependency, size_t minimalCardinality) {
-    if (minimalCardinality > 0) {
+    celix_status_t status = CELIX_SUCCESS;
+    if (!dependency) {
+        status = CELIX_ILLEGAL_ARGUMENT;
+    } else {
         dependency->minimalCardinality = minimalCardinality;
     }
-    return CELIX_SUCCESS;
+    return status;
 }
 
 celix_status_t serviceDependency_setStrategy(celix_dm_service_dependency_t *dependency, dm_service_dependency_strategy_t strategy) {
-	return celix_dmServiceDependency_setStrategy(dependency, strategy);
+    return celix_dmServiceDependency_setStrategy(dependency, strategy);
 }
 
 celix_status_t celix_dmServiceDependency_setStrategy(celix_dm_service_dependency_t *dependency, dm_service_dependency_strategy_t strategy) {
     dependency->strategy = strategy;
-	return CELIX_SUCCESS;
+    return CELIX_SUCCESS;
 }
 
 celix_status_t serviceDependency_getStrategy(celix_dm_service_dependency_t *dependency, dm_service_dependency_strategy_t* strategy) {
-	celix_dm_service_dependency_strategy_t str = celix_dmServiceDependency_getStrategy(dependency);
-	if (strategy != NULL) {
-		*strategy = str;
-	}
-	return CELIX_SUCCESS;
+    celix_dm_service_dependency_strategy_t str = celix_dmServiceDependency_getStrategy(dependency);
+    if (strategy != NULL) {
+        *strategy = str;
+    }
+    return CELIX_SUCCESS;
 }
 
 celix_dm_service_dependency_strategy_t celix_dmServiceDependency_getStrategy(celix_dm_service_dependency_t *dependency) {
-	return dependency->strategy;
+    return dependency->strategy;
 }
 
 celix_status_t serviceDependency_setService(celix_dm_service_dependency_t *dependency, const char* serviceName, const char* serviceVersionRange, const char* filter) {
-	return celix_dmServiceDependency_setService(dependency, serviceName, serviceVersionRange, filter);
+    return celix_dmServiceDependency_setService(dependency, serviceName, serviceVersionRange, filter);
 }
 
 celix_status_t celix_dmServiceDependency_setService(celix_dm_service_dependency_t *dependency, const char* serviceName, const char* serviceVersionRange, const char* filter) {
@@ -145,15 +129,15 @@ celix_status_t celix_dmServiceDependency_setService(celix_dm_service_dependency_
 }
 
 celix_status_t serviceDependency_getFilter(celix_dm_service_dependency_t *dependency, const char** filter) {
-	const char *f =  celix_dmServiceDependency_getFilter(dependency);
-	if (filter != NULL) {
-		*filter = f;
-	}
-	return CELIX_SUCCESS;
+    const char* f = celix_dmServiceDependency_getFilter(dependency);
+    if (filter != NULL) {
+        *filter = f;
+    }
+    return CELIX_SUCCESS;
 }
 
 const char* celix_dmServiceDependency_getFilter(celix_dm_service_dependency_t *dependency) {
-	return (const char*)dependency->filter;
+    return (const char*)dependency->filter;
 }
 
 celix_status_t serviceDependency_setCallbacks(celix_dm_service_dependency_t *dependency, service_set_fpt set, service_add_fpt add, service_change_fpt change CELIX_UNUSED, service_remove_fpt remove, service_swap_fpt swap  CELIX_UNUSED) {
@@ -164,57 +148,55 @@ celix_status_t serviceDependency_setCallbacks(celix_dm_service_dependency_t *dep
 }
 
 celix_status_t celix_dmServiceDependency_setCallback(celix_dm_service_dependency_t *dependency, celix_dm_service_update_fp set) {
-	dependency->set = set;
-	return CELIX_SUCCESS;
+    dependency->set = set;
+    return CELIX_SUCCESS;
 }
-
 
 celix_status_t celix_dmServiceDependency_setCallbackWithProperties(celix_dm_service_dependency_t *dependency, celix_dm_service_update_with_props_fp set) {
-	dependency->setWithProperties = set;
-	return CELIX_SUCCESS;
+    dependency->setWithProperties = set;
+    return CELIX_SUCCESS;
 }
 
-
 celix_status_t celix_dmServiceDependency_setCallbacksWithOptions(celix_dm_service_dependency_t *dependency, const celix_dm_service_dependency_callback_options_t *opts) {
-	dependency->set = opts->set;
-	dependency->add = opts->add;
-	dependency->remove = opts->remove;
+    dependency->set = opts->set;
+    dependency->add = opts->add;
+    dependency->remove = opts->remove;
 
-	dependency->setWithProperties = opts->setWithProps;
-	dependency->addWithProperties = opts->addWithProps;
-	dependency->remWithProperties = opts->removeWithProps;
-	return CELIX_SUCCESS;
+    dependency->setWithProperties = opts->setWithProps;
+    dependency->addWithProperties = opts->addWithProps;
+    dependency->remWithProperties = opts->removeWithProps;
+    return CELIX_SUCCESS;
 }
 
 celix_status_t celix_dmServiceDependency_setComponent(celix_dm_service_dependency_t *dependency, celix_dm_component_t *component) {
     dependency->component = component;
-	return CELIX_SUCCESS;
+    return CELIX_SUCCESS;
 }
 
 celix_status_t celix_dmServiceDependency_enable(celix_dm_service_dependency_t* dependency) {
-        celix_bundle_context_t* ctx = celix_dmComponent_getBundleContext(dependency->component);
+    celix_bundle_context_t* ctx = celix_dmComponent_getBundleContext(dependency->component);
 
-        if (dependency->serviceName == NULL && dependency->filter == NULL) {
-                celix_bundleContext_log(
-                    ctx, CELIX_LOG_LEVEL_ERROR, "Cannot start a service dependency without a service name and filter");
-                return CELIX_ILLEGAL_ARGUMENT;
-        }
+    if (dependency->serviceName == NULL && dependency->filter == NULL) {
+        celix_bundleContext_log(
+            ctx, CELIX_LOG_LEVEL_ERROR, "Cannot start a service dependency without a service name and filter");
+        return CELIX_ILLEGAL_ARGUMENT;
+    }
 
-        celixThreadMutex_lock(&dependency->mutex);
-        if (dependency->svcTrackerId == -1L) {
-                celix_service_tracking_options_t opts = CELIX_EMPTY_SERVICE_TRACKING_OPTIONS;
-                opts.filter.filter = dependency->filter;
-                opts.filter.serviceName = dependency->serviceName;
-                opts.filter.versionRange = dependency->versionRange;
-                opts.callbackHandle = dependency;
-                opts.addWithProperties = serviceDependency_addServiceTrackerCallback;
-                opts.removeWithProperties = serviceDependency_removeServiceTrackerCallback;
-                opts.setWithProperties = serviceDependency_setServiceTrackerCallback;
-                dependency->svcTrackerId = celix_bundleContext_trackServicesWithOptionsAsync(ctx, &opts);
-        }
-        celixThreadMutex_unlock(&dependency->mutex);
+    celixThreadMutex_lock(&dependency->mutex);
+    if (dependency->svcTrackerId == -1L) {
+        celix_service_tracking_options_t opts = CELIX_EMPTY_SERVICE_TRACKING_OPTIONS;
+        opts.filter.filter = dependency->filter;
+        opts.filter.serviceName = dependency->serviceName;
+        opts.filter.versionRange = dependency->versionRange;
+        opts.callbackHandle = dependency;
+        opts.addWithProperties = serviceDependency_addServiceTrackerCallback;
+        opts.removeWithProperties = serviceDependency_removeServiceTrackerCallback;
+        opts.setWithProperties = serviceDependency_setServiceTrackerCallback;
+        dependency->svcTrackerId = celix_bundleContext_trackServicesWithOptionsAsync(ctx, &opts);
+    }
+    celixThreadMutex_unlock(&dependency->mutex);
 
-        return CELIX_SUCCESS;
+    return CELIX_SUCCESS;
 }
 
 static void celix_serviceDependency_stopCallback(void *data) {
@@ -234,7 +216,7 @@ celix_status_t celix_dmServiceDependency_disable(celix_dm_service_dependency_t *
     }
     celixThreadMutex_unlock(&dependency->mutex);
 
-	return CELIX_SUCCESS;
+    return CELIX_SUCCESS;
 }
 
 bool celix_dmServiceDependency_isDisabled(celix_dm_service_dependency_t *dependency) {
@@ -318,13 +300,18 @@ celix_status_t celix_dmServiceDependency_invokeRemove(celix_dm_service_dependenc
 
 bool celix_dmServiceDependency_isAvailable(celix_dm_service_dependency_t *dependency) {
     celixThreadMutex_lock(&dependency->mutex);
-    bool avail = dependency->trackedSvcCount >= dependency->minimalCardinality;
+    bool avail = false;
+    if (dependency->minimalCardinality == 0) {
+        avail = dependency->trackedSvcCount > 0;
+    } else {
+        avail = dependency->trackedSvcCount >= dependency->minimalCardinality;
+    }
     celixThreadMutex_unlock(&dependency->mutex);
     return avail;
 }
 
 bool celix_dmServiceDependency_isRequired(const celix_dm_service_dependency_t* dep) {
-    return dep->required;
+    return dep->minimalCardinality > 0;
 }
 
 bool celix_dmServiceDependency_isTrackerOpen(celix_dm_service_dependency_t* dependency) {
@@ -345,10 +332,10 @@ bool celix_dmServiceDependency_isAddRemCallbacksConfigured(celix_dm_service_depe
 }
 
 celix_status_t serviceDependency_getServiceDependencyInfo(celix_dm_service_dependency_t *dep, dm_service_dependency_info_t **out) {
-	if (out != NULL) {
-		*out = celix_dmServiceDependency_createInfo(dep);
-	}
-	return CELIX_SUCCESS;
+    if (out != NULL) {
+        *out = celix_dmServiceDependency_createInfo(dep);
+    }
+    return CELIX_SUCCESS;
 }
 
 dm_service_dependency_info_t* celix_dmServiceDependency_createInfo(celix_dm_service_dependency_t* dep) {
@@ -360,7 +347,7 @@ dm_service_dependency_info_t* celix_dmServiceDependency_createInfo(celix_dm_serv
         info->serviceName = celix_utils_strdup(dep->serviceName);
         info->filter = celix_utils_strdup(dep->filter);
         info->versionRange = celix_utils_strdup(dep->versionRange);
-        info->required = dep->required;
+        info->required = dep->minimalCardinality > 0;
         info->count = dep->trackedSvcCount;
         celixThreadMutex_unlock(&dep->mutex);
     }
@@ -369,24 +356,24 @@ dm_service_dependency_info_t* celix_dmServiceDependency_createInfo(celix_dm_serv
 
 
 void dependency_destroyDependencyInfo(dm_service_dependency_info_pt info) {
-	celix_dmServiceDependency_destroyInfo(NULL, info);
+    celix_dmServiceDependency_destroyInfo(NULL, info);
 }
 
 void celix_dmServiceDependency_destroyInfo(celix_dm_service_dependency_t *dep CELIX_UNUSED, dm_service_dependency_info_t *info) {
-	if (info != NULL) {
-	    free(info->serviceName);
-		free(info->filter);
-		free(info->versionRange);
-	}
-	free(info);
+    if (info != NULL) {
+        free(info->serviceName);
+        free(info->filter);
+        free(info->versionRange);
+    }
+    free(info);
 }
 
 celix_status_t serviceDependency_setCallbackHandle(celix_dm_service_dependency_t *dependency, void* handle) {
-	return celix_dmServiceDependency_setCallbackHandle(dependency, handle);
+    return celix_dmServiceDependency_setCallbackHandle(dependency, handle);
 }
 
 celix_status_t celix_dmServiceDependency_setCallbackHandle(celix_dm_service_dependency_t *dependency, void* handle) {
-	dependency->callbackHandle = handle;
+    dependency->callbackHandle = handle;
     return CELIX_SUCCESS;
 }
 

--- a/libs/framework/src/dm_service_dependency.c
+++ b/libs/framework/src/dm_service_dependency.c
@@ -33,6 +33,7 @@ static void serviceDependency_addServiceTrackerCallback(void *handle, void *svc,
 static void serviceDependency_removeServiceTrackerCallback(void *handle, void *svc, const celix_properties_t *props);
 static void serviceDependency_setServiceTrackerCallback(void *handle, void *svc, const celix_properties_t *props);
 static void* serviceDependency_getCallbackHandle(celix_dm_service_dependency_t *dep);
+static bool serviceDependency_isAvailable(celix_dm_service_dependency_t *dep);
 
 celix_status_t serviceDependency_create(celix_dm_service_dependency_t **dependency_ptr) {
     celix_dm_service_dependency_t *dep = celix_dmServiceDependency_create();
@@ -300,8 +301,7 @@ celix_status_t celix_dmServiceDependency_invokeRemove(celix_dm_service_dependenc
 
 bool celix_dmServiceDependency_isAvailable(celix_dm_service_dependency_t *dependency) {
     celixThreadMutex_lock(&dependency->mutex);
-    bool avail = (dependency->minimalCardinality == 0) ? (dependency->trackedSvcCount > 0)
-                                                       : (dependency->trackedSvcCount >= dependency->minimalCardinality);
+    bool avail = serviceDependency_isAvailable(dependency);
     celixThreadMutex_unlock(&dependency->mutex);
     return avail;
 }
@@ -338,7 +338,7 @@ dm_service_dependency_info_t* celix_dmServiceDependency_createInfo(celix_dm_serv
     celix_dm_service_dependency_info_t* info = calloc(1, sizeof(*info));
     if (info != NULL) {
         celixThreadMutex_lock(&dep->mutex);
-        info->available = (dep->minimalCardinality == 0) ? (dep->trackedSvcCount > 0) : dep->trackedSvcCount >= dep->minimalCardinality;
+        info->available = serviceDependency_isAvailable(dep);
         info->minimalCardinality = dep->minimalCardinality;
         info->serviceName = celix_utils_strdup(dep->serviceName);
         info->filter = celix_utils_strdup(dep->filter);
@@ -375,4 +375,12 @@ celix_status_t celix_dmServiceDependency_setCallbackHandle(celix_dm_service_depe
 
 static void* serviceDependency_getCallbackHandle(celix_dm_service_dependency_t *dependency) {
     return dependency->callbackHandle == NULL ? component_getImplementation(dependency->component) : dependency->callbackHandle;
+}
+
+static bool serviceDependency_isAvailable(celix_dm_service_dependency_t* dep) {
+    if (dep->minimalCardinality == 0) {
+        return dep->trackedSvcCount > 0;
+    }
+
+    return dep->trackedSvcCount >= dep->minimalCardinality;
 }

--- a/libs/framework/src/dm_service_dependency.c
+++ b/libs/framework/src/dm_service_dependency.c
@@ -300,12 +300,8 @@ celix_status_t celix_dmServiceDependency_invokeRemove(celix_dm_service_dependenc
 
 bool celix_dmServiceDependency_isAvailable(celix_dm_service_dependency_t *dependency) {
     celixThreadMutex_lock(&dependency->mutex);
-    bool avail = false;
-    if (dependency->minimalCardinality == 0) {
-        avail = dependency->trackedSvcCount > 0;
-    } else {
-        avail = dependency->trackedSvcCount >= dependency->minimalCardinality;
-    }
+    bool avail = (dependency->minimalCardinality == 0) ? (dependency->trackedSvcCount > 0)
+                                                       : (dependency->trackedSvcCount >= dependency->minimalCardinality);
     celixThreadMutex_unlock(&dependency->mutex);
     return avail;
 }
@@ -342,7 +338,7 @@ dm_service_dependency_info_t* celix_dmServiceDependency_createInfo(celix_dm_serv
     celix_dm_service_dependency_info_t* info = calloc(1, sizeof(*info));
     if (info != NULL) {
         celixThreadMutex_lock(&dep->mutex);
-        info->available = dep->trackedSvcCount >= dep->minimalCardinality;
+        info->available = (dep->minimalCardinality == 0) ? (dep->trackedSvcCount > 0) : dep->trackedSvcCount >= dep->minimalCardinality;
         info->minimalCardinality = dep->minimalCardinality;
         info->serviceName = celix_utils_strdup(dep->serviceName);
         info->filter = celix_utils_strdup(dep->filter);

--- a/libs/framework/src/dm_service_dependency.c
+++ b/libs/framework/src/dm_service_dependency.c
@@ -352,19 +352,19 @@ celix_status_t serviceDependency_getServiceDependencyInfo(celix_dm_service_depen
 }
 
 dm_service_dependency_info_t* celix_dmServiceDependency_createInfo(celix_dm_service_dependency_t* dep) {
-	celix_dm_service_dependency_info_t *info = calloc(1, sizeof(*info));
-	if (info != NULL) {
-		celixThreadMutex_lock(&dep->mutex);
-		info->available = dep->trackedSvcCount >= dep->minimalCardinality;
+    celix_dm_service_dependency_info_t* info = calloc(1, sizeof(*info));
+    if (info != NULL) {
+        celixThreadMutex_lock(&dep->mutex);
+        info->available = dep->trackedSvcCount >= dep->minimalCardinality;
         info->minimalCardinality = dep->minimalCardinality;
-		info->serviceName = celix_utils_strdup(dep->serviceName);
-		info->filter = celix_utils_strdup(dep->filter);
-		info->versionRange = celix_utils_strdup(dep->versionRange);
-		info->required = dep->required;
-		info->count = dep->trackedSvcCount;
-		celixThreadMutex_unlock(&dep->mutex);
-	}
-	return info;
+        info->serviceName = celix_utils_strdup(dep->serviceName);
+        info->filter = celix_utils_strdup(dep->filter);
+        info->versionRange = celix_utils_strdup(dep->versionRange);
+        info->required = dep->required;
+        info->count = dep->trackedSvcCount;
+        celixThreadMutex_unlock(&dep->mutex);
+    }
+    return info;
 }
 
 

--- a/libs/framework/src/dm_service_dependency.c
+++ b/libs/framework/src/dm_service_dependency.c
@@ -48,6 +48,7 @@ celix_dm_service_dependency_t* celix_dmServiceDependency_create() {
 	celix_dm_service_dependency_t *dep = calloc(1, sizeof(*dep));
 	dep->strategy = DM_SERVICE_DEPENDENCY_DEFAULT_STRATEGY;
 	dep->svcTrackerId = -1;
+    dep->minimalCardinality = 1;
 	celixThreadMutex_create(&dep->mutex, NULL);
     return dep;
 }
@@ -93,6 +94,11 @@ celix_status_t celix_dmServiceDependency_setRequired(celix_dm_service_dependency
 	}
 
 	return status;
+}
+
+celix_status_t celix_dmServiceDependency_setMinimalCardinality(celix_dm_service_dependency_t *dependency, size_t minimalCardinality) {
+    dependency->minimalCardinality = minimalCardinality;
+    return CELIX_SUCCESS;
 }
 
 celix_status_t serviceDependency_setStrategy(celix_dm_service_dependency_t *dependency, dm_service_dependency_strategy_t strategy) {
@@ -310,7 +316,7 @@ celix_status_t celix_dmServiceDependency_invokeRemove(celix_dm_service_dependenc
 
 bool celix_dmServiceDependency_isAvailable(celix_dm_service_dependency_t *dependency) {
     celixThreadMutex_lock(&dependency->mutex);
-    bool avail = dependency->trackedSvcCount > 0;
+    bool avail = dependency->trackedSvcCount >= dependency->minimalCardinality;
     celixThreadMutex_unlock(&dependency->mutex);
     return avail;
 }
@@ -347,7 +353,8 @@ dm_service_dependency_info_t* celix_dmServiceDependency_createInfo(celix_dm_serv
 	celix_dm_service_dependency_info_t *info = calloc(1, sizeof(*info));
 	if (info != NULL) {
 		celixThreadMutex_lock(&dep->mutex);
-		info->available = dep->trackedSvcCount > 0;
+		info->available = dep->trackedSvcCount >= dep->minimalCardinality;
+        info->minimalCardinality = dep->minimalCardinality;
 		info->serviceName = celix_utils_strdup(dep->serviceName);
 		info->filter = celix_utils_strdup(dep->filter);
 		info->versionRange = celix_utils_strdup(dep->versionRange);

--- a/libs/framework/src/dm_service_dependency_impl.h
+++ b/libs/framework/src/dm_service_dependency_impl.h
@@ -51,7 +51,6 @@ struct celix_dm_service_dependency {
     char* serviceName;
     char* filter;
     char* versionRange;
-    bool required;
     dm_service_dependency_strategy_t strategy;
     celix_dm_component_t* component;
 

--- a/libs/framework/src/dm_service_dependency_impl.h
+++ b/libs/framework/src/dm_service_dependency_impl.h
@@ -59,8 +59,8 @@ struct celix_dm_service_dependency {
     long svcTrackerId;                 // active tracker id
     size_t nrOfActiveStoppingTrackers; // nr of async stop tracker still active (should be 0 or 1)
     size_t trackedSvcCount;
-    size_t minimalCardinality;         // minimal nr of service required for availability
-    void* callbackHandle; // This handle can be set to be used instead of the component implementation
+    size_t minimalCardinality; // minimal nr of service required for availability
+    void* callbackHandle;      // This handle can be set to be used instead of the component implementation
 };
 
 celix_status_t celix_dmServiceDependency_enable(celix_dm_service_dependency_t *dependency);

--- a/libs/framework/src/dm_service_dependency_impl.h
+++ b/libs/framework/src/dm_service_dependency_impl.h
@@ -59,6 +59,7 @@ struct celix_dm_service_dependency {
     long svcTrackerId;                 // active tracker id
     size_t nrOfActiveStoppingTrackers; // nr of async stop tracker still active (should be 0 or 1)
     size_t trackedSvcCount;
+    size_t minimalCardinality;         // minimal nr of service required for availability
     void* callbackHandle; // This handle can be set to be used instead of the component implementation
 };
 


### PR DESCRIPTION
Introduce a minimal cardinality for service dependencies to determine when a service dependency is considered to be available. This gives the ability to wait for a component to start until a certain number of a service dependency are available.

Mentioned in https://docs.osgi.org/specification/osgi.cmpn/7.0.0/service.component.html#service.component-minimum.cardinality.property.

Update:
 - Removed usage of setRequired and use minimalCardinality to determine whether a serviceDependency is required or not. 