### PR TITLE
Introduces binary type value for celix_properties_t.

### DIFF
--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -122,6 +122,7 @@ jobs:
           libavahi-compat-libdnssd-dev \
           libcivetweb-dev \
           civetweb \
+          libssl-dev \
           ccache
     - name: Prepare ccache timestamp
       id: ccache_cache_timestamp

--- a/cmake/CelixDeps.cmake.in
+++ b/cmake/CelixDeps.cmake.in
@@ -4,6 +4,7 @@ $<$<BOOL:$<TARGET_NAME_IF_EXISTS:Celix::pubsub_spi>>:find_dependency(libuuid)>
 $<$<BOOL:$<TARGET_NAME_IF_EXISTS:Celix::utils>>:find_dependency(libzip)>
 $<$<BOOL:$<TARGET_NAME_IF_EXISTS:Celix::utils>>:find_dependency(jansson)>
 $<$<BOOL:$<TARGET_NAME_IF_EXISTS:Celix::utils>>:find_dependency(libuv)>
+$<$<BOOL:$<TARGET_NAME_IF_EXISTS:Celix::utils>>:find_dependency(OpenSSL)>
 $<$<BOOL:$<TARGET_NAME_IF_EXISTS:Celix::deployment_admin>>:find_dependency(ZLIB)>
 $<$<BOOL:$<TARGET_NAME_IF_EXISTS:Celix::dfi>>:find_dependency(libffi)>
 $<$<BOOL:$<TARGET_NAME_IF_EXISTS:Celix::dfi>>:find_dependency(jansson)>

--- a/conanfile.py
+++ b/conanfile.py
@@ -420,6 +420,8 @@ class CelixConan(ConanFile):
                 tc.cache_variables["BUILD_ERROR_INJECTOR_MOSQUITTO"] = "ON"
             if "libcurl" in lst:
                 tc.cache_variables["BUILD_ERROR_INJECTOR_CURL"] = "ON"
+            if "openssl" in lst:
+                tc.cache_variables["BUILD_ERROR_INJECTOR_OPENSSL"] = "ON"
         tc.cache_variables["CELIX_ERR_BUFFER_SIZE"] = str(self.options.celix_err_buffer_size)
         #tc.cache_variables["CMAKE_PROJECT_Celix_INCLUDE"] = os.path.join(self.build_folder, "conan_paths.cmake")
         # the following is workaround for https://github.com/conan-io/conan/issues/7192

--- a/conanfile.py
+++ b/conanfile.py
@@ -167,6 +167,7 @@ class CelixConan(ConanFile):
         validation_rules = [
             ValidationRule(self.options.build_utils, 'libzip', "shared", True, 'build_utils=True'),
             ValidationRule(self.options.build_utils, 'libuv', "shared", True, 'build_utils=True'),
+            ValidationRule(self.options.build_utils, 'openssl', "shared", True, 'build_utils=True'),
             ValidationRule(self.options.build_framework, 'util-linux-libuuid', "shared", True, 'build_framework=True'),
             ValidationRule(self.options.build_framework and self.options.framework_curlinit, 'libcurl', "shared", True, 'build_framework=True and framework_curlinit=True'),
             ValidationRule(self.options.build_framework and self.options.framework_curlinit, 'openssl', "shared", True, 'build_framework=True and framework_curlinit=True'),
@@ -369,6 +370,7 @@ class CelixConan(ConanFile):
         if self.options.build_utils:
             self.requires("libzip/[>=1.7.3 <2.0.0]")
             self.requires("libuv/[>=1.49.2 <2.0.0]")
+            self.requires("openssl/[>=3.2.0]")
         if self.options.build_framework:
             self.requires("util-linux-libuuid/[>=2.39 <3.0.0]")
             if self.settings.os == "Macos":
@@ -394,7 +396,7 @@ class CelixConan(ConanFile):
             # TODO: To be replaced with mdnsresponder/1790.80.10, resolve some problems of mdnsresponder
             # https://github.com/conan-io/conan-center-index/pull/16254
             self.requires("mdnsresponder/1310.140.1")
-        self.requires("openssl/[>=3.2.0]", override=True)
+
         # Fix zlib to 1.3.1, 'libzip/1.10.1' and 'libcurl/7.64.1' requires different zlib versions causing conflicts
         self.requires("zlib/1.3.1", override=True)
         if self.options.build_event_admin_remote_provider_mqtt:

--- a/libs/error_injector/CMakeLists.txt
+++ b/libs/error_injector/CMakeLists.txt
@@ -58,3 +58,8 @@ celix_subproject(ERROR_INJECTOR_CURL "Option to enable building the curl error i
 if (ERROR_INJECTOR_CURL)
     add_subdirectory(curl)
 endif ()
+
+celix_subproject(ERROR_INJECTOR_OPENSSL "Option to enable building the openssl error injector" ON)
+if (ERROR_INJECTOR_OPENSSL)
+    add_subdirectory(openssl)
+endif ()

--- a/libs/error_injector/openssl/CMakeLists.txt
+++ b/libs/error_injector/openssl/CMakeLists.txt
@@ -1,0 +1,29 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+add_library(openssl_ei STATIC src/openssl_ei.cc)
+
+find_package(OpenSSL REQUIRED)
+
+target_include_directories(openssl_ei PUBLIC ${CMAKE_CURRENT_LIST_DIR}/include)
+target_link_libraries(openssl_ei PUBLIC Celix::error_injector OpenSSL::Crypto)
+
+target_link_options(openssl_ei INTERFACE
+        LINKER:--wrap,EVP_EncodeBlock
+)
+
+add_library(Celix::openssl_ei ALIAS openssl_ei)

--- a/libs/error_injector/openssl/include/openssl_ei.h
+++ b/libs/error_injector/openssl/include/openssl_ei.h
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#ifndef CELIX_OPENSSL_EI_H
+#define CELIX_OPENSSL_EI_H
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <openssl/evp.h>
+#include "celix_error_injector.h"
+
+CELIX_EI_DECLARE(EVP_EncodeBlock, int);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif //CELIX_OPENSSL_EI_H

--- a/libs/error_injector/openssl/src/openssl_ei.cc
+++ b/libs/error_injector/openssl/src/openssl_ei.cc
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+#include "openssl_ei.h"
+
+extern "C" {
+
+int __real_EVP_EncodeBlock(unsigned char *t, const unsigned char *f, int n);
+CELIX_EI_DEFINE(EVP_EncodeBlock, int)
+int __wrap_EVP_EncodeBlock(unsigned char *t, const unsigned char *f, int n) {
+    CELIX_EI_IMPL(EVP_EncodeBlock);
+    return __real_EVP_EncodeBlock(t, f, n);
+}
+
+}

--- a/libs/utils/CMakeLists.txt
+++ b/libs/utils/CMakeLists.txt
@@ -20,6 +20,7 @@ if (UTILS)
     find_package(libzip REQUIRED)
     find_package(jansson REQUIRED)
     find_package(libuv REQUIRED)
+    find_package(OpenSSL REQUIRED)
 
     set(MEMSTREAM_SOURCES )
     set(MEMSTREAM_INCLUDES )
@@ -46,7 +47,7 @@ if (UTILS)
             src/celix_json_utils.c
             ${MEMSTREAM_SOURCES}
             )
-    set(UTILS_PRIVATE_DEPS libzip::zip jansson::jansson)
+    set(UTILS_PRIVATE_DEPS libzip::zip jansson::jansson OpenSSL::Crypto)
     set(UTILS_PUBLIC_DEPS libuv::uv)
 
     add_library(utils SHARED ${UTILS_SRC})

--- a/libs/utils/gtest/CMakeLists.txt
+++ b/libs/utils/gtest/CMakeLists.txt
@@ -163,6 +163,7 @@ if (EI_TESTS)
             Celix::version_ei
             Celix::array_list_ei
             Celix::jansson_ei
+            Celix::openssl_ei
             GTest::gtest GTest::gtest_main
     )
     target_include_directories(test_utils_with_ei PRIVATE ../src) #for version_private (needs refactoring of test)

--- a/libs/utils/gtest/src/CelixJsonUtilsErrorInjectionTestSuite.cc
+++ b/libs/utils/gtest/src/CelixJsonUtilsErrorInjectionTestSuite.cc
@@ -20,6 +20,7 @@
 
 #include "celix_json_utils_private.h"
 #include "celix_err.h"
+#include "celix_stdlib_cleanup.h"
 #include "celix_version_ei.h"
 #include "jansson_ei.h"
 #include "asprintf_ei.h"
