### PR TITLE
Fix PushStream consumer replacement use-after-free

### DIFF
--- a/libs/pushstreams/api/celix/PushStream.h
+++ b/libs/pushstreams/api/celix/PushStream.h
@@ -23,6 +23,7 @@
 #include <iostream>
 #include <queue>
 #include <cstdint>
+#include <memory>
 
 #include "celix/IAutoCloseable.h"
 
@@ -131,8 +132,11 @@ namespace celix {
         bool compareAndSetState(State expectedValue, State newValue);
 
         State getAndSetState(State newValue);
+        void setNextEvent(PushEventConsumer<T> event);
+        long acceptNextEvent(const PushEvent<T>& event);
+
         std::shared_ptr<PromiseFactory> promiseFactory;
-        PushEventConsumer<T> nextEvent{};
+        std::shared_ptr<PushEventConsumer<T>> nextEvent{};
         ErrorFunction onErrorCallback{};
         CloseFunction onCloseCallback{};
         State closed {State::BUILDING};
@@ -159,16 +163,27 @@ celix::PushStream<T>::PushStream(std::shared_ptr<PromiseFactory>& _promiseFactor
 }
 
 template<typename T>
+void celix::PushStream<T>::setNextEvent(PushEventConsumer<T> event) {
+    std::atomic_store(&nextEvent, std::make_shared<PushEventConsumer<T>>(std::move(event)));
+}
+
+template<typename T>
+long celix::PushStream<T>::acceptNextEvent(const PushEvent<T>& event) {
+    auto next = std::atomic_load(&nextEvent);
+    return next ? next->accept(event) : IPushEventConsumer<T>::ABORT;
+}
+
+template<typename T>
 long celix::PushStream<T>::handleEvent(const PushEvent<T>& event) {
     if(closed != celix::PushStream<T>::State::CLOSED) {
-        return nextEvent.accept(event);
+        return acceptNextEvent(event);
     }
     return IPushEventConsumer<T>::ABORT;
 }
 
 template<typename T>
 celix::Promise<void> celix::PushStream<T>::forEach(ForEachFunction func) {
-    nextEvent = PushEventConsumer<T>([&, func = std::move(func)](const PushEvent<T>& event) -> long {
+    setNextEvent(PushEventConsumer<T>([&, func = std::move(func)](const PushEvent<T>& event) -> long {
         try {
             switch(event.getType()) {
                 case celix::PushEvent<T>::EventType::DATA:
@@ -189,21 +204,21 @@ celix::Promise<void> celix::PushStream<T>::forEach(ForEachFunction func) {
             close(errorEvent, false);
             return IPushEventConsumer<T>::ABORT;
         }
-    });
+    }));
 
     begin();
-    return streamEnd.getPromise();           
+    return streamEnd.getPromise();
 }
 
 template<typename T>
 celix::PushStream<T>& celix::PushStream<T>::filter(PredicateFunction predicate) {
     auto downstream = std::make_shared<celix::IntermediatePushStream<T>>(promiseFactory, *this);
-    nextEvent = PushEventConsumer<T>([downstream = downstream, predicate = std::move(predicate)](const PushEvent<T>& event) -> long {
+    setNextEvent(PushEventConsumer<T>([downstream = downstream, predicate = std::move(predicate)](const PushEvent<T>& event) -> long {
         if (event.getType() != celix::PushEvent<T>::EventType::DATA || predicate(event.getData())) {
             downstream->handleEvent(event);
         }
         return IPushEventConsumer<T>::CONTINUE;
-    });
+    }));
 
     return *downstream;
 }
@@ -216,7 +231,7 @@ std::vector<std::shared_ptr<celix::PushStream<T>>> celix::PushStream<T>::split(s
         result.push_back(std::make_shared<celix::IntermediatePushStream<T>>(promiseFactory, *this));
     }
 
-    nextEvent = PushEventConsumer<T>([result = result, predicates = std::move(predicates)](const PushEvent<T>& event) -> long {
+    setNextEvent(PushEventConsumer<T>([result = result, predicates = std::move(predicates)](const PushEvent<T>& event) -> long {
         for(long unsigned int i = 0; i < predicates.size(); i++) {
             if (event.getType() != celix::PushEvent<T>::EventType::DATA || predicates[i](event.getData())) {
                 result[i]->handleEvent(event);
@@ -224,7 +239,7 @@ std::vector<std::shared_ptr<celix::PushStream<T>>> celix::PushStream<T>::split(s
         }
 
         return IPushEventConsumer<T>::CONTINUE;
-    });
+    }));
 
     return result;
 }
@@ -234,14 +249,14 @@ template<typename R>
 celix::PushStream<R>& celix::PushStream<T>::map(std::function<R(const T&)> mapper) {
     auto downstream = std::make_shared<celix::IntermediatePushStream<R, T>>(promiseFactory, *this);
 
-    nextEvent = PushEventConsumer<T>([downstream = downstream, mapper = std::move(mapper)](const PushEvent<T>& event) -> long {
+    setNextEvent(PushEventConsumer<T>([downstream = downstream, mapper = std::move(mapper)](const PushEvent<T>& event) -> long {
         if (event.getType() == celix::PushEvent<T>::EventType::DATA) {
             downstream->handleEvent(DataPushEvent<R>(mapper(event.getData())));
         } else {
             downstream->handleEvent(celix::ClosePushEvent<R>());
         }
         return IPushEventConsumer<T>::CONTINUE;
-    });
+    }));
 
     return *downstream;
 }
@@ -274,8 +289,7 @@ template<typename T>
 bool celix::PushStream<T>::internal_close(const PushEvent<T>& event, bool sendDownStreamEvent) {
     if (this->getAndSetState(celix::PushStream<T>::State::CLOSED) != celix::PushStream<T>::State::CLOSED) {
         if (sendDownStreamEvent) {
-            auto next = nextEvent;
-            next.accept(event);
+            acceptNextEvent(event);
         }
 
         if (onCloseCallback) {

--- a/libs/pushstreams/api/celix/impl/BufferedPushStream.h
+++ b/libs/pushstreams/api/celix/impl/BufferedPushStream.h
@@ -100,7 +100,7 @@ void celix::BufferedPushStream<T>::startWorker() {
         if (lk) {
             std::unique_ptr<celix::PushEvent<T>> event = popQueue();
             while (event != nullptr) {
-                this->nextEvent.accept(*event);
+                this->acceptNextEvent(*event);
                 event = popQueue();
             }
             cv.notify_all();

--- a/libs/pushstreams/gtest/CMakeLists.txt
+++ b/libs/pushstreams/gtest/CMakeLists.txt
@@ -17,6 +17,7 @@
 
 add_executable(test_celix_pushstreams
         src/PushStreamTestSuite.cc
+        src/PushStreamConcurrencyTest.cc
 )
 target_compile_options(test_celix_pushstreams PRIVATE -std=c++17)
 target_link_libraries(test_celix_pushstreams PRIVATE GTest::gtest GTest::gtest_main Celix::PushStreams)

--- a/libs/pushstreams/gtest/src/PushStreamConcurrencyTest.cc
+++ b/libs/pushstreams/gtest/src/PushStreamConcurrencyTest.cc
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <mutex>
+
+#include <gtest/gtest.h>
+
+#include "celix/PushStreamProvider.h"
+
+using namespace std::chrono_literals;
+
+TEST(PushStreamConcurrencyTest, BufferedStreamKeepsInFlightConsumerAliveWhenForEachIsReplaced) {
+    celix::PushStreamProvider provider{};
+    auto promiseFactory = std::make_shared<celix::PromiseFactory>();
+    auto eventSource = provider.createSynchronousEventSource<int>(promiseFactory);
+    auto stream = provider.createStream<int>(eventSource, promiseFactory);
+
+    std::mutex mutex{};
+    std::condition_variable consumerEntered{};
+    std::condition_variable releaseConsumer{};
+    bool entered = false;
+    bool release = false;
+    std::atomic<int> firstConsumerCount{0};
+    std::atomic<int> secondConsumerCount{0};
+
+    auto firstStreamEnded = stream->forEach([&](const int&) {
+        {
+            std::lock_guard lock{mutex};
+            entered = true;
+        }
+        consumerEntered.notify_one();
+
+        std::unique_lock lock{mutex};
+        releaseConsumer.wait(lock, [&] { return release; });
+        firstConsumerCount.fetch_add(1);
+    });
+
+    eventSource->publish(1);
+
+    {
+        std::unique_lock lock{mutex};
+        ASSERT_TRUE(consumerEntered.wait_for(lock, 5s, [&] { return entered; }));
+    }
+
+    auto secondStreamEnded = stream->forEach([&](const int&) {
+        secondConsumerCount.fetch_add(1);
+    });
+
+    {
+        std::lock_guard lock{mutex};
+        release = true;
+    }
+    releaseConsumer.notify_one();
+    promiseFactory->getExecutor()->wait();
+
+    eventSource->publish(2);
+    promiseFactory->getExecutor()->wait();
+
+    eventSource->close();
+    secondStreamEnded.wait();
+
+    EXPECT_EQ(1, firstConsumerCount.load());
+    EXPECT_EQ(1, secondConsumerCount.load());
+
+    (void)firstStreamEnded;
+}


### PR DESCRIPTION
Fixes #708.

BufferedPushStream can execute nextEvent on its worker thread while another call to forEach() replaces that consumer. Replacing the stored std::function can destroy the previous callback while it is still in flight, resulting in the use-after-free reported by ASan.

This change makes the current consumer a shared_ptr and uses atomic load/store operations so each event invocation keeps a stable snapshot of the consumer for the duration of the callback.

It also adds a deterministic regression test that:

* blocks the first consumer while it is executing;
* replaces it with a second consumer;
* releases the first callback;
* verifies both consumers receive the expected events without invalidating the in-flight callback.

The existing Ubuntu CI matrix passes with GCC and Clang, including the ASan/UBSan-enabled Conan builds.