### PR TITLE
Pin OpenSSL below 4 to fix nightly conan builds

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -394,7 +394,9 @@ class CelixConan(ConanFile):
             # TODO: To be replaced with mdnsresponder/1790.80.10, resolve some problems of mdnsresponder
             # https://github.com/conan-io/conan-center-index/pull/16254
             self.requires("mdnsresponder/1310.140.1")
-        self.requires("openssl/[>=3.2.0]", override=True)
+        # OpenSSL 4.x is a breaking API change (like 3.0 was); civetweb/1.16 does not support it yet.
+        # Keep the range below 4 until civetweb and other consumers support the OpenSSL 4 API.
+        self.requires("openssl/[>=3.2.0 <4]", override=True)
         # Fix zlib to 1.3.1, 'libzip/1.10.1' and 'libcurl/7.64.1' requires different zlib versions causing conflicts
         self.requires("zlib/1.3.1", override=True)
         if self.options.build_event_admin_remote_provider_mqtt:


### PR DESCRIPTION
## Problem

The nightly `linux-build-conan` jobs started failing on 2026-08-11 with civetweb/1.16 compile errors against the OpenSSL headers:

- `civetweb.c:1561: #error "Please define OPENSSL_API_#_# or USE_MBEDTLS"`
- `X509_get_subject_name`/`X509_get_issuer_name` discard `const` (error under `-pedantic-errors`)
- `mg_openssl_initialized` undeclared

## Root cause

ConanCenter published `openssl/4.0.1` between 08-10 and 08-11. The unbounded `openssl/[>=3.2.0]` range in [conanfile.py](conanfile.py) resolved to it (the `override=True` also drops the `<4` upper bound that the civetweb recipe itself declares). civetweb/1.16 predates the OpenSSL 4 API, so its API-version detection has no branch for OpenSSL >= 4.0.

## Fix

Restrict the range to `openssl/[>=3.2.0 <4]`, matching the upper bound already declared by the civetweb recipe.

Verified locally: `conan graph info` now resolves `openssl/3.6.3`.

## Follow-up

Revisit once civetweb (or another consumer) supports the OpenSSL 4 API, then the bound can be lifted again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)