@@ -59,4 +60,24 @@ TEST_F(CelixJsonUtilsErrorInjectionTestSuite, ExtractVersionErrorWhenConvertingJ
     celix_autoptr(celix_version_t) version = nullptr;
     auto status = celix_utils_jsonToVersion(json, &version);
     ASSERT_EQ(ENOMEM, status);
+}
+
+TEST_F(CelixJsonUtilsErrorInjectionTestSuite, JsonSprintfErrorWhenConvertingBinaryToStringTest) {
+    celix_ei_expect_json_sprintf((void*)&celix_utils_binaryToJson, 0, nullptr);
+    char bin[3]= {1,2,3};
+    json_auto_t* json = nullptr;
+    auto status = celix_utils_binaryToJson(bin, sizeof(bin), &json);
+    ASSERT_EQ(ENOMEM, status);
+    ASSERT_TRUE(json == nullptr);
+}
+
+TEST_F(CelixJsonUtilsErrorInjectionTestSuite, ExtractBinaryErrorWhenConvertingJsonToBinaryTest) {
+    celix_ei_expect_vasprintf((void*)&celix_utils_jsonToBinary, 2, -1);
+    std::string base64(512,'A');
+    json_auto_t* json = json_string(("base64<" + base64 + ">").c_str());
+    celix_autofree void* data = nullptr;
+    size_t size = 0;
+    auto status = celix_utils_jsonToBinary(json, &data, &size);
+    ASSERT_EQ(ENOMEM, status);
+    ASSERT_TRUE(data == nullptr);
 }

--- a/libs/utils/gtest/src/CelixJsonUtilsTestSuite.cc
+++ b/libs/utils/gtest/src/CelixJsonUtilsTestSuite.cc
@@ -18,6 +18,9 @@
  */
 #include <gtest/gtest.h>
 
+#include <limits>
+
+#include "celix_stdlib_cleanup.h"
 #include "celix_json_utils_private.h"
 #include "celix_err.h"
 
@@ -103,3 +106,129 @@ TEST_F(CelixJsonUtilsTestSuite, JsonErrorToCelixStatusTest) {
     ASSERT_EQ(CELIX_ILLEGAL_ARGUMENT, celix_utils_jsonErrorToStatus(json_error_index_out_of_range));
 }
 
+TEST_F(CelixJsonUtilsTestSuite, BinaryToJsonTest) {
+    {
+        char bin[3]= {1,2,3};
+        json_auto_t* json = nullptr;
+        auto status = celix_utils_binaryToJson(bin, sizeof(bin), &json);
+        ASSERT_EQ(CELIX_SUCCESS, status);
+        ASSERT_TRUE(json != nullptr);
+        ASSERT_STREQ("base64<AQID>", json_string_value(json));
+    }
+
+    {
+        char bin[2]= {1,2};
+        json_auto_t* json = nullptr;
+        auto status = celix_utils_binaryToJson(bin, sizeof(bin), &json);
+        ASSERT_EQ(CELIX_SUCCESS, status);
+        ASSERT_TRUE(json != nullptr);
+        ASSERT_STREQ("base64<AQI=>", json_string_value(json));
+    }
+
+    {
+        char bin[1]= {1};
+        json_auto_t* json = nullptr;
+        auto status = celix_utils_binaryToJson(bin, sizeof(bin), &json);
+        ASSERT_EQ(CELIX_SUCCESS, status);
+        ASSERT_TRUE(json != nullptr);
+        ASSERT_STREQ("base64<AQ==>", json_string_value(json));
+    }
+
+    {
+        char bin[1];
+        json_auto_t* json = nullptr;
+        auto status = celix_utils_binaryToJson(bin, std::numeric_limits<int>::max(), &json);
+        ASSERT_EQ(ENOMEM, status);
+        ASSERT_EQ(nullptr, json);
+    }
+}
+
+TEST_F(CelixJsonUtilsTestSuite, JsonToBinaryTest) {
+    {
+        json_auto_t* json = json_string("base64<AQID>");
+        celix_autofree void* data = nullptr;
+        size_t size = 0;
+        auto status = celix_utils_jsonToBinary(json, &data, &size);
+        ASSERT_EQ(CELIX_SUCCESS, status);
+        ASSERT_TRUE(data != nullptr);
+        ASSERT_EQ(3, size);
+        char* bin = (char*)data;
+        ASSERT_EQ(1, bin[0]);
+        ASSERT_EQ(2, bin[1]);
+        ASSERT_EQ(3, bin[2]);
+    }
+
+    {
+        json_auto_t* json = json_string("base64<AQI=>");
+        celix_autofree void* data = nullptr;
+        size_t size = 0;
+        auto status = celix_utils_jsonToBinary(json, &data, &size);
+        ASSERT_EQ(CELIX_SUCCESS, status);
+        ASSERT_TRUE(data != nullptr);
+        ASSERT_EQ(2, size);
+        char* bin = (char*)data;
+        ASSERT_EQ(1, bin[0]);
+        ASSERT_EQ(2, bin[1]);
+    }
+
+    {
+        json_auto_t* json = json_string("base64<AQ==>");
+        celix_autofree void* data = nullptr;
+        size_t size = 0;
+        auto status = celix_utils_jsonToBinary(json, &data, &size);
+        ASSERT_EQ(CELIX_SUCCESS, status);
+        ASSERT_TRUE(data != nullptr);
+        ASSERT_EQ(1, size);
+        char* bin = (char*)data;
+        ASSERT_EQ(1, bin[0]);
+    }
+}
+
+TEST_F(CelixJsonUtilsTestSuite, WrongBinaryJsonToBinaryTest) {
+    {
+        json_auto_t* json = json_string("base64<Invalid>");
+        celix_autofree void* data = nullptr;
+        size_t size = 0;
+        auto status = celix_utils_jsonToBinary(json, &data, &size);
+        ASSERT_EQ(CELIX_ILLEGAL_ARGUMENT, status);
+        ASSERT_TRUE(data == nullptr);
+    }
+
+    {
+        json_auto_t* json = json_string("base64<AQID");
+        celix_autofree void* data = nullptr;
+        size_t size = 0;
+        auto status = celix_utils_jsonToBinary(json, &data, &size);
+        ASSERT_EQ(CELIX_ILLEGAL_ARGUMENT, status);
+        ASSERT_TRUE(data == nullptr);
+    }
+
+    {
+        json_auto_t* json = json_string("base64<>");
+        celix_autofree void* data = nullptr;
+        size_t size = 0;
+        auto status = celix_utils_jsonToBinary(json, &data, &size);
+        ASSERT_EQ(CELIX_ILLEGAL_ARGUMENT, status);
+        ASSERT_TRUE(data == nullptr);
+    }
+}
+
+TEST_F(CelixJsonUtilsTestSuite, InvalidBinaryJsonTest) {
+    {
+        json_auto_t* json = json_string("base64<AQID");
+        auto result = celix_utils_isBinaryJsonString(json);
+        ASSERT_FALSE(result);
+    }
+
+    {
+        json_auto_t* json = json_string("base64AQID>");
+        auto result = celix_utils_isBinaryJsonString(json);
+        ASSERT_FALSE(result);
+    }
+
+    {
+        json_auto_t* json = json_integer(1);
+        auto result = celix_utils_isBinaryJsonString(json);
+        ASSERT_FALSE(result);
+    }
+}

--- a/libs/utils/gtest/src/ConvertUtilsErrorInjectionTestSuite.cc
+++ b/libs/utils/gtest/src/ConvertUtilsErrorInjectionTestSuite.cc
@@ -23,7 +23,10 @@
 #include "celix_convert_utils.h"
 #include "celix_version_ei.h"
 #include "stdio_ei.h"
+#include "malloc_ei.h"
+#include "openssl_ei.h"
 #include "celix_err.h"
+#include "celix_stdlib_cleanup.h"
 
 class ConvertUtilsWithErrorInjectionTestSuite : public ::testing::Test {
 public:
@@ -37,6 +40,8 @@ public:
         celix_ei_expect_open_memstream(nullptr, 0, nullptr);
         celix_ei_expect_fputs(nullptr, 0, 0);
         celix_ei_expect_fputc(nullptr, 0, 0);
+        celix_ei_expect_malloc(nullptr, 0, nullptr);
+        celix_ei_expect_EVP_EncodeBlock(nullptr, 0, 0);
 
         celix_err_printErrors(stderr, nullptr, nullptr);
     }
@@ -177,4 +182,46 @@ TEST_F(ConvertUtilsWithErrorInjectionTestSuite, StringArrayToStringTest) {
     result = celix_utils_arrayListToString(list);
     //Then the result is null
     EXPECT_EQ(nullptr, result);
+}
+
+TEST_F(ConvertUtilsWithErrorInjectionTestSuite, AllocMemoryErrorWhenConvertingBinaryToStringTest) {
+    celix_ei_expect_malloc((void*)&celix_utils_binaryToBase64String, 0, nullptr);
+    char bin[3]= {1,2,3};
+    char* base64 =  celix_utils_binaryToBase64String(bin, sizeof(bin));
+    ASSERT_EQ(nullptr, base64);
+}
+
+TEST_F(ConvertUtilsWithErrorInjectionTestSuite, EncodeBase64ErrorWhenConvertingBinaryToStringTest) {
+    celix_ei_expect_EVP_EncodeBlock((void*)&celix_utils_binaryToBase64String, 0, -1);
+    char bin[3]= {1,2,3};
+    char* base64 =  celix_utils_binaryToBase64String(bin, sizeof(bin));
+    ASSERT_EQ(nullptr, base64);
+}
+
+TEST_F(ConvertUtilsWithErrorInjectionTestSuite, EncodedBase64LenErrorWhenConvertingBinaryToStringTest) {
+    char bin[3]= {1,2,3};
+    celix_ei_expect_EVP_EncodeBlock((void*)&celix_utils_binaryToBase64String, 0, sizeof(bin)/3 * 4 + 1);
+    char* base64 =  celix_utils_binaryToBase64String(bin, sizeof(bin));
+    ASSERT_EQ(nullptr, base64);
+}
+
+TEST_F(ConvertUtilsWithErrorInjectionTestSuite, AllocMemoryErrorWhenConvertingStringToBinaryTest) {
+    char bin[3]= {1, 2, 3};
+    celix_autofree char* base64String = celix_utils_binaryToBase64String(bin, sizeof(bin));
+    celix_autofree void* data = nullptr;
+    size_t size = 0;
+    celix_ei_expect_malloc((void*)&celix_utils_convertBase64StringToBinary, 0, nullptr);
+    auto status = celix_utils_convertBase64StringToBinary(base64String,  0, nullptr, &size, &data);
+    ASSERT_EQ(ENOMEM, status);
+    ASSERT_EQ(nullptr, data);
+}
+
+TEST_F(ConvertUtilsWithErrorInjectionTestSuite, AllocMemoryErrorForDeafultValueWhenConvertingStringToBinaryTest) {
+    char bin[3]= {1, 2, 3};
+    celix_autofree void* data = nullptr;
+    size_t size = 0;
+    celix_ei_expect_malloc((void*)&celix_utils_convertBase64StringToBinary, 0, nullptr);
+    auto status = celix_utils_convertBase64StringToBinary(nullptr,  sizeof(bin), bin, &size, &data);
+    ASSERT_EQ(ENOMEM, status);
+    ASSERT_EQ(nullptr, data);
 }

--- a/libs/utils/gtest/src/ConvertUtilsTestSuite.cc
+++ b/libs/utils/gtest/src/ConvertUtilsTestSuite.cc
@@ -23,8 +23,10 @@
 
 #include <string>
 #include <cmath>
+#include <limits>
 
 #include "celix_err.h"
+#include "celix_stdlib_cleanup.h"
 
 class ConvertUtilsTestSuite : public ::testing::Test {
   public:
@@ -574,4 +576,114 @@ TEST_F(ConvertUtilsTestSuite, InvalidArgumentsForArrayToStringTest) {
     EXPECT_EQ(nullptr, celix_utils_arrayListToString(list1));
     celix_autoptr(celix_array_list_t) list2 = celix_arrayList_createPointerArray(); //unsupported pointer type
     EXPECT_EQ(nullptr, celix_utils_arrayListToString(list2));
+}
+
+TEST_F(ConvertUtilsTestSuite, BinaryToStringTest) {
+    {
+        char bin[3]= {0};
+        celix_autofree char* base64String = celix_utils_binaryToBase64String(bin, sizeof(bin));
+        ASSERT_TRUE(base64String != nullptr);
+        ASSERT_STREQ("AAAA", base64String);
+    }
+
+    {
+        char bin[2]= {0};
+        celix_autofree char* base64String = celix_utils_binaryToBase64String(bin, sizeof(bin));
+        ASSERT_TRUE(base64String != nullptr);
+        ASSERT_STREQ("AAA=", base64String);
+    }
+
+    {
+        char bin[1]= {0};
+        celix_autofree char* base64String = celix_utils_binaryToBase64String(bin, sizeof(bin));
+        ASSERT_TRUE(base64String != nullptr);
+        ASSERT_STREQ("AA==", base64String);
+    }
+}
+
+TEST_F(ConvertUtilsTestSuite, InvalidArgsForBinaryToStringTest) {
+    char bin[3]= {0};
+    EXPECT_EQ(nullptr,celix_utils_binaryToBase64String(nullptr, sizeof(bin)));
+    EXPECT_EQ(nullptr,celix_utils_binaryToBase64String(bin, 0));
+    EXPECT_EQ(nullptr,celix_utils_binaryToBase64String(bin, std::numeric_limits<int>::max()));
+}
+
+TEST_F(ConvertUtilsTestSuite, ConvertStringToBinaryTest) {
+    {
+        char bin[3]= {1, 2, 3};
+        celix_autofree char* base64String = celix_utils_binaryToBase64String(bin, sizeof(bin));
+        celix_autofree void* data = nullptr;
+        size_t size = 0;
+        auto status = celix_utils_convertBase64StringToBinary(base64String,  0, nullptr, &size, &data);
+        ASSERT_EQ(CELIX_SUCCESS, status);
+        ASSERT_TRUE(data != nullptr);
+        ASSERT_EQ(sizeof(bin), size);
+        ASSERT_EQ(0, memcmp(bin, data, size));
+    }
+
+    {
+        char bin[2]= {1, 2};
+        celix_autofree char* base64String = celix_utils_binaryToBase64String(bin, sizeof(bin));
+        celix_autofree void* data = nullptr;
+        size_t size = 0;
+        auto status = celix_utils_convertBase64StringToBinary(base64String,  0, nullptr, &size, &data);
+        ASSERT_EQ(CELIX_SUCCESS, status);
+        ASSERT_TRUE(data != nullptr);
+        ASSERT_EQ(sizeof(bin), size);
+        ASSERT_EQ(0, memcmp(bin, data, size));
+    }
+
+    {
+        char bin[1]= {1};
+        celix_autofree char* base64String = celix_utils_binaryToBase64String(bin, sizeof(bin));
+        celix_autofree void* data = nullptr;
+        size_t size = 0;
+        auto status = celix_utils_convertBase64StringToBinary(base64String,  0, nullptr, &size, &data);
+        ASSERT_EQ(CELIX_SUCCESS, status);
+        ASSERT_TRUE(data != nullptr);
+        ASSERT_EQ(sizeof(bin), size);
+        ASSERT_EQ(0, memcmp(bin, data, size));
+    }
+}
+
+TEST_F(ConvertUtilsTestSuite, WrongBase64StringToBinaryTest) {
+    celix_autofree void* data = nullptr;
+    size_t size = 0;
+    auto status = celix_utils_convertBase64StringToBinary("invalid",  0, nullptr, &size, &data);
+    ASSERT_EQ(CELIX_ILLEGAL_ARGUMENT, status);
+    ASSERT_EQ(nullptr, data);
+
+    char bin[3]= {1, 2, 3};
+    status = celix_utils_convertBase64StringToBinary("invalid",  sizeof(bin), bin, &size, &data);
+    ASSERT_EQ(CELIX_ILLEGAL_ARGUMENT, status);
+    ASSERT_NE(nullptr, data);
+    ASSERT_EQ(sizeof(bin), size);
+    ASSERT_EQ(0, memcmp(bin, data, size));
+}
+
+TEST_F(ConvertUtilsTestSuite, InvalidArgsForBase64StringToBinaryTest) {
+    celix_autofree void* data = nullptr;
+    size_t size = 0;
+    auto status = celix_utils_convertBase64StringToBinary(nullptr,  0, nullptr, &size, &data);
+    ASSERT_EQ(CELIX_ILLEGAL_ARGUMENT, status);
+    ASSERT_EQ(nullptr, data);
+
+    celix_autofree void* data1 = nullptr;
+    char bin[3]= {1, 2, 3};
+    status = celix_utils_convertBase64StringToBinary(nullptr,  sizeof(bin), bin, &size, &data1);
+    ASSERT_EQ(CELIX_ILLEGAL_ARGUMENT, status);
+    ASSERT_NE(nullptr, data1);
+    ASSERT_EQ(sizeof(bin), size);
+    ASSERT_EQ(0, memcmp(bin, data1, size));
+
+    status = celix_utils_convertBase64StringToBinary("",  0, nullptr, &size, &data);
+    ASSERT_EQ(CELIX_ILLEGAL_ARGUMENT, status);
+    ASSERT_EQ(nullptr, data);
+
+    celix_autofree void* data2 = nullptr;
+    status = celix_utils_convertBase64StringToBinary("",  sizeof(bin), bin, &size, &data2);
+    ASSERT_EQ(CELIX_ILLEGAL_ARGUMENT, status);
+    ASSERT_NE(nullptr, data2);
+    ASSERT_EQ(sizeof(bin), size);
+    ASSERT_EQ(0, memcmp(bin, data2, size));
 }

--- a/libs/utils/gtest/src/PropertiesEncodingErrorInjectionTestSuite.cc
+++ b/libs/utils/gtest/src/PropertiesEncodingErrorInjectionTestSuite.cc
@@ -29,6 +29,7 @@
 #include "jansson_ei.h"
 #include "malloc_ei.h"
 #include "stdio_ei.h"
+#include "celix_string_hash_map_ei.h"
 
 class PropertiesEncodingErrorInjectionTestSuite : public ::testing::Test {
   public:
@@ -44,6 +45,7 @@ class PropertiesEncodingErrorInjectionTestSuite : public ::testing::Test {
         celix_ei_expect_malloc(nullptr, 0, nullptr);
         celix_ei_expect_celix_arrayList_createWithOptions(nullptr, 0, nullptr);
         celix_ei_expect_celix_arrayList_addString(nullptr, 0, CELIX_SUCCESS);
+        celix_ei_expect_celix_stringHashMap_put(nullptr, 0, 0);
         celix_err_resetErrors();
     }
 };
@@ -210,6 +212,18 @@ TEST_F(PropertiesEncodingErrorInjectionTestSuite, EncodeVersionErrorTest) {
     celix_err_printErrors(stderr, "Test Error: ", "\n");
 }
 
+TEST_F(PropertiesEncodingErrorInjectionTestSuite, EncodeBinaryErrorTest) {
+    celix_autoptr(celix_properties_t) props = celix_properties_create();
+    char bin[1]={0};
+    celix_properties_setBinary(props, "key", bin, sizeof(bin));
+    celix_ei_expect_json_sprintf((void*)celix_properties_saveToString, 4, nullptr);
+    char* out;
+    auto status = celix_properties_saveToString(props, 0, &out);
+    EXPECT_EQ(ENOMEM, status);
+    EXPECT_EQ(1, celix_err_getErrorCount());
+    celix_err_printErrors(stderr, "Test Error: ", "\n");
+}
+
 TEST_F(PropertiesEncodingErrorInjectionTestSuite, EncodeDumpfErrorTest) {
     // Given a dummy properties object
     celix_autoptr(celix_properties_t) props = celix_properties_create();
@@ -313,6 +327,16 @@ TEST_F(PropertiesEncodingErrorInjectionTestSuite, DecodeVersionErrorTest) {
     // And I expect 1 error message in celix_err
     EXPECT_EQ(1, celix_err_getErrorCount());
     celix_err_printErrors(stderr, "Test Error: ", "\n");
+}
+
+TEST_F(PropertiesEncodingErrorInjectionTestSuite, DecodeBinaryErrorTest) {
+    const char* json = R"({"key":"base64<AA==>"})";
+
+    celix_ei_expect_celix_stringHashMap_put((void*)celix_properties_loadFromString, 5, ENOMEM);
+
+    celix_properties_t* props;
+    auto status = celix_properties_loadFromString(json, 0, &props);
+    EXPECT_EQ(ENOMEM, status);
 }
 
 TEST_F(PropertiesEncodingErrorInjectionTestSuite, SaveCxxPropertiesErrorTest) {

--- a/libs/utils/gtest/src/PropertiesEncodingTestSuite.cc
+++ b/libs/utils/gtest/src/PropertiesEncodingTestSuite.cc
@@ -60,6 +60,8 @@ TEST_F(PropertiesSerializationTestSuite, SavePropertiesWithSingleValuesTest) {
         celix_properties_setDouble(props, "key4", 4.0);
         celix_properties_setBool(props, "key5", true);
         celix_properties_assignVersion(props, "key6", celix_version_create(1, 2, 3, "qualifier"));
+        char bin[1]={0};
+        celix_properties_setBinary(props, "key7", bin, sizeof(bin));
 
         //And an in-memory stream
         celix_autofree char* buf = nullptr;
@@ -78,6 +80,7 @@ TEST_F(PropertiesSerializationTestSuite, SavePropertiesWithSingleValuesTest) {
         EXPECT_NE(nullptr, strstr(buf, R"("key4":4.0)")) << "JSON: " << buf;
         EXPECT_NE(nullptr, strstr(buf, R"("key5":true)")) << "JSON: " << buf;
         EXPECT_NE(nullptr, strstr(buf, R"("key6":"version<1.2.3.qualifier>")")) << "JSON: " << buf;
+        EXPECT_NE(nullptr, strstr(buf, R"("key7":"base64<AA==>")")) << "JSON: " << buf;
 
         //And the buf is a valid JSON object
         json_error_t error;
@@ -538,7 +541,8 @@ TEST_F(PropertiesSerializationTestSuite, LoadPropertiesWithSingleValuesTest) {
         "longKey":42,
         "doubleKey":2.0,
         "boolKey":true,
-        "versionKey":"version<1.2.3.qualifier>"
+        "versionKey":"version<1.2.3.qualifier>",
+        "binKey":"base64<AA==>"
     })";
 
     //And a stream with the JSON object
@@ -550,7 +554,7 @@ TEST_F(PropertiesSerializationTestSuite, LoadPropertiesWithSingleValuesTest) {
     ASSERT_EQ(CELIX_SUCCESS, status);
 
     //Then the properties object contains the single values
-    EXPECT_EQ(5, celix_properties_size(props));
+    EXPECT_EQ(6, celix_properties_size(props));
     EXPECT_STREQ("strValue", celix_properties_getString(props, "strKey"));
     EXPECT_EQ(42, celix_properties_getLong(props, "longKey", -1));
     EXPECT_DOUBLE_EQ(2.0, celix_properties_getDouble(props, "doubleKey", NAN));
@@ -559,6 +563,11 @@ TEST_F(PropertiesSerializationTestSuite, LoadPropertiesWithSingleValuesTest) {
     ASSERT_NE(nullptr, v);
     celix_autofree char* vStr = celix_version_toString(v);
     EXPECT_STREQ("1.2.3.qualifier", vStr);
+    size_t binSize = 0;
+    const void* bin = celix_properties_getBinary(props, "binKey", &binSize);
+    ASSERT_NE(nullptr, bin);
+    EXPECT_EQ(1, binSize);
+    EXPECT_EQ(0, static_cast<const unsigned char *>(bin)[0]);
 }
 
 TEST_F(PropertiesSerializationTestSuite, LoadPropertiesWithArrayListsTest) {
@@ -1134,4 +1143,16 @@ TEST_F(PropertiesSerializationTestSuite, KeyCollision) {
     EXPECT_STREQ(R"({"a":{"b":{"c":"value1"}}})", output);
     std::cout << output << std::endl;
     EXPECT_EQ(CELIX_SUCCESS, status);
+}
+
+TEST_F(PropertiesSerializationTestSuite, LoadPropertiesWithInvalidBinaryValueTest) {
+    const char* jsonInput = R"({
+        "strKey":"strValue",
+        "longKey":42,
+        "binKey":"base64<invalid>"
+    })";
+    celix_properties_t* props = nullptr;
+    auto status = celix_properties_loadFromString(jsonInput, 0, &props);
+    ASSERT_EQ(CELIX_ILLEGAL_ARGUMENT, status);
+    ASSERT_EQ(nullptr, props);
 }

--- a/libs/utils/gtest/src/PropertiesErrorInjectionTestSuite.cc
+++ b/libs/utils/gtest/src/PropertiesErrorInjectionTestSuite.cc
@@ -343,3 +343,13 @@ TEST_F(PropertiesErrorInjectionTestSuite, SetVersionFailureTest) {
     ASSERT_EQ(1, celix_err_getErrorCount());
     celix_err_resetErrors();
 }
+
+TEST_F(PropertiesErrorInjectionTestSuite, SetBinaryFailureTest) {
+    celix_autoptr(celix_properties_t) props = celix_properties_create();
+    celix_ei_expect_malloc((void*)celix_properties_setBinary, 0, nullptr);
+    char bin[2] = {1,1};
+    auto status = celix_properties_setBinary(props, "key", bin, sizeof(bin));
+    ASSERT_EQ(status, CELIX_ENOMEM);
+    ASSERT_EQ(1, celix_err_getErrorCount());
+    celix_err_resetErrors();
+}

--- a/libs/utils/gtest/src/PropertiesTestSuite.cc
+++ b/libs/utils/gtest/src/PropertiesTestSuite.cc
@@ -275,6 +275,12 @@ TEST_F(PropertiesTestSuite, GetSetOverwrite) {
     EXPECT_EQ(false, celix_properties_getAsBool(props, "key", true));
     EXPECT_EQ(CELIX_SUCCESS, celix_properties_assignVersion(props, "key", version));
     EXPECT_EQ(version, celix_properties_getVersion(props, "key"));
+    char bin[3] = {0};
+    EXPECT_EQ(CELIX_SUCCESS, celix_properties_setBinary(props, "key", bin, sizeof(bin)));
+    size_t binarySize = 0;
+    const void* binaryData = celix_properties_getBinary(props, "key", &binarySize);
+    EXPECT_EQ(sizeof(bin), binarySize);
+    EXPECT_EQ(0, memcmp(bin, binaryData, sizeof(bin)));
     celix_properties_set(props, "key", "last");
 
     celix_properties_destroy(props);
@@ -315,8 +321,10 @@ TEST_F(PropertiesTestSuite, GetTypeAndCopyTest) {
     celix_arrayList_addLong(longList, 2);
     celix_arrayList_addLong(longList, 3);
     celix_properties_setArrayList(props, "array", longList);
+    char bin[1] = {0};
+    celix_properties_setBinary(props, "binary", bin, sizeof(bin));
 
-    EXPECT_EQ(6, celix_properties_size(props));
+    EXPECT_EQ(7, celix_properties_size(props));
     EXPECT_EQ(CELIX_PROPERTIES_VALUE_TYPE_STRING, celix_properties_getType(props, "string"));
     EXPECT_EQ(CELIX_PROPERTIES_VALUE_TYPE_LONG, celix_properties_getType(props, "long"));
     EXPECT_EQ(CELIX_PROPERTIES_VALUE_TYPE_DOUBLE, celix_properties_getType(props, "double"));
@@ -325,9 +333,14 @@ TEST_F(PropertiesTestSuite, GetTypeAndCopyTest) {
     EXPECT_EQ(CELIX_PROPERTIES_VALUE_TYPE_UNSET, celix_properties_getType(props, "missing"));
     EXPECT_EQ(CELIX_PROPERTIES_VALUE_TYPE_ARRAY_LIST, celix_properties_getType(props, "array"));
     EXPECT_TRUE(celix_arrayList_equals(longList, celix_properties_getArrayList(props, "array")));
+    EXPECT_EQ(CELIX_PROPERTIES_VALUE_TYPE_BINARY, celix_properties_getType(props, "binary"));
+    size_t binarySize = 0;
+    const void* binaryData = celix_properties_getBinary(props, "binary", &binarySize);
+    EXPECT_EQ(sizeof(bin), binarySize);
+    EXPECT_EQ(0, memcmp(bin, binaryData, sizeof(bin)));
 
     auto* copy = celix_properties_copy(props);
-    EXPECT_EQ(6, celix_properties_size(copy));
+    EXPECT_EQ(7, celix_properties_size(copy));
     EXPECT_EQ(CELIX_PROPERTIES_VALUE_TYPE_STRING, celix_properties_getType(copy, "string"));
     EXPECT_EQ(CELIX_PROPERTIES_VALUE_TYPE_LONG, celix_properties_getType(copy, "long"));
     EXPECT_EQ(CELIX_PROPERTIES_VALUE_TYPE_DOUBLE, celix_properties_getType(copy, "double"));
@@ -335,6 +348,11 @@ TEST_F(PropertiesTestSuite, GetTypeAndCopyTest) {
     EXPECT_EQ(CELIX_PROPERTIES_VALUE_TYPE_VERSION, celix_properties_getType(copy, "version"));
     EXPECT_EQ(CELIX_PROPERTIES_VALUE_TYPE_ARRAY_LIST, celix_properties_getType(copy, "array"));
     EXPECT_TRUE(celix_arrayList_equals(longList, celix_properties_getArrayList(copy, "array")));
+    EXPECT_EQ(CELIX_PROPERTIES_VALUE_TYPE_BINARY, celix_properties_getType(copy, "binary"));
+    size_t copyBinarySize = 0;
+    const void* copyBinaryData = celix_properties_getBinary(copy, "binary", &copyBinarySize);
+    EXPECT_EQ(sizeof(bin), copyBinarySize);
+    EXPECT_EQ(0, memcmp(bin, copyBinaryData, sizeof(bin)));
 
     celix_version_destroy(version);
     celix_properties_destroy(props);
@@ -349,6 +367,8 @@ TEST_F(PropertiesTestSuite, GetEntryTest) {
     celix_properties_setBool(props, "key4", true);
     auto* version = celix_version_create(1, 2, 3, nullptr);
     celix_properties_setVersion(props, "key5", version);
+    char bin[2] = {0};
+    celix_properties_setBinary(props, "key6", bin, sizeof(bin));
 
     auto* entry = celix_properties_getEntry(props, "key1");
     EXPECT_EQ(CELIX_PROPERTIES_VALUE_TYPE_STRING, entry->valueType);
@@ -378,6 +398,13 @@ TEST_F(PropertiesTestSuite, GetEntryTest) {
     EXPECT_EQ(3, celix_version_getMicro(entry->typed.versionValue));
 
     entry = celix_properties_getEntry(props, "key6");
+    EXPECT_EQ(CELIX_PROPERTIES_VALUE_TYPE_BINARY, entry->valueType);
+    size_t binarySize = 0;
+    const void* binaryData = celix_properties_getBinary(props, "key6", &binarySize);
+    EXPECT_EQ(sizeof(bin), binarySize);
+    EXPECT_EQ(0, memcmp(bin, binaryData, sizeof(bin)));
+
+    entry = celix_properties_getEntry(props, "key7");
     EXPECT_EQ(nullptr, entry);
 
     celix_version_destroy(version);
@@ -565,19 +592,22 @@ TEST_F(PropertiesTestSuite, SetEntryTest) {
     celix_arrayList_addLong(longList, 2);
     celix_arrayList_addLong(longList, 3);
     celix_properties_setArrayList(props1, "key6", longList);
+    char bin[3] = {0};
+    celix_properties_setBinary(props1, "key7", bin, sizeof(bin));
 
     CELIX_PROPERTIES_ITERATE(props1, visit) {
         celix_properties_setEntry(props2, visit.key, &visit.entry);
         celix_properties_setEntry(nullptr, visit.key, &visit.entry);
     }
-    celix_properties_setEntry(props2, "key7", nullptr);
-    EXPECT_EQ(6, celix_properties_size(props2));
+    celix_properties_setEntry(props2, "key8", nullptr);
+    EXPECT_EQ(7, celix_properties_size(props2));
     EXPECT_STREQ("value1", celix_properties_getAsString(props2, "key1", nullptr));
     EXPECT_EQ(123, celix_properties_getAsLong(props2, "key2", -1L));
     EXPECT_EQ(true, celix_properties_getAsBool(props2, "key3", false));
     EXPECT_EQ(3.14, celix_properties_getAsDouble(props2, "key4", -1.0));
     EXPECT_EQ(CELIX_PROPERTIES_VALUE_TYPE_VERSION, celix_properties_getType(props2, "key5"));
     EXPECT_EQ(CELIX_PROPERTIES_VALUE_TYPE_ARRAY_LIST, celix_properties_getType(props2, "key6"));
+    EXPECT_EQ(CELIX_PROPERTIES_VALUE_TYPE_BINARY, celix_properties_getType(props2, "key7"));
     EXPECT_TRUE(celix_properties_equals(props1, props2));
 
     celix_properties_destroy(props1);
@@ -650,6 +680,10 @@ TEST_F(PropertiesTestSuite, PropertiesNullArgumentsTest) {
     EXPECT_EQ(CELIX_SUCCESS, celix_properties_assignVersion(nullptr, "key", celix_version_copy(version)));
     EXPECT_EQ(CELIX_SUCCESS, celix_properties_setArrayList(nullptr, "key", list));
     EXPECT_EQ(CELIX_SUCCESS, celix_properties_assignArrayList(nullptr, "key", celix_arrayList_copy(list)));
+    char bin[1] = {0};
+    EXPECT_EQ(CELIX_SUCCESS, celix_properties_setBinary(nullptr, "key", bin, sizeof(bin)));
+    void *bin2 = malloc(1);
+    EXPECT_EQ(CELIX_SUCCESS, celix_properties_assignBinary(nullptr, "key", bin2, 1));
     celix_autoptr(celix_properties_t) copy = celix_properties_copy(nullptr);
     EXPECT_NE(nullptr, copy);
 }
@@ -687,6 +721,16 @@ TEST_F(PropertiesTestSuite, InvalidArgumentsTest) {
     EXPECT_EQ(CELIX_ILLEGAL_ARGUMENT, celix_properties_assignArrayList(props, "list", nullptr));
     EXPECT_EQ(CELIX_ILLEGAL_ARGUMENT, celix_properties_assignArrayList(props, "list", celix_steal_ptr(list1)));
     EXPECT_EQ(CELIX_ILLEGAL_ARGUMENT, celix_properties_assignArrayList(props, "list", celix_steal_ptr(list3)));
+
+    char bin[1] = {0};
+    EXPECT_EQ(CELIX_ILLEGAL_ARGUMENT, celix_properties_setBinary(props, nullptr, bin, sizeof(bin)));
+    EXPECT_EQ(CELIX_ILLEGAL_ARGUMENT, celix_properties_setBinary(props, "version", nullptr, sizeof(bin)));
+    EXPECT_EQ(CELIX_ILLEGAL_ARGUMENT, celix_properties_setBinary(props, "version", bin, 0));
+    void *bin2 = malloc(1);
+    EXPECT_EQ(CELIX_ILLEGAL_ARGUMENT, celix_properties_assignBinary(props, nullptr, bin2, 1));
+    EXPECT_EQ(CELIX_ILLEGAL_ARGUMENT, celix_properties_assignBinary(props, "version", nullptr, 1));
+    void *bin3 = malloc(1);
+    EXPECT_EQ(CELIX_ILLEGAL_ARGUMENT, celix_properties_assignBinary(props, "version", bin3, 0));
 }
 
 TEST_F(PropertiesTestSuite, GetStatsTest) {
@@ -951,4 +995,50 @@ TEST_F(PropertiesTestSuite, EmptyStringKeyTest) {
     celix_properties_set(props, "", "value"); // "" is a valid key (nullptr is not)
     EXPECT_EQ(1, celix_properties_size(props));
     EXPECT_STREQ("value", celix_properties_getString(props, ""));
+}
+
+TEST_F(PropertiesTestSuite, BinaryPropertiesEqualsTest) {
+    celix_autoptr(celix_properties_t) prop1 = celix_properties_create();
+    celix_autoptr(celix_properties_t) prop2 = celix_properties_create();
+    EXPECT_TRUE(celix_properties_equals(prop1, prop2));
+
+    char bin1[2] = {1,1};
+    char bin2[2] = {1,1};
+    EXPECT_EQ(CELIX_SUCCESS, celix_properties_setBinary(prop1, "key", bin1, sizeof(bin1)));
+    EXPECT_EQ(CELIX_SUCCESS, celix_properties_setBinary(prop2, "key", bin2, sizeof(bin2)));
+    EXPECT_TRUE(celix_properties_equals(prop1, prop2));
+
+    char bin3[2] = {1,2};
+    EXPECT_EQ(CELIX_SUCCESS, celix_properties_setBinary(prop2, "key", bin3, sizeof(bin3)));
+    EXPECT_FALSE(celix_properties_equals(prop1, prop2));
+
+    EXPECT_EQ(CELIX_SUCCESS, celix_properties_setBinary(prop1, "key", bin3, sizeof(bin3)));
+    EXPECT_TRUE(celix_properties_equals(prop1, prop2));
+
+    char bin4[3] = {1, 2, 3};
+    EXPECT_EQ(CELIX_SUCCESS, celix_properties_setBinary(prop2, "key", bin4, sizeof(bin4)));
+    EXPECT_FALSE(celix_properties_equals(prop1, prop2));
+}
+
+TEST_F(PropertiesTestSuite, GetBinaryTest) {
+    celix_autoptr(celix_properties_t) props = celix_properties_create();
+    char bin[2] = {1,1};
+    EXPECT_EQ(CELIX_SUCCESS, celix_properties_setBinary(props, "key", bin, sizeof(bin)));
+    EXPECT_EQ(1, celix_properties_size(props));
+
+    size_t outSize;
+    const void* outBin = celix_properties_getBinary(props, "key", &outSize);
+    EXPECT_EQ(sizeof(bin), outSize);
+    EXPECT_EQ(0, memcmp(bin, outBin, sizeof(bin)));
+    EXPECT_NE(nullptr, celix_properties_getBinary(props, "key", nullptr));
+
+    EXPECT_EQ(nullptr, celix_properties_getBinary(props, "non-existing", nullptr));
+    EXPECT_EQ(nullptr, celix_properties_getBinary(props, "non-existing", &outSize));
+    EXPECT_EQ(0, outSize);
+
+    celix_properties_unset(props, "key");
+    EXPECT_EQ(nullptr, celix_properties_getBinary(props, "key", &outSize));
+
+    celix_properties_setLong(props, "longKey", 42);
+    EXPECT_EQ(nullptr, celix_properties_getBinary(props, "longKey", &outSize));
 }

--- a/libs/utils/include/celix_convert_utils.h
+++ b/libs/utils/include/celix_convert_utils.h
@@ -221,7 +221,39 @@ celix_status_t celix_utils_convertStringToVersionArrayList(const char* val,
 CELIX_UTILS_EXPORT
 char* celix_utils_arrayListToString(const celix_array_list_t* list);
 
+/**
+ * @brief Convert binary data to a base64 encoded string.
+ *
+ * In case of an error, an error message is added to celix_err.
+ *
+ * @param[in] data The binary data to convert.
+ * @param[in] size The size of the binary data.
+ * @return The base64 encoded string. The returned string is allocated and should be freed.
+ * @returnvalue NULL if the data is NULL or if the size is 0 or if memory could not be allocated.
+ */
+CELIX_UTILS_EXPORT
+char* celix_utils_binaryToBase64String(const void* data, size_t size);
 
+/**
+ * @brief Convert a base64 encoded string to binary data.
+ *
+ * In case of an error, an error message is added to celix_err.
+ *
+ * @param[in] val The base64 encoded string to convert.
+ * @param[in] defaultSize The default size if the string is not a valid base64 encoded string.
+ * @param[in] defaultVal The default value if the string is not a valid base64 encoded string. The default value is expected
+ *                       to be of size defaultSize. Note that the defaultVal is copied if the string is not a valid
+ *                       base64 encoded string.
+ * @param[out] size The size of the converted binary data. If the string is not a valid base64 encoded string, the size will
+ *                  be set to defaultSize. Must be not NULL.
+ * @param[out] bin The converted binary data. If the string is not a valid base64 encoded string, the bin will be set to a
+ *                 copy of defaultVal. The returned binary data should be freed by the caller. Must be not NULL.
+ * @return CELIX_SUCCESS if the string is a valid base64 encoded string, CELIX_ILLEGAL_ARGUMENT if the string is not a
+ * valid base64 encoded string and CELIX_ENOMEM if memory could not be allocated. Note that on a CELIX_ILLEGAL_ARGUMENT
+ * the bin will be set to a copy of defaultVal and size will be set to defaultSize.
+ */
+CELIX_UTILS_EXPORT
+celix_status_t celix_utils_convertBase64StringToBinary(const char* val, size_t defaultSize, const void* defaultVal, size_t* size, void** bin);
 
 #ifdef __cplusplus
 }

--- a/libs/utils/include/celix_properties.h
+++ b/libs/utils/include/celix_properties.h
@@ -33,6 +33,7 @@
  *  - double
  *  - bool
  *  - celix_version_t*
+ *  - binary data
  */
 
 #ifndef CELIX_PROPERTIES_H_
@@ -67,6 +68,7 @@ typedef enum celix_properties_value_type {
               CELIX_ARRAY_LIST_ELEMENT_TYPE_STRING, CELIX_ARRAY_LIST_ELEMENT_TYPE_LONG,
               CELIX_ARRAY_LIST_ELEMENT_TYPE_DOUBLE, CELIX_ARRAY_LIST_ELEMENT_TYPE_BOOL or
               CELIX_ARRAY_LIST_ELEMENT_TYPE_VERSION. */
+    CELIX_PROPERTIES_VALUE_TYPE_BINARY = 7,  /**< Property value is binary data. */
 } celix_properties_value_type_e;
 
 /**
@@ -85,6 +87,10 @@ typedef struct celix_properties_entry {
         const celix_version_t* versionValue; /**< The Celix version value of the entry. */
         const celix_array_list_t*
             arrayValue; /**< The array list of longs, doubles, bools, strings or versions value of the entry. */
+        struct {
+            const void* data;                /**< The binary data of the entry. */
+            size_t size;                     /**< The size of the binary data. */
+        } binaryValue;                       /**< The binary value of the entry. */
     } typed;            /**< The typed values of the entry. Only valid if valueType
                              is not CELIX_PROPERTIES_VALUE_TYPE_UNSET and only the matching
                              value types should be used. E.g typed.boolValue if valueType is
@@ -1012,6 +1018,8 @@ CELIX_UTILS_EXPORT bool celix_propertiesIterator_equals(const celix_properties_i
  * - CELIX_PROPERTIES_TYPE_ARRAY: The value is encoded as a JSON array, with each element encoded according to its type.
  * - CELIX_PROPERTIES_TYPE_VERSION: The value is encoded as a JSON string with a "version<" prefix and a ">" suffix
  * (e.g. "version<1.2.3>").
+ * - CELIX_PROPERTIES_TYPE_BINARY: The value is encoded as a JSON string with "base64<" prefix and ">" suffix
+ * (e.g. "base64<SGVsbG8=>").
  *
  * For a overview of the possible encode flags, see the CELIX_PROPERTIES_ENCODE_* flags documentation.
  * The default encoding style is a compact and flat JSON representation.
@@ -1170,6 +1178,8 @@ CELIX_UTILS_EXPORT celix_status_t celix_properties_saveToString(const celix_prop
  * - JSON boolean values are decoded as boolean properties entries.
  * - jSON string values with a "version<" prefix and a ">" suffix are decoded as version properties entries (e.g.
  * "version<1.2.3>").
+ * - JSON string values with a "base64<" prefix and a ">" suffix are decoded as binary properties entries (e.g.
+ * "base64<SGVsbG8=>").
  * - JSON array values are decoded as array properties entries. The array can contain any of the above types, but mixed
  * arrays are not supported.
  * - JSON null values are ignored.
@@ -1236,6 +1246,56 @@ CELIX_UTILS_EXPORT celix_status_t celix_properties_load(const char* filename,
 CELIX_UTILS_EXPORT celix_status_t celix_properties_loadFromString(const char* input,
                                                                    int decodeFlags,
                                                                    celix_properties_t** out);
+
+/**
+ * @brief Set the value of a property to binary data.
+ *
+ * The set property type will be CELIX_PROPERTIES_VALUE_TYPE_BINARY.
+ *
+ * This function will make a copy of the provided binary data and store it in the property set.
+ * If the return status is an error, an error message is logged to celix_err.
+ *
+ * @param[in] properties The property set to modify.
+ * @param[in] key The key of the property to set.
+ * @param[in] data The binary data to set. The function will make a copy of this data and store it in the property set.
+ * @param[in] size The size of the binary data.
+ * @return CELIX_SUCCESS if the operation was successful, CELIX_ENOMEM if there was not enough memory to set the entry
+ *         and CELIX_ILLEGAL_ARGUMENT if the provided key is NULL or data is NULL.
+ */
+CELIX_UTILS_EXPORT celix_status_t celix_properties_setBinary(celix_properties_t* properties, const char* key, const void* data, size_t size);
+
+/**
+ * @brief Assign the value of a property to binary data, taking ownership of the provided data.
+ *
+ * The set property type will be CELIX_PROPERTIES_VALUE_TYPE_BINARY.
+ *
+ * The function will take ownership of the provided binary data and free it when the property is destroyed. This means that the caller should not modify or free the provided data after calling this function.
+ *
+ * If the return status is an error, an error message is logged to celix_err.
+ *
+ * @param[in] properties The property set to modify.
+ * @param[in] key The key of the property to set.
+ * @param[in] data The binary data to set. The function will take ownership of this data and free it when the property is destroyed. The caller should ensure that the memory of data can be freed by 'free' function.
+ * @param[in] size The size of the binary data.
+ * @return CELIX_SUCCESS if the operation was successful, CELIX_ENOMEM if there was not enough memory to set the entry
+ *         and CELIX_ILLEGAL_ARGUMENT if the provided key is NULL or data is NULL.
+ */
+CELIX_UTILS_EXPORT celix_status_t celix_properties_assignBinary(celix_properties_t* properties, const char* key, void* data, size_t size);
+
+/**
+ * @brief Get the binary data value of a property without copying.
+ *
+ * This function provides a non-owning, read-only access to binary data contained in the properties.
+ * It returns a const pointer to the binary data associated with the specified key.
+ * This function does not perform any conversion from a string property value to binary data.
+ *
+ * @param[in] properties The property set to search.
+ * @param[in] key The key of the property to get.
+ * @param[out] size The size of the binary data. If the property is not set or the value is not binary data, this is set to 0.
+ * @return A const pointer to the binary data if it is present and valid, or NULL if the
+ * property is not set or the value is not binary data. The returned pointer should not be modified or freed.
+ */
+CELIX_UTILS_EXPORT const void* celix_properties_getBinary(const celix_properties_t* properties, const char* key, size_t* size);
 
 #ifdef __cplusplus
 }

--- a/libs/utils/src/celix_convert_utils.c
+++ b/libs/utils/src/celix_convert_utils.c
@@ -25,6 +25,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <stdint.h>
+#include <limits.h>
+#include <openssl/evp.h>
 
 #include "celix_array_list.h"
 #include "celix_err.h"
@@ -387,4 +390,92 @@ char* celix_utils_arrayListToString(const celix_array_list_t* list) {
         default:
             return NULL;
     }
+}
+
+char* celix_utils_binaryToBase64String(const void* data, size_t size) {
+    if (!data || size == 0) {
+        celix_err_push("Input data is NULL or size is 0.");
+        return NULL;
+    }
+    //Calculate encoded size: 4 * ceil(size/3) + 1 for null terminator
+    uint64_t encodedSize = UINT64_C(4) * ((size + 2) / 3) + 1;
+    if (encodedSize > INT_MAX) {
+        celix_err_push("Encoded base64 size is too large.");
+        return NULL;
+    }
+    celix_autofree char* base64 = malloc(encodedSize);
+    if (!base64) {
+        celix_err_push("Failed to allocate memory for base64 encoding.");
+        return NULL;
+    }
+    int encodedLen = EVP_EncodeBlock((unsigned char*)base64, data, (int)size);
+    if (encodedLen < 0) {
+        celix_err_push("Failed to base64 encode data.");
+        return NULL;
+    }
+    /* Ensure null termination and guard against unexpected overflow */
+    if ((size_t)encodedLen >= encodedSize) {
+        celix_err_push("Base64 encoded length exceeds buffer.");
+        return NULL;
+    }
+    base64[encodedLen] = '\0';
+    return celix_steal_ptr(base64);
+}
+
+celix_status_t celix_utils_convertBase64StringToBinary(const char* val, size_t defaultSize, const void* defaultVal, size_t* size, void** bin) {
+    assert(size != NULL);
+    assert(bin != NULL);
+
+    celix_status_t status = CELIX_SUCCESS;
+    *size = 0;
+    *bin = NULL;
+    do {
+        if (val == NULL) {
+            celix_err_push("Input string is NULL.");
+            status =  CELIX_ILLEGAL_ARGUMENT;
+            break;
+        }
+
+        size_t base64Len = strlen(val);
+        if (base64Len > INT_MAX || base64Len == 0) {
+            celix_err_push("Invalid base64 string length.");
+            status = CELIX_ILLEGAL_ARGUMENT;
+            break;
+        }
+        // Calculate maximum decoded size: ((base64Len + 3) / 4) * 3
+        size_t decodedSize = ((base64Len + UINT64_C(3)) / 4) * 3;
+        celix_autofree unsigned char* decoded = malloc(decodedSize);
+        if (!decoded) {
+            celix_err_push("Failed to allocate memory for base64 decoding.");
+            status = ENOMEM;
+            break;
+        }
+        int decodedLen = EVP_DecodeBlock(decoded, (const unsigned char*)val, (int)base64Len);
+        if (decodedLen < 0) {
+            celix_err_push("Failed to decode base64.");
+            status = CELIX_ILLEGAL_ARGUMENT;
+            break;
+        }
+        /* EVP_DecodeBlock returns the length ignoring padding; however it may include \0 from padding - adjust for '=' padding */
+        int actualLen = decodedLen;
+        if (base64Len >= 1 && val[base64Len-1] == '=') actualLen--;
+        if (base64Len >= 2 && val[base64Len-2] == '=') actualLen--;
+        if (actualLen < 0) actualLen = 0;
+        if (actualLen != 0) {
+            *bin = celix_steal_ptr(decoded);
+        }
+        *size = (size_t)actualLen;
+    } while (0);
+
+    if (status == CELIX_ILLEGAL_ARGUMENT && defaultSize && defaultVal) {
+        *bin = malloc(defaultSize);
+        if (*bin == NULL) {
+            celix_err_push("Failed to allocate memory for binary data.");
+            return ENOMEM;
+        }
+        *size = defaultSize;
+        memcpy(*bin, defaultVal, defaultSize);
+    }
+
+    return status;
 }

--- a/libs/utils/src/celix_json_utils.c
+++ b/libs/utils/src/celix_json_utils.c
@@ -20,6 +20,7 @@
 #include "celix_json_utils_private.h"
 #include "celix_err.h"
 #include "celix_utils.h"
+#include "celix_convert_utils.h"
 #include "celix_stdlib_cleanup.h"
 
 #include <string.h>
@@ -103,4 +104,54 @@ celix_status_t celix_utils_jsonErrorToStatus(enum json_error_code error) {
         default:
             return CELIX_ILLEGAL_ARGUMENT;
     }
+}
+
+celix_status_t celix_utils_binaryToJson(const void* data, size_t size, json_t** out) {
+    assert(data != NULL);
+    assert(out != NULL);
+    *out = NULL;
+
+    celix_autofree char* base64 = celix_utils_binaryToBase64String(data, size);
+    if (!base64) {
+        celix_err_push("Failed to allocate memory for base64 encoding.");
+        return ENOMEM;
+    }
+    *out = json_sprintf("base64<%s>", (const char*)base64);
+    if (!*out) {
+        celix_err_push("Failed to create json string for binary.");
+        return ENOMEM;
+    }
+    return CELIX_SUCCESS;
+}
+
+celix_status_t celix_utils_jsonToBinary(const json_t* json, void** data, size_t* size) {
+    assert(json != NULL);
+    assert(data != NULL);
+    assert(size != NULL);
+    *data = NULL;
+    *size = 0;
+    if (!celix_utils_isBinaryJsonString(json)) {
+        celix_err_push("Failed to convert json to binary, json is not a binary string.");
+        return CELIX_ILLEGAL_ARGUMENT;
+    }
+    const char* value = json_string_value(json);
+    assert(value != NULL);
+    char buf[256];
+    char* extracted = celix_utils_writeOrCreateString(buf, sizeof(buf), "%.*s", (int)strlen(value) - 8, value + 7);
+    celix_auto(celix_utils_string_guard_t) guard = celix_utils_stringGuard_init(buf, extracted);
+    if (!extracted) {
+        celix_err_push("Failed to create extracted base64 string.");
+        return ENOMEM;
+    }
+    return celix_utils_convertBase64StringToBinary(extracted, 0, NULL, size, data);
+}
+
+bool celix_utils_isBinaryJsonString(const json_t* string)
+{
+    if (!json_is_string(string)) {
+        return false;
+    }
+    const char* value = json_string_value(string);
+    assert(value != NULL);
+    return strncmp(value, "base64<", 7) == 0 && value[strlen(value) - 1] == '>';
 }

--- a/libs/utils/src/celix_json_utils_private.h
+++ b/libs/utils/src/celix_json_utils_private.h
@@ -25,6 +25,8 @@
 
 #include <jansson.h>
 
+#include <stddef.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -67,6 +69,40 @@ bool celix_utils_isVersionJsonString(const json_t* string);
  * @return The corresponding celix_status_t.
  */
 celix_status_t celix_utils_jsonErrorToStatus(enum json_error_code error);
+
+/**
+ * @brief Convert binary data to a json object.
+ *
+ * If the return status is an error, an error message is logged to celix_err.
+ *
+ * @param[in] data The binary data to convert. Must be not NULL.
+ * @param[in] size The size of the binary data.
+ * @param[out] out The converted json object. Caller is owner. Must be not NULL.
+ * @return CELIX_SUCCESS if conversion was successful.
+ *       ENOMEM if an memory allocation failed.
+ */
+celix_status_t celix_utils_binaryToJson(const void* data, size_t size, json_t** out);
+
+/**
+ * @brief Convert a json object to binary data.
+ *
+ * If the return status is an error, an error message is logged to celix_err.
+ *
+ * @param[in] json The json object to convert. Must be not NULL.
+ * @param[out] data The converted binary data. Caller is owner. Must be not NULL.
+ * @param[out] size The size of the binary data. Must be not NULL.
+ * @return CELIX_SUCCESS if conversion was successful.
+ *       CELIX_ILLEGAL_ARGUMENT if json object is not a binary string.
+ *       ENOMEM if memory allocation failed.
+ */
+celix_status_t celix_utils_jsonToBinary(const json_t* json, void** data, size_t* size);
+
+/**
+ * @brief Check if the given json object is a binary string.
+ * @param[in] string The json object to check.
+ * @return true if the json object is a binary string.
+ */
+bool celix_utils_isBinaryJsonString(const json_t* string);
 
 #ifdef __cplusplus
 }

--- a/libs/utils/src/properties.c
+++ b/libs/utils/src/properties.c
@@ -144,6 +144,8 @@ static celix_status_t celix_properties_fillEntry(celix_properties_t* properties,
         entry->value = entry->typed.boolValue ? CELIX_PROPERTIES_BOOL_TRUE_STRVAL : CELIX_PROPERTIES_BOOL_FALSE_STRVAL;
     } else if (entry->valueType == CELIX_PROPERTIES_VALUE_TYPE_ARRAY_LIST) {
         entry->value = celix_utils_arrayListToString(entry->typed.arrayValue);
+    } else if (entry->valueType == CELIX_PROPERTIES_VALUE_TYPE_BINARY) {
+        entry->value = celix_utils_binaryToBase64String(entry->typed.binaryValue.data, entry->typed.binaryValue.size);
     } else /*string value*/ {
         assert(entry->valueType == CELIX_PROPERTIES_VALUE_TYPE_STRING);
         entry->value = entry->typed.strValue;
@@ -198,6 +200,10 @@ static void celix_properties_freeTypedEntry(celix_properties_t* properties, celi
     } else if (entry->valueType == CELIX_PROPERTIES_VALUE_TYPE_ARRAY_LIST) {
         celix_arrayList_destroy((celix_array_list_t*)entry->typed.arrayValue);
         entry->typed.arrayValue = NULL;
+    } else if (entry->valueType == CELIX_PROPERTIES_VALUE_TYPE_BINARY) {
+        free((void*)entry->typed.binaryValue.data);
+        entry->typed.binaryValue.data = NULL;
+        entry->typed.binaryValue.size = 0;
     } else {
         // nop
     }
@@ -438,6 +444,8 @@ celix_properties_setEntry(celix_properties_t* properties, const char* key, const
             return celix_properties_setBool(properties, key, entry->typed.boolValue);
         case CELIX_PROPERTIES_VALUE_TYPE_VERSION:
             return celix_properties_setVersion(properties, key, entry->typed.versionValue);
+        case CELIX_PROPERTIES_VALUE_TYPE_BINARY:
+            return celix_properties_setBinary(properties, key, entry->typed.binaryValue.data, entry->typed.binaryValue.size);
         default: //CELIX_PROPERTIES_VALUE_TYPE_ARRAY_LIST
             return celix_properties_setArrayList(properties, key, entry->typed.arrayValue);
         }
@@ -462,6 +470,9 @@ static bool celix_properties_entryEquals(const celix_properties_entry_t* entry1,
         return entry1->typed.boolValue == entry2->typed.boolValue;
     case CELIX_PROPERTIES_VALUE_TYPE_VERSION:
         return celix_version_compareTo(entry1->typed.versionValue, entry2->typed.versionValue) == 0;
+    case CELIX_PROPERTIES_VALUE_TYPE_BINARY:
+        return entry1->typed.binaryValue.size == entry2->typed.binaryValue.size &&
+               memcmp(entry1->typed.binaryValue.data, entry2->typed.binaryValue.data, entry1->typed.binaryValue.size) == 0;
     default: //CELIX_PROPERTIES_VALUE_TYPE_ARRAY_LIST
         return celix_arrayList_equals(entry1->typed.arrayValue, entry2->typed.arrayValue);
     }
@@ -910,4 +921,49 @@ celix_properties_statistics_t celix_properties_getStatistics(const celix_propert
     stats.fillEntriesOptimizationBufferPercentage = (double)properties->currentEntriesBufferIndex / CELIX_PROPERTIES_OPTIMIZATION_ENTRIES_BUFFER_SIZE;
     stats.mapStatistics = celix_stringHashMap_getStatistics(properties->map);
     return stats;
+}
+
+celix_status_t celix_properties_setBinary(celix_properties_t* properties, const char* key, const void* data, size_t size) {
+    if (!data || size == 0) {
+        celix_err_push("Cannot set binary property with NULL data or size 0");
+        return CELIX_ILLEGAL_ARGUMENT;
+    }
+    void* copy = malloc(size);
+    if (!copy) {
+        celix_err_push("Failed to allocate memory for binary property");
+        return ENOMEM;
+    }
+    memcpy(copy, data, size);
+    celix_properties_entry_t prototype = {0};
+    prototype.valueType = CELIX_PROPERTIES_VALUE_TYPE_BINARY;
+    prototype.typed.binaryValue.data = copy;
+    prototype.typed.binaryValue.size = size;
+    return celix_properties_createAndSetEntry(properties, key, &prototype);
+}
+
+const void* celix_properties_getBinary(const celix_properties_t* properties, const char* key, size_t* size) {
+    const celix_properties_entry_t* entry = celix_properties_getEntry(properties, key);
+    if (entry && entry->valueType == CELIX_PROPERTIES_VALUE_TYPE_BINARY) {
+        if (size) {
+            *size = entry->typed.binaryValue.size;
+        }
+        return entry->typed.binaryValue.data;
+    }
+    if (size) {
+        *size = 0;
+    }
+    return NULL;
+}
+
+celix_status_t celix_properties_assignBinary(celix_properties_t* properties, const char* key, void* data, size_t size) {
+    if (!data || size == 0) {
+        free(data); // Free the data if key or data is NULL
+        celix_err_push("Cannot assign binary property with NULL data or size 0");
+        return CELIX_ILLEGAL_ARGUMENT;
+    }
+    celix_properties_entry_t prototype = {0};
+    prototype.valueType = CELIX_PROPERTIES_VALUE_TYPE_BINARY;
+    prototype.typed.binaryValue.data = data;
+    prototype.typed.binaryValue.size = size;
+    return celix_properties_createAndSetEntry(properties, key, &prototype);
 }

--- a/libs/utils/src/properties_encoding.c
+++ b/libs/utils/src/properties_encoding.c
@@ -90,6 +90,8 @@ celix_properties_entryValueToJson(const char* key, const celix_properties_entry_
         return celix_utils_versionToJson(entry->typed.versionValue, out);
     case CELIX_PROPERTIES_VALUE_TYPE_ARRAY_LIST:
         return celix_properties_arrayEntryValueToJson(key, entry, flags, out);
+    case CELIX_PROPERTIES_VALUE_TYPE_BINARY:
+        return celix_utils_binaryToJson(entry->typed.binaryValue.data, entry->typed.binaryValue.size, out);
     default:
         // LCOV_EXCL_START
         celix_err_pushf("Unexpected properties entry type %d.", entry->valueType);
@@ -303,6 +305,11 @@ celix_properties_decodeValue(celix_properties_t* props, const char* key, json_t*
         celix_version_t* version;
         status = celix_utils_jsonToVersion(jsonValue, &version);
         status = CELIX_DO_IF(status, celix_properties_assignVersion(props, key, version));
+    } else if (celix_utils_isBinaryJsonString(jsonValue)) {
+        void* data = NULL;
+        size_t size = 0;
+        status = celix_utils_jsonToBinary(jsonValue, &data, &size);
+        status = CELIX_DO_IF(status, celix_properties_assignBinary(props, key, data, size));
     } else if (json_is_string(jsonValue)) {
         status = celix_properties_setString(props, key, json_string_value(jsonValue));
     } else if (json_is_integer(jsonValue)) {


### PR DESCRIPTION
In order to enable event admin to transmit arbitrary messages via the "payload" property entry, this pull request introduces a binary type value for celix_properties_t. And the serialization of binary data is achieved through the base64 encoding.